### PR TITLE
BF027: loudly refuse a component that returns JSX through a local variable (#2720)

### DIFF
--- a/.changeset/return-value-not-recognized-as-jsx-2720.md
+++ b/.changeset/return-value-not-recognized-as-jsx-2720.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Fix #2720: a component whose render is bound to a local `const`/`let` and returned by name (`const __root = <jsx/>; return __root`, or the block-scoped variant `{ const __root = <jsx/>; return __root }`) used to produce `{files: [], errors: []}` — neither sound (nothing emitted) nor loud (nothing reported), since return position never resolves an identifier through its initializer the way JSX-child position does. Now reports **BF027** instead of silently dropping the component. The `blockBody` mutation the #2481 mutation sweep applies to every corpus fixture reproduced this identically (41/41, `refused=0`); this fix flips them all to `refused` under the sound-or-loud trichotomy. The faithful fix — actually resolving the identifier so the component compiles — is tracked separately by #2720.

--- a/packages/jsx/src/__tests__/return-through-local-var.test.ts
+++ b/packages/jsx/src/__tests__/return-through-local-var.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Regression tests for #2720: a component whose render is bound to a local
+ * const and returned by name —
+ *
+ *   export function Button() {
+ *     const __root = (<button>Go</button>)
+ *     return __root
+ *   }
+ *
+ * — previously produced `{files: [], errors: []}`: neither sound (nothing
+ * emitted) nor loud (nothing reported). Two structural variants of this
+ * shape need two separate detectors, both landing here:
+ *
+ * 1. **Flat** (statements are direct children of the component body, as
+ *    written above): `ctx.jsxReturn` DOES get set (to the `__root`
+ *    Identifier — `visitComponentBody`'s return handler captures any
+ *    return expression, not just syntactic JSX), but return position never
+ *    resolves an identifier through its initializer the way JSX-child
+ *    position does via `jsxConstants` / `inlineableJsxConsts` (#547 /
+ *    #1409) — so `transformJsxExpression`'s scalar-leaf case returns `null`
+ *    and `buildIRRoot` (`jsx-to-ir.ts`) drops the component silently. Fixed
+ *    there: recognize a bare Identifier at return position that names a
+ *    local already proven to hold JSX by those two maps, and report BF027
+ *    instead of dropping it.
+ *
+ * 2. **Nested-block** (`{ const __root = <jsx/>; return __root }` as a
+ *    single block statement — the exact shape the #2481 mutation sweep's
+ *    `block-body` mutation produces by wrapping the ORIGINAL return
+ *    statement): the block is a direct child of the component body, so
+ *    `visitComponentBody`'s opaque-block preservation (#930 — "a bare
+ *    block at the top of a component body is inert side-effect scoping,
+ *    preserve it verbatim, don't recurse") swallows it whole. Neither
+ *    `jsxConstants` nor `jsxReturn` are EVER set, so the flat-case fix
+ *    above never runs. Fixed in `analyzer.ts`'s `visitComponentBody`:
+ *    before preserving such a block, `findBlockBodyReturnedJsxLocalName`
+ *    checks whether it is exactly this "name the JSX, then return the
+ *    name" shape and reports BF027 directly.
+ *
+ * The "faithful" fix (resolving the identifier through its initializer so
+ * the component actually compiles, for either variant) is tracked
+ * separately by #2720 and not implemented here — this PR is the loud
+ * stopgap only.
+ *
+ * Found by the #2481 mutation sweep's `block-body` mutation
+ * (`packages/adapter-tests/mutation/mutations.ts`, the nested-block shape
+ * above): 41/41 corpus fixtures reproduced this identically before this
+ * fix, classified `broken` with `refused` at 0. This fix flips them to
+ * `refused` (a pass under the sound-or-loud trichotomy).
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+describe('BF027: return-through-local-variable is not recognized as JSX (#2720)', () => {
+  test('function component: `const __root = (<jsx/>); return __root` reports BF027 instead of silently emitting nothing', () => {
+    const source = `
+      export function Button() {
+        const __root = (<button>Go</button>)
+        return __root
+      }
+    `
+    const result = compileJSX(source, 'Button.tsx', { adapter })
+
+    // Neither silent-drop nor silent-emit: no files, but a loud diagnostic.
+    expect(result.files).toHaveLength(0)
+    const bf027 = result.errors.find(e => e.code === 'BF027')
+    expect(bf027).toBeDefined()
+    expect(bf027!.severity).toBe('error')
+    expect(bf027!.message).toContain('Button')
+    expect(bf027!.message).toMatch(/not recognized as JSX/)
+  })
+
+  test('arrow component: same shape via `export const Button = () => {...}`', () => {
+    const source = `
+      export const Button = () => {
+        const __root = <button>Go</button>
+        return __root
+      }
+    `
+    const result = compileJSX(source, 'Button.tsx', { adapter })
+    expect(result.files).toHaveLength(0)
+    expect(result.errors.find(e => e.code === 'BF027')).toBeDefined()
+  })
+
+  test('non-root JSX initializer (ternary) through a local also reports BF027', () => {
+    const source = `
+      export function Button({ ok }: { ok: boolean }) {
+        const __root = ok ? <button>Go</button> : <span>No</span>
+        return __root
+      }
+    `
+    const result = compileJSX(source, 'Button.tsx', { adapter })
+    expect(result.files).toHaveLength(0)
+    expect(result.errors.find(e => e.code === 'BF027')).toBeDefined()
+  })
+
+  test('nested-block shape (the actual mutation-sweep output): `{ const __root = <jsx/>; return __root }` reports BF027', () => {
+    // This is the shape `packages/adapter-tests/mutation/mutations.ts`'s
+    // `blockBody` mutation actually produces (it wraps the ORIGINAL return
+    // statement in a new block rather than splicing the const/return in as
+    // top-level statements) — structurally distinct from the flat case
+    // above because the block is opaque to `visitComponentBody` (#930).
+    const source = `
+      export function Button() {
+        {
+          const __root = <button>Go</button>
+          return __root
+        }
+      }
+    `
+    const result = compileJSX(source, 'Button.tsx', { adapter })
+    expect(result.files).toHaveLength(0)
+    const bf027 = result.errors.find(e => e.code === 'BF027')
+    expect(bf027).toBeDefined()
+    expect(bf027!.message).toContain('Button')
+  })
+
+  test('nested-block shape with a ternary JSX initializer also reports BF027', () => {
+    const source = `
+      export function Button({ ok }: { ok: boolean }) {
+        {
+          const __root = ok ? <button>Go</button> : <span>No</span>
+          return __root
+        }
+      }
+    `
+    const result = compileJSX(source, 'Button.tsx', { adapter })
+    expect(result.files).toHaveLength(0)
+    expect(result.errors.find(e => e.code === 'BF027')).toBeDefined()
+  })
+
+  test('multi-component file: the broken sibling is flagged but the good sibling still compiles', () => {
+    const source = `
+      export function Good() { return <div>ok</div> }
+      export function Bad() {
+        const __root = <button>Go</button>
+        return __root
+      }
+    `
+    const result = compileJSX(source, 'Multi.tsx', { adapter })
+    const bf027 = result.errors.find(e => e.code === 'BF027')
+    expect(bf027).toBeDefined()
+    expect(bf027!.message).toContain('Bad')
+    // Good still produces output despite Bad's failure.
+    expect(result.files.length).toBeGreaterThan(0)
+  })
+
+  describe('control: direct JSX return keeps compiling clean', () => {
+    test('function component returning JSX directly has no BF027 and produces files', () => {
+      const source = `
+        export function Button() {
+          return (<button>Go</button>)
+        }
+      `
+      const result = compileJSX(source, 'Button.tsx', { adapter })
+      expect(result.errors.find(e => e.code === 'BF027')).toBeUndefined()
+      expect(result.files.length).toBeGreaterThan(0)
+    })
+  })
+
+  describe('no false positive: PascalCase exports that legitimately do not return JSX stay silent', () => {
+    test('a PascalCase function returning a plain object is untouched (not a component at all)', () => {
+      const source = `
+        export function CreateUser() {
+          return { name: 'x' }
+        }
+      `
+      const result = compileJSX(source, 'CreateUser.tsx', { adapter })
+      // Pre-existing behaviour for a non-component PascalCase export:
+      // no files, no errors. BF027 must not fire here — there is no local
+      // proven to hold JSX anywhere in this function.
+      expect(result.files).toHaveLength(0)
+      expect(result.errors.find(e => e.code === 'BF027')).toBeUndefined()
+    })
+
+    test('render-nothing literals (null / <></> / false) returned directly stay clean', () => {
+      const source = `
+        export function ReturnsNull() { return null }
+        export function ReturnsFragment() { return <></> }
+        export function ReturnsFalse(): any { return false }
+      `
+      const result = compileJSX(source, 'ReturnsNull.tsx', { adapter })
+      expect(result.errors.find(e => e.code === 'BF027')).toBeUndefined()
+    })
+
+    test('a local const unrelated to JSX does not spuriously trip BF027', () => {
+      const source = `
+        export function Button() {
+          const count = 1
+          return <button>{count}</button>
+        }
+      `
+      const result = compileJSX(source, 'Button.tsx', { adapter })
+      expect(result.errors.find(e => e.code === 'BF027')).toBeUndefined()
+      expect(result.files.length).toBeGreaterThan(0)
+    })
+
+    test('an ordinary top-level scoping block with no returned local is untouched', () => {
+      // A bare block used for legitimate imperative scoping ahead of the
+      // real render — #930's opaque-block preservation path — must not be
+      // mistaken for the #2720 shape just because SOME block sits at the
+      // top of the component body.
+      const source = `
+        export function Button() {
+          {
+            const x = 1
+            console.log(x)
+          }
+          return <button>Go</button>
+        }
+      `
+      const result = compileJSX(source, 'Button.tsx', { adapter })
+      expect(result.errors.find(e => e.code === 'BF027')).toBeUndefined()
+      expect(result.files.length).toBeGreaterThan(0)
+    })
+
+    test('a nested block whose returned identifier is not locally JSX-initialized stays silent', () => {
+      // The block's last statement returns `result`, but nothing in the
+      // block declares `result` as JSX — e.g. it is a prop or an outer
+      // local. Must not false-positive just because the shape ends in
+      // `return <identifier>`.
+      const source = `
+        export function Widget({ result }: { result: number }) {
+          {
+            const other = 1
+            return result
+          }
+        }
+      `
+      const compileResult = compileJSX(source, 'Widget.tsx', { adapter })
+      expect(compileResult.errors.find(e => e.code === 'BF027')).toBeUndefined()
+    })
+  })
+})

--- a/packages/jsx/src/__tests__/return-through-local-var.test.ts
+++ b/packages/jsx/src/__tests__/return-through-local-var.test.ts
@@ -132,6 +132,38 @@ describe('BF027: return-through-local-variable is not recognized as JSX (#2720)'
     expect(result.errors.find(e => e.code === 'BF027')).toBeDefined()
   })
 
+  test('nested-block shape with a `.map()`-with-JSX-callback initializer also reports BF027', () => {
+    // `initializerShapeContainsJsx` stops at arrow boundaries, so this
+    // variant needs the same `isMapLikeCallWithJsx` check `collectConstant`
+    // uses (#1554) — without it this shape slipped back into the silent
+    // drop even after BF027 landed (Copilot review on #2726).
+    const source = `
+      export function List() {
+        {
+          const __root = ['a', 'b'].map((item) => <div>{item}</div>)
+          return __root
+        }
+      }
+    `
+    const result = compileJSX(source, 'List.tsx', { adapter })
+    expect(result.files).toHaveLength(0)
+    const bf027 = result.errors.find(e => e.code === 'BF027')
+    expect(bf027).toBeDefined()
+    expect(bf027!.message).toContain('List')
+  })
+
+  test('flat shape with a `.map()`-with-JSX-callback initializer reports BF027 (via inlineableJsxConsts)', () => {
+    const source = `
+      export function List() {
+        const __root = ['a', 'b'].map((item) => <div>{item}</div>)
+        return __root
+      }
+    `
+    const result = compileJSX(source, 'List.tsx', { adapter })
+    expect(result.files).toHaveLength(0)
+    expect(result.errors.find(e => e.code === 'BF027')).toBeDefined()
+  })
+
   test('multi-component file: the broken sibling is flagged but the good sibling still compiles', () => {
     const source = `
       export function Good() { return <div>ok</div> }

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -796,6 +796,29 @@ function visitComponentBody(node: ts.Node, ctx: AnalyzerContext): void {
       (ts.isBlock(node) && node.parent === ctx.componentBodyBlock)
     )
   ) {
+    // #2720: a bare top-level block whose ONLY job is naming the render
+    // value before returning it (`{ const __root = <jsx/>; return __root
+    // }`) would otherwise be swallowed whole by the opaque-block
+    // preservation above — this walk never recurses into it, so neither
+    // `jsxConstants` nor `jsxReturn` ever get set and the component
+    // silently produces zero files, zero diagnostics. Detect the shape
+    // before preserving it and report loudly instead.
+    if (ts.isBlock(node)) {
+      const returnedLocal = findBlockBodyReturnedJsxLocalName(node)
+      if (returnedLocal) {
+        ctx.errors.push(createError(
+          ErrorCodes.RETURN_VALUE_NOT_JSX,
+          getSourceLocation(node, ctx.sourceFile, ctx.filePath),
+          {
+            message:
+              `Component '${ctx.componentName ?? '(unknown)'}' return value is not recognized ` +
+              `as JSX — return the JSX expression directly instead of binding it to a local ` +
+              `variable first (\`return ${returnedLocal}\` after \`const ${returnedLocal} = ` +
+              `<jsx/>\` is not resolved at return position).`,
+          },
+        ))
+      }
+    }
     collectInitStatement(node, ctx)
     return
   }
@@ -884,6 +907,46 @@ export function unwrapJsxTransparent(expr: ts.Expression): ts.Expression {
     current = (current as ts.AsExpression | ts.ParenthesizedExpression | ts.SatisfiesExpression | ts.NonNullExpression | ts.TypeAssertion).expression
   }
   return current
+}
+
+/**
+ * BF027 (#2720) shape detector: a block whose last statement returns a
+ * bare identifier, where some earlier statement in the SAME block declares
+ * that identifier as a `const`/`let` initialized to JSX (root JSX, or JSX
+ * nested in a ternary/`&&`/`||`/`??`) — `{ const __root = <jsx/>; return
+ * __root }`. Mirrors the same two "does this initializer hold JSX" checks
+ * `collectConstant` uses to populate `jsxConstants` / `inlineableJsxConsts`
+ * for ordinary top-level locals, applied here to a nested block that would
+ * otherwise never be walked (it is preserved whole as an opaque init
+ * statement, see #930). Returns the identifier's name on a match, else
+ * null — deliberately narrow (exact "name, then return that name" shape)
+ * so an ordinary block scoping unrelated imperative logic is untouched.
+ */
+function findBlockBodyReturnedJsxLocalName(block: ts.Block): string | null {
+  const stmts = block.statements
+  const last = stmts[stmts.length - 1]
+  if (!last || !ts.isReturnStatement(last) || !last.expression) return null
+  const returned = unwrapJsxTransparent(last.expression)
+  if (!ts.isIdentifier(returned)) return null
+  const name = returned.text
+
+  for (const stmt of stmts) {
+    if (!ts.isVariableStatement(stmt)) continue
+    for (const decl of stmt.declarationList.declarations) {
+      if (!ts.isIdentifier(decl.name) || decl.name.text !== name || !decl.initializer) continue
+      let init: ts.Expression = decl.initializer
+      while (ts.isParenthesizedExpression(init)) init = init.expression
+      if (
+        ts.isJsxElement(init) ||
+        ts.isJsxSelfClosingElement(init) ||
+        ts.isJsxFragment(init) ||
+        initializerShapeContainsJsx(init)
+      ) {
+        return name
+      }
+    }
+  }
+  return null
 }
 
 /**

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -940,7 +940,15 @@ function findBlockBodyReturnedJsxLocalName(block: ts.Block): string | null {
         ts.isJsxElement(init) ||
         ts.isJsxSelfClosingElement(init) ||
         ts.isJsxFragment(init) ||
-        initializerShapeContainsJsx(init)
+        initializerShapeContainsJsx(init) ||
+        // `initializerShapeContainsJsx` deliberately stops at arrow
+        // boundaries, so a `.map()`/`.flatMap()` whose CALLBACK returns JSX
+        // needs the same dedicated check `collectConstant` uses to admit
+        // that shape into `inlineableJsxConsts` (#1554) — without it,
+        // `{ const __root = items.map(i => <div/>); return __root }` slips
+        // past BF027 back into the silent-drop path (Copilot review on
+        // #2726).
+        isMapLikeCallWithJsx(init)
       ) {
         return name
       }

--- a/packages/jsx/src/errors.ts
+++ b/packages/jsx/src/errors.ts
@@ -22,11 +22,24 @@ export const ErrorCodes = {
   // Signal/Memo errors (BF011-BF019)
   SIGNAL_OUTSIDE_COMPONENT: 'BF011',
 
-  // JSX errors (BF021-BF029)
+  // JSX errors (BF021-BF029). BF022 was retired (see
+  // `invalid-jsx-attribute.audit.test.ts`) and BF026 is reserved by
+  // `spec/callback-fidelity.md` for a future `.map()`-callback-shape
+  // diagnostic — BF027 is the next free slot.
   UNSUPPORTED_JSX_PATTERN: 'BF021',
   MISSING_KEY_IN_LIST: 'BF023',
   MISSING_KEY_IN_NESTED_LIST: 'BF024',
   UNSUPPORTED_DESTRUCTURE_REST: 'BF025',
+  // The component's return statement resolves to a bare identifier that
+  // refers to a local `const`/`let` whose initializer IS JSX (or a
+  // JSX-shaped ternary/`&&`/`||`/`??`), e.g. `const __root = <div/>; return
+  // __root`. JSX-child position resolves such identifiers through
+  // `jsxConstants` / `inlineableJsxConsts` (#547 / #1409), but return
+  // position deliberately does not (see `transformExpressionInner`'s
+  // docstring) — so the dispatcher's scalar-leaf fallback silently produces
+  // no IR and no diagnostic (#2720). Loud stopgap until the analyzer learns
+  // to resolve the identifier at return position too.
+  RETURN_VALUE_NOT_JSX: 'BF027',
 
   // Component errors (BF043-BF049)
   PROPS_DESTRUCTURING: 'BF043',
@@ -151,6 +164,9 @@ const errorMessages: Record<ErrorCode, string> = {
     // keeps its name so external consumers' `e.code === 'BF025'` checks remain
     // stable.
     'Computed property key in .map() callback destructure is not supported. Rewrite the callback to destructure explicit bindings (e.g., `({ a, b }) => ...`) so the compiler can rewrite references to per-item signal accessors.',
+
+  [ErrorCodes.RETURN_VALUE_NOT_JSX]:
+    "Component's return value is not recognized as JSX — return the JSX expression directly instead of binding it to a local variable first.",
 
   [ErrorCodes.PROPS_DESTRUCTURING]:
     'Props destructuring in function parameters breaks reactivity. Use props object directly.',

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -1066,7 +1066,37 @@ function buildIRRoot(analyzer: AnalyzerContext): IRNode | null {
   // scope; the inner IR must not double-mark a nested element as root.
   ctx.isRoot = false
   const ir = transformJsxExpression(jsxReturn, ctx)
-  if (ir === null) return null
+  if (ir === null) {
+    // BF027 (#2720): a bare identifier at return position that names a
+    // local `const`/`let` PROVEN to hold JSX (`jsxConstants` — pure JSX
+    // literal; `inlineableJsxConsts` — a JSX-shaped ternary/`&&`/`||`/`??`)
+    // is the "returned JSX through a local variable" shape. Return position
+    // deliberately does not resolve identifiers the way JSX-child position
+    // does (see the #547/#1409 inlining above), so the scalar-leaf fallback
+    // would otherwise drop this component with zero files and zero
+    // diagnostics. Scoped to identifiers already proven JSX-holding by
+    // those two maps so an ordinary non-JSX return (`return 42`, `return
+    // someHelperResult`) — including from a PascalCase-but-not-a-component
+    // export the analyzer's syntactic component detector still matches —
+    // stays silent exactly as before.
+    if (
+      ts.isIdentifier(jsxReturn) &&
+      (analyzer.jsxConstants.has(jsxReturn.text) || analyzer.inlineableJsxConsts.has(jsxReturn.text))
+    ) {
+      analyzer.errors.push(createError(
+        ErrorCodes.RETURN_VALUE_NOT_JSX,
+        getSourceLocation(jsxReturn, analyzer.sourceFile, analyzer.filePath),
+        {
+          message:
+            `Component '${analyzer.componentName ?? '(unknown)'}' return value is not recognized ` +
+            `as JSX — return the JSX expression directly instead of binding it to a local variable ` +
+            `first (\`return ${jsxReturn.text}\` after \`const ${jsxReturn.text} = <jsx/>\` is not ` +
+            `resolved at return position).`,
+        },
+      ))
+    }
+    return null
+  }
   return wrapInScopeElement(ir)
 }
 

--- a/spec/compiler.md
+++ b/spec/compiler.md
@@ -841,6 +841,7 @@ symbol of each JSX tag through to the resolver; tracked as a follow-up.
 | BF023 | Missing `key` attribute in `.map()` loop — root JSX element has no `key` prop |
 | BF024 | Missing `key` attribute in nested `.map()` loop — inner loop root JSX element has no `key` prop |
 | BF025 | Unsupported destructure shape in `.map()` callback (computed property key — rest elements have been supported since #1244/#1309) |
+| BF027 | Component's return statement is a bare identifier naming a local `const`/`let` already proven to hold JSX (`const __root = <jsx/>; return __root`) — return position does not resolve identifiers through their initializer the way JSX-child position does, so this shape produced zero output and zero diagnostics before this code existed (#2720) |
 | BF101 | An adapter has no template-language lowering for the expression (an off-catalogue array/string method, a nested higher-order callback, or a loop array bound to a computed component-scope local) — raised only by non-JS template adapters (Go, Mojo, Xslate, Twig, ERB, Blade, Jinja, MiniJinja); a JS-runtime adapter (Hono, CSR) executes the expression verbatim instead. See "Unsupported Expressions (BF101)" below. |
 | BF043 | Props destructuring breaks reactivity |
 | BF044 | Signal/memo getter passed without calling it |


### PR DESCRIPTION
Fixes the loud half of #2720 (the faithful half — actually resolving the identifier at return position — stays tracked there).

`const __root = (<jsx/>); return __root` used to make `compileJSX` return `{files: [], errors: []}` — no output, no diagnostic. The mutation sweep (#2725) found it on its first run: 41/41 corpus fixtures reproduced it identically under the `block-body` mutation, the exact silence class the compat policy forbids.

## Change

New diagnostic **BF027 `RETURN_VALUE_NOT_JSX`** (BF022 retired, BF026 reserved by `spec/callback-fidelity.md` — next free slot), fired at the two structural variants:

- **Flat form** (`buildIRRoot`, `jsx-to-ir.ts`): the returned bare identifier names a local already PROVEN to hold JSX by `jsxConstants` / `inlineableJsxConsts` — precision comes from those existing maps, so an ordinary non-JSX return (`return 42`, a PascalCase helper returning an object) stays silent exactly as before.
- **Nested-block form** (`visitComponentBody`, `analyzer.ts` — the shape the `block-body` mutation actually generates): before the #930 opaque-block preservation swallows a bare block, a new check recognizes "last statement returns a bare identifier that a same-block `const`/`let` initializes with JSX (or a JSX-shaped ternary/`&&`/`||`/`??`)".

## Verification

- New `return-through-local-var.test.ts` (12 tests): both variants refuse with BF027; direct JSX returns, render-nothing components, non-JSX PascalCase exports, opaque non-JSX blocks, and props-derived identifier returns all stay untouched; in a multi-component file only the broken component is flagged and the healthy one still emits.
- False-positive proof: `bun test packages/jsx` 3158 tests, 0 fail — no existing component trips the new diagnostic.
- Mutation-sweep effect: `block-body` classification flips **broken 41 → refused 41** (a pass under #2481's sound-or-loud trichotomy), every manifest entry carrying `["BF027"]`. `bun test packages/adapter-tests` 2142 pass.
- `spec/compiler.md` error-code table gains the BF027 row; changeset: `@barefootjs/jsx` patch (a silent drop replaced by a loud refusal).

No conformance fixture is added: this narrows nothing and widens nothing — it converts an existing silent rejection into a diagnostic, and no corpus fixture has the shape (`expectedDiagnostics` unaffected, adapter suites green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198yG2px5ygfvmdoMkhRS13

---
_Generated by [Claude Code](https://claude.ai/code/session_0198yG2px5ygfvmdoMkhRS13)_