### PR TITLE
Gate the reactive `.value` DOM write to genuine form controls (#2716)

### DIFF
--- a/.changeset/value-idl-property-non-form-root-2716.md
+++ b/.changeset/value-idl-property-non-form-root-2716.md
@@ -1,0 +1,7 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Fix #2716: a reactive `value` prop/attribute unconditionally wrote the live `.value` DOM IDL property, even onto elements that aren't form controls — most visibly a child component's root `<div>` reactively mirroring a parent-passed `value` prop (e.g. `<ReactiveChild value={count()} />`). SSR never renders a `.value` property, so hydration silently planted an expando the server-rendered DOM never had — a hydrated/SSR DOM-state divergence, and a hazard for any code that duck-types form controls via `'value' in el`.
+
+The write is now gated at runtime to genuine form controls (input/textarea/select/option, the controlled-value contract) via the same `'value' in target` check `applyRestAttrs` already used for its own rest-spread handling. A developer-authored `value=` attribute on a plain element (SSR already renders it) falls back to a plain attribute write; the child-root prop MIRROR (`emitReactivePropBindings`/`emitReactiveChildProps`, which has no SSR-rendered counterpart at all) writes nothing on a non-form-control root instead, matching what SSR rendered there.

--- a/packages/adapter-tests/e2e/mutation-quarantine.ts
+++ b/packages/adapter-tests/e2e/mutation-quarantine.ts
@@ -215,8 +215,7 @@ const ENTRIES: readonly MutationQuarantineEntry[] = [
     mutationId: 'alias-props',
     oracle: 'idempotence',
     reason:
-      "Click on '.btn-parent-increment' times out on one of the two legs. reactive-props already carries a known, different hydration divergence (a live .value DOM property appearing only after hydration — oracle-quarantine.ts, issue 2716) that is NOT quarantined for idempotence on the base fixture; this alias-props mutant's idempotence failure has not been isolated from that existing issue and may be the same underlying cause compounded by the extra alias hop.",
-    issue: 'https://github.com/piconic-ai/barefootjs/issues/2716',
+      "Click on '.btn-parent-increment' times out on one of the two legs. Confirmed INDEPENDENT of #2716 (the live .value DOM property expando this row's reason used to implicate): #2716 is fixed and this idempotence failure persists unchanged, so it is a genuine alias-props-specific defect, not that bug compounded by the extra alias hop. Not yet isolated to a root cause of its own.",
   },
 
   // --- G6 -------------------------------------------------------------------
@@ -227,6 +226,38 @@ const ENTRIES: readonly MutationQuarantineEntry[] = [
     reason:
       "Click on '[data-slot=\"carousel-next\"]' times out (button stays disabled). The base fixture's idempotence oracle is already excluded (not merely quarantined) in oracle.playwright.ts's IDEMPOTENCE_EXCLUDED map for the same reason: embla's drag steps are pointer-position-dependent on a CSS-less host page (#1971), so replaying the SAME drag sequence twice is inherently flaky independent of any real bug. This mutant reproduces that known flakiness rather than a new fragment-wrap-specific defect; kept here (mutation.playwright.ts has no equivalent exclusion map, only the ORACLE_QUARANTINE skip) rather than silently passing.",
     issue: 'https://github.com/piconic-ai/barefootjs/issues/1971',
+  },
+
+  // --- G7 ---------------------------------------------------------------
+  // Unmasked by the #2716 fix: `props-reactivity-comparison` and
+  // `reactive-props` were entirely quarantined in oracle-quarantine.ts
+  // (the .value expando) before this PR, so mutation.playwright.ts's
+  // `baseAlreadyQuarantined` skip (this file's docstring) skipped EVERY
+  // mutation triple for these two fixtures outright — none of them had
+  // ever actually run. With that quarantine gone, they ran for the first
+  // time and hit the SAME already-documented mutation-tool artifacts G2/G3
+  // already catalogue for other fixtures — not new bugs, just newly-run
+  // triples that happen to reproduce them.
+  {
+    fixtureId: 'props-reactivity-comparison',
+    mutationId: 'fragment-wrap',
+    oracle: 'three-point',
+    reason: FRAGMENT_WRAP_CSR_MOUNT_SCOPE_ID_PRE_INTERACTION,
+    issue: 'https://github.com/piconic-ai/barefootjs/issues/2722',
+  },
+  {
+    fixtureId: 'reactive-props',
+    mutationId: 'fragment-wrap',
+    oracle: 'three-point',
+    reason: FRAGMENT_WRAP_CSR_MOUNT_SCOPE_ID_PRE_INTERACTION,
+    issue: 'https://github.com/piconic-ai/barefootjs/issues/2722',
+  },
+  {
+    fixtureId: 'reactive-props',
+    mutationId: 'alias-props',
+    oracle: 'three-point',
+    reason: ALIAS_PROPS_CSR_MOUNT_EMPTY,
+    issue: 'https://github.com/piconic-ai/barefootjs/issues/2723',
   },
 ]
 

--- a/packages/adapter-tests/e2e/oracle-quarantine.ts
+++ b/packages/adapter-tests/e2e/oracle-quarantine.ts
@@ -133,27 +133,22 @@ export const ORACLE_QUARANTINE: Readonly<Record<string, QuarantineEntry>> = {
     reason: 'SSR <li> carries data-key="1:a &amp; b"; absent after hydration claims the loop row.',
     issue: 'https://github.com/piconic-ai/barefootjs/issues/2718',
   },
-  // Unexplained expando `.value` DOM PROPERTY (not attribute — `dom-
-  // state.ts` reads the IDL property) appears on a plain, non-form-
-  // control root element after hydration, absent pre-hydration. Traced
-  // to `apply-rest-attrs.ts`'s unconditional `el.value = …` write for any
-  // spread `value` key (`ChildProps.value` here is a plain numeric data
-  // prop, not a form control's value) — worth confirming that's really
-  // the path hit for a `<div>` root that spreads nothing itself.
-  'props-reactivity-comparison': {
-    oracles: ['snap', 'three-point'],
-    reason: 'PropsStyleChild/DestructuredStyleChild root <div> gains a live .value=1 DOM property after hydration that is absent pre-hydration.',
-    issue: 'https://github.com/piconic-ai/barefootjs/issues/2716',
-  },
-  'reactive-props': {
-    oracles: ['snap', 'three-point'],
-    reason: 'ReactiveChild root <div> gains a live .value=0 DOM property after hydration that is absent pre-hydration (same shape as props-reactivity-comparison).',
-    issue: 'https://github.com/piconic-ai/barefootjs/issues/2716',
-  },
+  // tabs' `snap` row (the expando-.value shape, #2716) is gone — the fix
+  // there was verified with the real oracle run. `three-point`'s FIRST
+  // comparison (SSR vs hydrated) now passes for the same reason, which
+  // unmasked a SECOND, previously-hidden comparison inside the same oracle
+  // (hydrated vs csr-mount, `runThreePointOracle` in oracle-core.ts runs it
+  // only after the first passes): csr-mount's default-active TabsTrigger
+  // renders `aria-selected="false" data-state="inactive"` with no
+  // `data-value` at all, while the hydrated leg correctly shows
+  // `aria-selected="true" data-state="active" data-value="account"` — the
+  // csr-mount leg isn't computing the default active tab the same way.
+  // Unrelated to #2716's DOM-property write; filed separately as #2728.
   tabs: {
-    oracles: ['snap', 'three-point', 'idempotence'],
-    reason: 'Tabs root <div> gains a live .value="account" DOM property after hydration that is absent pre-hydration (same shape as props-reactivity-comparison). Idempotence: replaying its two click steps times out (10s) waiting for the second tab trigger — its [data-value] locator never matches in one leg.',
-    issue: 'https://github.com/piconic-ai/barefootjs/issues/2716',
+    oracles: ['three-point', 'idempotence'],
+    reason:
+      "three-point: csr-mount's default-active TabsTrigger disagrees with the hydrated leg on aria-selected/data-state/data-value (see module comment above) — a distinct, previously-masked divergence, not the #2716 .value shape. Idempotence: replaying its two click steps times out (10s) waiting for the second tab trigger — its [data-value] locator never matches in one leg; may or may not share a root cause with the three-point row.",
+    issue: 'https://github.com/piconic-ai/barefootjs/issues/2728',
   },
   'todo-app': {
     oracles: ['snap', 'three-point'],

--- a/packages/adapter-tests/fixtures/__snapshots__/ai-chat.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/ai-chat.client.js
@@ -47,7 +47,7 @@ export function initAIChatInteractive(__scope, _p = {}) {
   createEffect(() => {
     if (_s6) {
       const __val = String(input())
-      if (_s6.value !== __val) _s6.value = __val
+      if ('value' in _s6) { if (_s6.value !== __val) _s6.value = __val } else { _s6.setAttribute('value', __val) }
       _s6.disabled = !!(isStreaming())
     }
   })

--- a/packages/adapter-tests/fixtures/__snapshots__/combobox.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/combobox.client.js
@@ -3233,8 +3233,7 @@ export function initComboboxBasicDemo(__scope, _p = {}) {
   // Reactive prop bindings
   createEffect(() => {
     if (_s10) {
-      const __val = String(value())
-      if (_s10.value !== __val) _s10.value = __val
+      if ('value' in _s10) { const __val = String(value()); if (_s10.value !== __val) _s10.value = __val }
     }
   })
 
@@ -3242,8 +3241,7 @@ export function initComboboxBasicDemo(__scope, _p = {}) {
   createEffect(() => {
     const [__Combobox_s10El] = $c(__scope, 's10')
     if (__Combobox_s10El) {
-      const __val = String(value())
-      if (__Combobox_s10El.value !== __val) __Combobox_s10El.value = __val
+      if ('value' in __Combobox_s10El) { const __val = String(value()); if (__Combobox_s10El.value !== __val) __Combobox_s10El.value = __val }
     }
   })
 
@@ -3288,12 +3286,10 @@ export function initComboboxFormDemo(__scope, _p = {}) {
   // Reactive prop bindings
   createEffect(() => {
     if (_s10) {
-      const __val = String(language())
-      if (_s10.value !== __val) _s10.value = __val
+      if ('value' in _s10) { const __val = String(language()); if (_s10.value !== __val) _s10.value = __val }
     }
     if (_s21) {
-      const __val = String(framework())
-      if (_s21.value !== __val) _s21.value = __val
+      if ('value' in _s21) { const __val = String(framework()); if (_s21.value !== __val) _s21.value = __val }
     }
   })
 
@@ -3301,13 +3297,11 @@ export function initComboboxFormDemo(__scope, _p = {}) {
   createEffect(() => {
     const [__Combobox_s10El] = $c(__scope, 's10')
     if (__Combobox_s10El) {
-      const __val = String(language())
-      if (__Combobox_s10El.value !== __val) __Combobox_s10El.value = __val
+      if ('value' in __Combobox_s10El) { const __val = String(language()); if (__Combobox_s10El.value !== __val) __Combobox_s10El.value = __val }
     }
     const [__Combobox_s21El] = $c(__scope, 's21')
     if (__Combobox_s21El) {
-      const __val = String(framework())
-      if (__Combobox_s21El.value !== __val) __Combobox_s21El.value = __val
+      if ('value' in __Combobox_s21El) { const __val = String(framework()); if (__Combobox_s21El.value !== __val) __Combobox_s21El.value = __val }
     }
   })
 
@@ -3361,8 +3355,7 @@ export function initComboboxGroupedDemo(__scope, _p = {}) {
   // Reactive prop bindings
   createEffect(() => {
     if (_s20) {
-      const __val = String(timezone())
-      if (_s20.value !== __val) _s20.value = __val
+      if ('value' in _s20) { const __val = String(timezone()); if (_s20.value !== __val) _s20.value = __val }
     }
   })
 
@@ -3370,8 +3363,7 @@ export function initComboboxGroupedDemo(__scope, _p = {}) {
   createEffect(() => {
     const [__Combobox_s20El] = $c(__scope, 's20')
     if (__Combobox_s20El) {
-      const __val = String(timezone())
-      if (__Combobox_s20El.value !== __val) __Combobox_s20El.value = __val
+      if ('value' in __Combobox_s20El) { const __val = String(timezone()); if (__Combobox_s20El.value !== __val) __Combobox_s20El.value = __val }
     }
   })
 

--- a/packages/adapter-tests/fixtures/__snapshots__/data-table.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/data-table.client.js
@@ -3410,7 +3410,7 @@ export function initDataTableFilteringDemo(__scope, _p = {}) {
   createEffect(() => {
     if (_s0) {
       const __val = String(filter())
-      if (_s0.value !== __val) _s0.value = __val
+      if ('value' in _s0) { if (_s0.value !== __val) _s0.value = __val } else { _s0.setAttribute('value', __val) }
     }
   })
 

--- a/packages/adapter-tests/fixtures/__snapshots__/dialog.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/dialog.client.js
@@ -383,7 +383,7 @@ export function initDialogFormDemo(__scope, _p = {}) {
   createEffect(() => {
     if (_s5) {
       const __val = String(confirmText())
-      if (_s5.value !== __val) _s5.value = __val
+      if ('value' in _s5) { if (_s5.value !== __val) _s5.value = __val } else { _s5.setAttribute('value', __val) }
     }
   })
 

--- a/packages/adapter-tests/fixtures/__snapshots__/dropdown-menu.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/dropdown-menu.client.js
@@ -3428,8 +3428,7 @@ export function initDropdownMenuProfileDemo(__scope, _p = {}) {
       __scope.open = !!(open())
     }
     if (_s11) {
-      const __val = String(language())
-      if (_s11.value !== __val) _s11.value = __val
+      if ('value' in _s11) { const __val = String(language()); if (_s11.value !== __val) _s11.value = __val }
     }
     if (_s18) {
       _s18.checked = !!(showBookmarks())
@@ -3446,8 +3445,7 @@ export function initDropdownMenuProfileDemo(__scope, _p = {}) {
     }
     const [__DropdownMenuRadioGroup_s11El] = $c(__scope, 's11')
     if (__DropdownMenuRadioGroup_s11El) {
-      const __val = String(language())
-      if (__DropdownMenuRadioGroup_s11El.value !== __val) __DropdownMenuRadioGroup_s11El.value = __val
+      if ('value' in __DropdownMenuRadioGroup_s11El) { const __val = String(language()); if (__DropdownMenuRadioGroup_s11El.value !== __val) __DropdownMenuRadioGroup_s11El.value = __val }
     }
     const [__DropdownMenuCheckboxItem_s18El] = $c(__scope, 's18')
     if (__DropdownMenuCheckboxItem_s18El) {

--- a/packages/adapter-tests/fixtures/__snapshots__/props-reactivity-comparison.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/props-reactivity-comparison.client.js
@@ -50,12 +50,10 @@ export function initReactiveProps(__scope, _p = {}) {
   // Reactive prop bindings
   createEffect(() => {
     if (_s5) {
-      const __val = String(count())
-      if (_s5.value !== __val) _s5.value = __val
+      if ('value' in _s5) { const __val = String(count()); if (_s5.value !== __val) _s5.value = __val }
     }
     if (_s6) {
-      const __val = String(doubled())
-      if (_s6.value !== __val) _s6.value = __val
+      if ('value' in _s6) { const __val = String(doubled()); if (_s6.value !== __val) _s6.value = __val }
     }
   })
 
@@ -63,13 +61,11 @@ export function initReactiveProps(__scope, _p = {}) {
   createEffect(() => {
     const [__ReactiveChild_s5El] = $c(__scope, 's5')
     if (__ReactiveChild_s5El) {
-      const __val = String(count())
-      if (__ReactiveChild_s5El.value !== __val) __ReactiveChild_s5El.value = __val
+      if ('value' in __ReactiveChild_s5El) { const __val = String(count()); if (__ReactiveChild_s5El.value !== __val) __ReactiveChild_s5El.value = __val }
     }
     const [__ReactiveChild_s6El] = $c(__scope, 's6')
     if (__ReactiveChild_s6El) {
-      const __val = String(doubled())
-      if (__ReactiveChild_s6El.value !== __val) __ReactiveChild_s6El.value = __val
+      if ('value' in __ReactiveChild_s6El) { const __val = String(doubled()); if (__ReactiveChild_s6El.value !== __val) __ReactiveChild_s6El.value = __val }
     }
   })
 
@@ -159,12 +155,10 @@ export function initPropsReactivityComparison(__scope, _p = {}) {
   // Reactive prop bindings
   createEffect(() => {
     if (_s3) {
-      const __val = String(count())
-      if (_s3.value !== __val) _s3.value = __val
+      if ('value' in _s3) { const __val = String(count()); if (_s3.value !== __val) _s3.value = __val }
     }
     if (_s4) {
-      const __val = String(count())
-      if (_s4.value !== __val) _s4.value = __val
+      if ('value' in _s4) { const __val = String(count()); if (_s4.value !== __val) _s4.value = __val }
     }
   })
 
@@ -172,13 +166,11 @@ export function initPropsReactivityComparison(__scope, _p = {}) {
   createEffect(() => {
     const [__PropsStyleChild_s3El] = $c(__scope, 's3')
     if (__PropsStyleChild_s3El) {
-      const __val = String(count())
-      if (__PropsStyleChild_s3El.value !== __val) __PropsStyleChild_s3El.value = __val
+      if ('value' in __PropsStyleChild_s3El) { const __val = String(count()); if (__PropsStyleChild_s3El.value !== __val) __PropsStyleChild_s3El.value = __val }
     }
     const [__DestructuredStyleChild_s4El] = $c(__scope, 's4')
     if (__DestructuredStyleChild_s4El) {
-      const __val = String(count())
-      if (__DestructuredStyleChild_s4El.value !== __val) __DestructuredStyleChild_s4El.value = __val
+      if ('value' in __DestructuredStyleChild_s4El) { const __val = String(count()); if (__DestructuredStyleChild_s4El.value !== __val) __DestructuredStyleChild_s4El.value = __val }
     }
   })
 

--- a/packages/adapter-tests/fixtures/__snapshots__/reactive-props.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/reactive-props.client.js
@@ -50,12 +50,10 @@ export function initReactiveProps(__scope, _p = {}) {
   // Reactive prop bindings
   createEffect(() => {
     if (_s5) {
-      const __val = String(count())
-      if (_s5.value !== __val) _s5.value = __val
+      if ('value' in _s5) { const __val = String(count()); if (_s5.value !== __val) _s5.value = __val }
     }
     if (_s6) {
-      const __val = String(doubled())
-      if (_s6.value !== __val) _s6.value = __val
+      if ('value' in _s6) { const __val = String(doubled()); if (_s6.value !== __val) _s6.value = __val }
     }
   })
 
@@ -63,13 +61,11 @@ export function initReactiveProps(__scope, _p = {}) {
   createEffect(() => {
     const [__ReactiveChild_s5El] = $c(__scope, 's5')
     if (__ReactiveChild_s5El) {
-      const __val = String(count())
-      if (__ReactiveChild_s5El.value !== __val) __ReactiveChild_s5El.value = __val
+      if ('value' in __ReactiveChild_s5El) { const __val = String(count()); if (__ReactiveChild_s5El.value !== __val) __ReactiveChild_s5El.value = __val }
     }
     const [__ReactiveChild_s6El] = $c(__scope, 's6')
     if (__ReactiveChild_s6El) {
-      const __val = String(doubled())
-      if (__ReactiveChild_s6El.value !== __val) __ReactiveChild_s6El.value = __val
+      if ('value' in __ReactiveChild_s6El) { const __val = String(doubled()); if (__ReactiveChild_s6El.value !== __val) __ReactiveChild_s6El.value = __val }
     }
   })
 
@@ -159,12 +155,10 @@ export function initPropsReactivityComparison(__scope, _p = {}) {
   // Reactive prop bindings
   createEffect(() => {
     if (_s3) {
-      const __val = String(count())
-      if (_s3.value !== __val) _s3.value = __val
+      if ('value' in _s3) { const __val = String(count()); if (_s3.value !== __val) _s3.value = __val }
     }
     if (_s4) {
-      const __val = String(count())
-      if (_s4.value !== __val) _s4.value = __val
+      if ('value' in _s4) { const __val = String(count()); if (_s4.value !== __val) _s4.value = __val }
     }
   })
 
@@ -172,13 +166,11 @@ export function initPropsReactivityComparison(__scope, _p = {}) {
   createEffect(() => {
     const [__PropsStyleChild_s3El] = $c(__scope, 's3')
     if (__PropsStyleChild_s3El) {
-      const __val = String(count())
-      if (__PropsStyleChild_s3El.value !== __val) __PropsStyleChild_s3El.value = __val
+      if ('value' in __PropsStyleChild_s3El) { const __val = String(count()); if (__PropsStyleChild_s3El.value !== __val) __PropsStyleChild_s3El.value = __val }
     }
     const [__DestructuredStyleChild_s4El] = $c(__scope, 's4')
     if (__DestructuredStyleChild_s4El) {
-      const __val = String(count())
-      if (__DestructuredStyleChild_s4El.value !== __val) __DestructuredStyleChild_s4El.value = __val
+      if ('value' in __DestructuredStyleChild_s4El) { const __val = String(count()); if (__DestructuredStyleChild_s4El.value !== __val) __DestructuredStyleChild_s4El.value = __val }
     }
   })
 

--- a/packages/adapter-tests/fixtures/__snapshots__/select-native-shared.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/select-native-shared.client.js
@@ -23,7 +23,7 @@ export function initSelectNative(__scope, _p = {}) {
   createEffect(() => {
     if (_s2) {
       const __val = String(picked())
-      if (_s2.value !== __val) _s2.value = __val
+      if ('value' in _s2) { if (_s2.value !== __val) _s2.value = __val } else { _s2.setAttribute('value', __val) }
     }
   })
 
@@ -43,7 +43,7 @@ export function initSelectNative(__scope, _p = {}) {
       if (__t) {
         const __x = f().id
         const __val = String(__x)
-        if (__t.value !== __val) __t.value = __val
+        if ('value' in __t) { if (__t.value !== __val) __t.value = __val } else { __t.setAttribute('value', __val) }
         __l[0] = __x
       } }
       { const __t = __r[0]
@@ -66,7 +66,7 @@ export function initSelectNative(__scope, _p = {}) {
         const __x = f().id
         if (!(0 in __l) || !Object.is(__l[0], __x)) {
           const __val = String(__x)
-          if (__t.value !== __val) __t.value = __val
+          if ('value' in __t) { if (__t.value !== __val) __t.value = __val } else { __t.setAttribute('value', __val) }
         }
         __l[0] = __x
       } }

--- a/packages/adapter-tests/fixtures/__snapshots__/select.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/select.client.js
@@ -3131,8 +3131,7 @@ export function initSelectBasicDemo(__scope, _p = {}) {
   // Reactive prop bindings
   createEffect(() => {
     if (_s8) {
-      const __val = String(value())
-      if (_s8.value !== __val) _s8.value = __val
+      if ('value' in _s8) { const __val = String(value()); if (_s8.value !== __val) _s8.value = __val }
     }
   })
 
@@ -3140,8 +3139,7 @@ export function initSelectBasicDemo(__scope, _p = {}) {
   createEffect(() => {
     const [__Select_s8El] = $c(__scope, 's8')
     if (__Select_s8El) {
-      const __val = String(value())
-      if (__Select_s8El.value !== __val) __Select_s8El.value = __val
+      if ('value' in __Select_s8El) { const __val = String(value()); if (__Select_s8El.value !== __val) __Select_s8El.value = __val }
     }
   })
 
@@ -3186,16 +3184,13 @@ export function initSelectFormDemo(__scope, _p = {}) {
   // Reactive prop bindings
   createEffect(() => {
     if (_s7) {
-      const __val = String(framework())
-      if (_s7.value !== __val) _s7.value = __val
+      if ('value' in _s7) { const __val = String(framework()); if (_s7.value !== __val) _s7.value = __val }
     }
     if (_s15) {
-      const __val = String(role())
-      if (_s15.value !== __val) _s15.value = __val
+      if ('value' in _s15) { const __val = String(role()); if (_s15.value !== __val) _s15.value = __val }
     }
     if (_s23) {
-      const __val = String(experience())
-      if (_s23.value !== __val) _s23.value = __val
+      if ('value' in _s23) { const __val = String(experience()); if (_s23.value !== __val) _s23.value = __val }
     }
   })
 
@@ -3203,18 +3198,15 @@ export function initSelectFormDemo(__scope, _p = {}) {
   createEffect(() => {
     const [__Select_s7El] = $c(__scope, 's7')
     if (__Select_s7El) {
-      const __val = String(framework())
-      if (__Select_s7El.value !== __val) __Select_s7El.value = __val
+      if ('value' in __Select_s7El) { const __val = String(framework()); if (__Select_s7El.value !== __val) __Select_s7El.value = __val }
     }
     const [__Select_s15El] = $c(__scope, 's15')
     if (__Select_s15El) {
-      const __val = String(role())
-      if (__Select_s15El.value !== __val) __Select_s15El.value = __val
+      if ('value' in __Select_s15El) { const __val = String(role()); if (__Select_s15El.value !== __val) __Select_s15El.value = __val }
     }
     const [__Select_s23El] = $c(__scope, 's23')
     if (__Select_s23El) {
-      const __val = String(experience())
-      if (__Select_s23El.value !== __val) __Select_s23El.value = __val
+      if ('value' in __Select_s23El) { const __val = String(experience()); if (__Select_s23El.value !== __val) __Select_s23El.value = __val }
     }
   })
 
@@ -3271,8 +3263,7 @@ export function initSelectGroupedDemo(__scope, _p = {}) {
   // Reactive prop bindings
   createEffect(() => {
     if (_s21) {
-      const __val = String(timezone())
-      if (_s21.value !== __val) _s21.value = __val
+      if ('value' in _s21) { const __val = String(timezone()); if (_s21.value !== __val) _s21.value = __val }
     }
   })
 
@@ -3280,8 +3271,7 @@ export function initSelectGroupedDemo(__scope, _p = {}) {
   createEffect(() => {
     const [__Select_s21El] = $c(__scope, 's21')
     if (__Select_s21El) {
-      const __val = String(timezone())
-      if (__Select_s21El.value !== __val) __Select_s21El.value = __val
+      if ('value' in __Select_s21El) { const __val = String(timezone()); if (__Select_s21El.value !== __val) __Select_s21El.value = __val }
     }
   })
 

--- a/packages/adapter-tests/fixtures/__snapshots__/tabs.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/tabs.client.js
@@ -137,8 +137,7 @@ export function initTabsBasicDemo(__scope, _p = {}) {
   // Reactive prop bindings
   createEffect(() => {
     if (__scope) {
-      const __val = String(activeTab())
-      if (__scope.value !== __val) __scope.value = __val
+      if ('value' in __scope) { const __val = String(activeTab()); if (__scope.value !== __val) __scope.value = __val }
     }
     if (_s0) {
       _s0.setAttribute('aria-selected', String(isAccountSelected()))
@@ -171,8 +170,7 @@ export function initTabsBasicDemo(__scope, _p = {}) {
   // Reactive child component props
   createEffect(() => {
     if (__scope) {
-      const __val = String(activeTab())
-      if (__scope.value !== __val) __scope.value = __val
+      if ('value' in __scope) { const __val = String(activeTab()); if (__scope.value !== __val) __scope.value = __val }
     }
     const [__TabsTrigger_s0El] = $c(__scope, 's0')
     if (__TabsTrigger_s0El) {
@@ -219,8 +217,7 @@ export function initTabsMultipleDemo(__scope, _p = {}) {
   // Reactive prop bindings
   createEffect(() => {
     if (__scope) {
-      const __val = String(activeTab())
-      if (__scope.value !== __val) __scope.value = __val
+      if ('value' in __scope) { const __val = String(activeTab()); if (__scope.value !== __val) __scope.value = __val }
     }
     if (_s0) {
       _s0.setAttribute('aria-selected', String(isOverviewSelected()))
@@ -279,8 +276,7 @@ export function initTabsMultipleDemo(__scope, _p = {}) {
   // Reactive child component props
   createEffect(() => {
     if (__scope) {
-      const __val = String(activeTab())
-      if (__scope.value !== __val) __scope.value = __val
+      if ('value' in __scope) { const __val = String(activeTab()); if (__scope.value !== __val) __scope.value = __val }
     }
     const [__TabsTrigger_s0El] = $c(__scope, 's0')
     if (__TabsTrigger_s0El) {
@@ -345,8 +341,7 @@ export function initTabsDisabledDemo(__scope, _p = {}) {
   // Reactive prop bindings
   createEffect(() => {
     if (__scope) {
-      const __val = String(activeTab())
-      if (__scope.value !== __val) __scope.value = __val
+      if ('value' in __scope) { const __val = String(activeTab()); if (__scope.value !== __val) __scope.value = __val }
     }
     if (_s0) {
       _s0.setAttribute('aria-selected', String(isActiveSelected()))
@@ -379,8 +374,7 @@ export function initTabsDisabledDemo(__scope, _p = {}) {
   // Reactive child component props
   createEffect(() => {
     if (__scope) {
-      const __val = String(activeTab())
-      if (__scope.value !== __val) __scope.value = __val
+      if ('value' in __scope) { const __val = String(activeTab()); if (__scope.value !== __val) __scope.value = __val }
     }
     const [__TabsTrigger_s0El] = $c(__scope, 's0')
     if (__TabsTrigger_s0El) {

--- a/packages/adapter-tests/fixtures/__snapshots__/textarea-native-shared.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/textarea-native-shared.client.js
@@ -18,7 +18,7 @@ export function initNoteBoxNative(__scope, _p = {}) {
   createEffect(() => {
     if (_s0) {
       const __val = String(note())
-      if (_s0.value !== __val) _s0.value = __val
+      if ('value' in _s0) { if (_s0.value !== __val) _s0.value = __val } else { _s0.setAttribute('value', __val) }
     }
   })
 

--- a/packages/adapter-tests/fixtures/__snapshots__/textarea.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/textarea.client.js
@@ -21,7 +21,7 @@ export function initTextarea(__scope, _p = {}) {
       { const __v = `placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input w-full min-w-0 rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-[invalid]:ring-destructive/20 dark:aria-[invalid]:ring-destructive/40 aria-[invalid]:border-destructive ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
       { const __v = (_p.placeholder ?? ''); if (__v != null) _s0.setAttribute('placeholder', String(__v)); else _s0.removeAttribute('placeholder') }
       const __val = String((_p.value ?? ''))
-      if (_s0.value !== __val) _s0.value = __val
+      if ('value' in _s0) { if (_s0.value !== __val) _s0.value = __val } else { _s0.setAttribute('value', __val) }
       _s0.disabled = !!((_p.disabled ?? false))
       _s0.readonly = !!((_p.readonly ?? false))
       { const __v = _p.rows; if (__v != null) _s0.setAttribute('rows', String(__v)); else _s0.removeAttribute('rows') }

--- a/packages/adapter-tests/fixtures/__snapshots__/todo-app-ssr.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/todo-app-ssr.client.js
@@ -27,7 +27,7 @@ export function initTodoItem(__scope, _p = {}) {
   createEffect(() => {
     if (_s4) {
       const __val = String(_p.todo.text)
-      if (_s4.value !== __val) _s4.value = __val
+      if ('value' in _s4) { if (_s4.value !== __val) _s4.value = __val } else { _s4.setAttribute('value', __val) }
     }
   })
 
@@ -168,7 +168,7 @@ export function initTodoAppSSR(__scope, _p = {}) {
   createEffect(() => {
     if (_s0) {
       const __val = String(newText())
-      if (_s0.value !== __val) _s0.value = __val
+      if ('value' in _s0) { if (_s0.value !== __val) _s0.value = __val } else { _s0.setAttribute('value', __val) }
     }
   })
 

--- a/packages/adapter-tests/fixtures/__snapshots__/todo-app.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/todo-app.client.js
@@ -27,7 +27,7 @@ export function initTodoItem(__scope, _p = {}) {
   createEffect(() => {
     if (_s4) {
       const __val = String(_p.todo.text)
-      if (_s4.value !== __val) _s4.value = __val
+      if ('value' in _s4) { if (_s4.value !== __val) _s4.value = __val } else { _s4.setAttribute('value', __val) }
     }
   })
 
@@ -168,7 +168,7 @@ export function initTodoApp(__scope, _p = {}) {
   createEffect(() => {
     if (_s0) {
       const __val = String(newText())
-      if (_s0.value !== __val) _s0.value = __val
+      if ('value' in _s0) { if (_s0.value !== __val) _s0.value = __val } else { _s0.setAttribute('value', __val) }
     }
   })
 

--- a/packages/client/__tests__/runtime/issue-2716-value-expando.test.ts
+++ b/packages/client/__tests__/runtime/issue-2716-value-expando.test.ts
@@ -16,9 +16,13 @@
  *
  * The fix gates the IDL-property write on `'value' in target` at runtime
  * (the same duck-type `applyRestAttrs.ts` already used for its own
- * rest-spread `value` handling) and falls back to a plain attribute mirror
- * for everything else — so a genuine form control (e.g. `<input>`) still
- * gets the live controlled-value write real user interaction requires.
+ * rest-spread `value` handling), so an element that already exposes
+ * `.value` (e.g. `<input>`) still gets the live controlled-value write real
+ * user interaction requires. Two DIFFERENT fallbacks for everything else,
+ * matching what SSR rendered in each case: a developer-authored `value=`
+ * attribute falls back to `setAttribute` (SSR renders that attribute), but
+ * the CHILD-ROOT named-prop mirror exercised below writes NOTHING — no
+ * property and no attribute — because SSR renders no mirror at all.
  */
 import { describe, test, expect, beforeAll, beforeEach } from 'bun:test'
 import { GlobalRegistrator } from '@happy-dom/global-registrator'
@@ -126,12 +130,16 @@ describe('#2716 — reactive `value` prop does not plant a `.value` expando on a
     expect('value' in childAfter).toBe(false)
     expect((childAfter as unknown as Record<string, unknown>).value).toBeUndefined()
 
-    // The signal-driven update still reaches the child — as a plain
-    // attribute mirror, not a live property (#2715 already tracks that
-    // SSR itself doesn't render this mirror attribute; out of scope here).
+    // The child-root mirror writes NOTHING on an element with no native
+    // `.value`: no property AND no attribute (an attribute fallback here
+    // would be a fresh SSR/hydrate divergence of its own, since SSR renders
+    // no mirror at all). The signal-driven update still reaches the child
+    // through its own text binding.
+    expect(childAfter.hasAttribute('value')).toBe(false)
     document.querySelector('button')!.dispatchEvent(new window.Event('click', { bubbles: true }))
     expect(childAfter.textContent).toBe('1')
     expect('value' in childAfter).toBe(false)
+    expect(childAfter.hasAttribute('value')).toBe(false)
   })
 
   test('a genuine form control (<input>) still gets the live controlled-value property', async () => {

--- a/packages/client/__tests__/runtime/issue-2716-value-expando.test.ts
+++ b/packages/client/__tests__/runtime/issue-2716-value-expando.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Regression test for #2716: `emitAttrUpdate` (and `emitReactivePropBindings`'s
+ * own inline `value` branch, `packages/jsx/src/ir-to-client-js/emit-reactive.ts`)
+ * used to write the DOM `.value` IDL property unconditionally whenever a
+ * reactive prop or attribute was named `value` — including onto a child
+ * component's root element when that root is a plain, non-form-control tag
+ * (e.g. `<div>`). SSR never renders a `.value` property (there is no such
+ * thing in markup), so hydration silently planted a live expando the
+ * server-rendered DOM never had — a hydrated/SSR DOM-state divergence, and a
+ * hazard for any code that duck-types form controls via `'value' in el`.
+ *
+ * This mirrors the shape of the `props-reactivity-comparison` / `reactive-props`
+ * / `tabs` adapter-tests fixtures that first surfaced the bug via the oracle
+ * harness (#2481): a child component whose root is a `<div>` receives a
+ * plain numeric `value` prop from its parent.
+ *
+ * The fix gates the IDL-property write on `'value' in target` at runtime
+ * (the same duck-type `applyRestAttrs.ts` already used for its own
+ * rest-spread `value` handling) and falls back to a plain attribute mirror
+ * for everything else — so a genuine form control (e.g. `<input>`) still
+ * gets the live controlled-value write real user interaction requires.
+ */
+import { describe, test, expect, beforeAll, beforeEach } from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+import { compileJSX } from '../../../jsx/src/compiler'
+import { TestAdapter } from '../../../jsx/src/adapters/test-adapter'
+import { renderHonoComponent } from '../../../adapter-hono/src/test-render'
+import { HonoAdapter } from '../../../adapter-hono/src/adapter/hono-adapter'
+import { writeFileSync, mkdtempSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+beforeAll(() => {
+  if (typeof window === 'undefined') GlobalRegistrator.register()
+})
+
+const adapter = new TestAdapter()
+const runtimePath = join(__dirname, '../../src/runtime/index.ts')
+
+const DIV_CHILD = `'use client'
+export function ValueChild(props: { value: number }) {
+  return <div class="child">{props.value}</div>
+}`
+
+const INPUT_CHILD = `'use client'
+export function ValueChild(props: { value: string }) {
+  return <input class="child" value={props.value} />
+}`
+
+function reproSource(): string {
+  return `'use client'
+import { createSignal } from '@barefootjs/client'
+import { ValueChild } from './ValueChild'
+export function Repro() {
+  const [count, setCount] = createSignal(0)
+  return (
+    <div>
+      <button onClick={() => setCount(c => c + 1)}>+</button>
+      <ValueChild value={count()} />
+    </div>
+  )
+}`
+}
+
+/** Compile a component's client JS with imports re-anchored to the live runtime. */
+function clientJsFor(source: string, filename: string): string {
+  const result = compileJSX(source, filename, { adapter })
+  const errors = result.errors.filter(e => e.severity === 'error')
+  if (errors.length > 0) {
+    throw new Error(`Compile errors in ${filename}:\n${errors.map(e => `${e.code}: ${e.message}`).join('\n')}`)
+  }
+  const clientJs = result.files.find(f => f.type === 'clientJs')?.content
+  if (!clientJs) throw new Error(`No client JS for ${filename}`)
+  return clientJs
+    .replace(/from\s+['"]@barefootjs\/client\/runtime['"]/g, `from '${runtimePath}'`)
+    .replace(/^import '\/\* @bf-child:\w+ \*\/'\n/gm, '')
+}
+
+async function setupHydration(childSource: string): Promise<{ hydrate: () => void }> {
+  const dir = mkdtempSync(join(tmpdir(), 'bf-2716-'))
+  const modules: Array<[string, string, string]> = [
+    [childSource, 'ValueChild.tsx', 'ValueChild'],
+    [reproSource(), 'Repro.tsx', 'Repro'],
+  ]
+  for (const [source, filename, name] of modules) {
+    const file = join(dir, `${name}.mjs`)
+    writeFileSync(file, clientJsFor(source, filename))
+    await import(file)
+  }
+
+  const ssrHtml = await renderHonoComponent({
+    adapter: new HonoAdapter(),
+    source: reproSource(),
+    components: { './ValueChild.tsx': childSource },
+    props: { __instanceId: 'Repro_test' },
+  })
+  document.body.innerHTML = ssrHtml
+
+  const { rehydrateAll, flushHydration } = await import(runtimePath)
+  return {
+    hydrate: () => {
+      rehydrateAll()
+      flushHydration()
+    },
+  }
+}
+
+describe('#2716 — reactive `value` prop does not plant a `.value` expando on a non-form root', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  test('a <div>-rooted child never gains a `.value` IDL property, before or after hydration', async () => {
+    const { hydrate } = await setupHydration(DIV_CHILD)
+
+    const childBefore = document.querySelector('.child') as HTMLElement
+    expect(childBefore).toBeTruthy()
+    expect('value' in childBefore).toBe(false)
+
+    hydrate()
+
+    const childAfter = document.querySelector('.child') as HTMLElement
+    // Same element identity check isn't required — the point is the LIVE
+    // element post-hydration, whichever it is, must not have gained the
+    // property SSR never rendered.
+    expect('value' in childAfter).toBe(false)
+    expect((childAfter as unknown as Record<string, unknown>).value).toBeUndefined()
+
+    // The signal-driven update still reaches the child — as a plain
+    // attribute mirror, not a live property (#2715 already tracks that
+    // SSR itself doesn't render this mirror attribute; out of scope here).
+    document.querySelector('button')!.dispatchEvent(new window.Event('click', { bubbles: true }))
+    expect(childAfter.textContent).toBe('1')
+    expect('value' in childAfter).toBe(false)
+  })
+
+  test('a genuine form control (<input>) still gets the live controlled-value property', async () => {
+    const { hydrate } = await setupHydration(INPUT_CHILD)
+    hydrate()
+
+    const input = document.querySelector('.child') as HTMLInputElement
+    expect(input).toBeTruthy()
+    expect(input.value).toBe('0')
+
+    document.querySelector('button')!.dispatchEvent(new window.Event('click', { bubbles: true }))
+    expect(input.value).toBe('1')
+  })
+})

--- a/packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap
+++ b/packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap
@@ -2630,8 +2630,7 @@ export function initExample(__scope, _p = {}) {
   // Reactive prop bindings
   createEffect(() => {
     if (_s0) {
-      const __val = String(count())
-      if (_s0.value !== __val) _s0.value = __val
+      if ('value' in _s0) { const __val = String(count()); if (_s0.value !== __val) _s0.value = __val }
     }
   })
 
@@ -2639,8 +2638,7 @@ export function initExample(__scope, _p = {}) {
   createEffect(() => {
     const [__Child_s0El] = $c(__scope, 's0')
     if (__Child_s0El) {
-      const __val = String(count())
-      if (__Child_s0El.value !== __val) __Child_s0El.value = __val
+      if ('value' in __Child_s0El) { const __val = String(count()); if (__Child_s0El.value !== __val) __Child_s0El.value = __val }
     }
   })
 

--- a/packages/jsx/src/__tests__/client-js-generation.test.ts
+++ b/packages/jsx/src/__tests__/client-js-generation.test.ts
@@ -1245,7 +1245,14 @@ describe('Client JS generation', () => {
 
       const clientJs = result.files.find(f => f.type === 'clientJs')
       expect(clientJs).toBeDefined()
-      // Should use .value = for value prop, not setAttribute
+      // `value={text()}` on a CHILD COMPONENT drives the child-root MIRROR
+      // path (emitReactivePropBindings/emitReactiveChildProps), gated by a
+      // runtime `'value' in el` check (#2716): a genuine form-control root
+      // still gets the live `.value =` property write, but a non-form root
+      // gets NOTHING (no setAttribute fallback either) since this mirror has
+      // no SSR-rendered counterpart to stay in sync with — see
+      // `emitChildValueMirrorStatements`'s docstring.
+      expect(clientJs!.content).toContain("'value' in")
       expect(clientJs!.content).toContain('.value =')
       expect(clientJs!.content).not.toContain("setAttribute('value'")
     })
@@ -1274,6 +1281,35 @@ describe('Client JS generation', () => {
       // Should use .disabled = !! for boolean prop, not setAttribute
       expect(clientJs!.content).toContain('.disabled = !!')
       expect(clientJs!.content).not.toContain("setAttribute('disabled'")
+    })
+
+    // #2716: a `value` prop passed to a CHILD COMPONENT (above) drives the
+    // no-SSR-fallback mirror path; a `value` ATTRIBUTE the developer writes
+    // directly on a plain HOST element is the opposite case — SSR renders
+    // that attribute, so `emitAttrUpdate`'s dispatch (used here, not the
+    // mirror helper) correctly keeps the attribute fallback for a
+    // non-form-control target.
+    test('compiles a directly-authored value attribute on a plain element with an attribute fallback (emitAttrUpdate)', () => {
+      const source = `
+        'use client'
+        import { createSignal } from '@barefootjs/client'
+
+        export function LabeledValue() {
+          const [count, setCount] = createSignal(0)
+          return <div value={count()}>{count()}</div>
+        }
+      `
+
+      const result = compileJSX(source, 'LabeledValue.tsx', { adapter })
+      expect(result.errors).toHaveLength(0)
+
+      const clientJs = result.files.find(f => f.type === 'clientJs')
+      expect(clientJs).toBeDefined()
+      // Gated the same way as the mirror path, but WITH an attribute
+      // fallback — this is a literal attribute SSR already rendered.
+      expect(clientJs!.content).toContain("'value' in")
+      expect(clientJs!.content).toContain('.value =')
+      expect(clientJs!.content).toContain("setAttribute('value'")
     })
   })
 

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/lazy-row.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/lazy-row.ts
@@ -554,8 +554,8 @@ function seedDiffersExpr(target: string, a: LazyRowAttrBinding): string {
   if (html === 'style') return `${target}.getAttribute('style') !== styleToCss(__x)`
   if (html === 'class') return `${target}.getAttribute('class') !== (__x != null ? String(__x) : null)`
   // Mirrors `emitValueUpdateStatements`'s runtime `'value' in target` gate
-  // (#2716): a non-form-control target never gets the live `.value`
-  // property, so the seed-diff must compare against the ATTRIBUTE it would
+  // (#2716): a target with no native `.value` property never gets one
+  // written, so the seed-diff must compare against the ATTRIBUTE it would
   // actually receive there, not the (absent) property.
   if (html === 'value') {
     return `('value' in ${target} ? ${target}.value !== String(__x) : ${target}.getAttribute('value') !== String(__x))`

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/lazy-row.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/lazy-row.ts
@@ -553,7 +553,13 @@ function seedDiffersExpr(target: string, a: LazyRowAttrBinding): string {
   if (a.attrName === 'dangerouslySetInnerHTML' || html === 'dangerouslySetInnerHTML') return 'true'
   if (html === 'style') return `${target}.getAttribute('style') !== styleToCss(__x)`
   if (html === 'class') return `${target}.getAttribute('class') !== (__x != null ? String(__x) : null)`
-  if (html === 'value') return `${target}.value !== String(__x)`
+  // Mirrors `emitValueUpdateStatements`'s runtime `'value' in target` gate
+  // (#2716): a non-form-control target never gets the live `.value`
+  // property, so the seed-diff must compare against the ATTRIBUTE it would
+  // actually receive there, not the (absent) property.
+  if (html === 'value') {
+    return `('value' in ${target} ? ${target}.value !== String(__x) : ${target}.getAttribute('value') !== String(__x))`
+  }
   if (isBooleanAttr(html)) return `${target}.${html} !== !!(__x)`
   if (a.meta.presenceOrUndefined) {
     // Compare the VALUE the writer would produce, not just presence.

--- a/packages/jsx/src/ir-to-client-js/emit-reactive.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-reactive.ts
@@ -32,16 +32,17 @@ function bindingIdArg(ctx: ClientJsContext, slotId: string | undefined): string 
  * Generate statements that write a `value` HTML ATTRIBUTE the developer
  * wrote directly on an element (`<div value={x}>`, a loop row's `<li
  * value={x}>`, …) — SSR renders that same attribute, so hydration keeping
- * it in sync is exactly the contract. Gated at runtime to genuine form
- * controls (input/textarea/select/option — the controlled-value contract,
- * where `setAttribute('value', x)` only sets the INITIAL HTML attribute and
- * the live `.value` IDL property is required after user interaction); any
+ * it in sync is exactly the contract. Gated at runtime to elements that
+ * ALREADY expose a native `.value` IDL property (`'value' in target` —
+ * form controls, but also e.g. `<li value>`; the same duck-type check
+ * `applyRestAttrs` uses, deliberately not a tag-name allowlist), because
+ * for those `setAttribute('value', x)` only sets the INITIAL HTML
+ * attribute and the live property is required after user interaction; any
  * other element falls back to a plain attribute write, which still matches
  * what SSR rendered there. Writing the live property unconditionally would
  * plant an expando SSR never had — a hydrated/SSR DOM-state divergence and a
  * hazard for anything that duck-types form controls via `'value' in el`
- * (#2716). `'value' in target` is the same runtime check `applyRestAttrs`
- * already uses for its own rest-spread `value` handling.
+ * (#2716).
  *
  * NOT for the child-component-root `value` MIRROR (`emitReactivePropBindings`
  * / `emitReactiveChildProps` reflecting a named prop onto a child's root
@@ -63,13 +64,14 @@ function emitValueUpdateStatements(target: string, expression: string): string[]
  * element). Unlike a developer-authored `value=` attribute
  * (`emitValueUpdateStatements`), this mirror has NO SSR-rendered
  * counterpart at all — SSR never puts a `value` attribute on a child's
- * root just because the parent passed a `value` prop. So a non-form-control
- * root gets NOTHING written (confirmed against the oracle's structural-HTML
- * comparison, #2716: an attribute fallback here reintroduced a fresh
- * SSR/hydrate divergence one layer down from the IDL-property expando this
- * replaces). A genuine form-control root (`'value' in target`) still gets
- * the live controlled-value property, same contract as the direct-attribute
- * case.
+ * root just because the parent passed a `value` prop. So a root WITHOUT a
+ * native `.value` property gets NOTHING written — not even an attribute
+ * (confirmed against the oracle's structural-HTML comparison, #2716: an
+ * attribute fallback here reintroduced a fresh SSR/hydrate divergence one
+ * layer down from the IDL-property expando this replaces). A root that
+ * already exposes `.value` (`'value' in target`, same duck-type gate as
+ * the direct-attribute case) still gets the live controlled-value
+ * property.
  */
 function emitChildValueMirrorStatements(target: string, expression: string): string[] {
   return [

--- a/packages/jsx/src/ir-to-client-js/emit-reactive.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-reactive.ts
@@ -29,6 +29,55 @@ function bindingIdArg(ctx: ClientJsContext, slotId: string | undefined): string 
 }
 
 /**
+ * Generate statements that write a `value` HTML ATTRIBUTE the developer
+ * wrote directly on an element (`<div value={x}>`, a loop row's `<li
+ * value={x}>`, …) — SSR renders that same attribute, so hydration keeping
+ * it in sync is exactly the contract. Gated at runtime to genuine form
+ * controls (input/textarea/select/option — the controlled-value contract,
+ * where `setAttribute('value', x)` only sets the INITIAL HTML attribute and
+ * the live `.value` IDL property is required after user interaction); any
+ * other element falls back to a plain attribute write, which still matches
+ * what SSR rendered there. Writing the live property unconditionally would
+ * plant an expando SSR never had — a hydrated/SSR DOM-state divergence and a
+ * hazard for anything that duck-types form controls via `'value' in el`
+ * (#2716). `'value' in target` is the same runtime check `applyRestAttrs`
+ * already uses for its own rest-spread `value` handling.
+ *
+ * NOT for the child-component-root `value` MIRROR (`emitReactivePropBindings`
+ * / `emitReactiveChildProps` reflecting a named prop onto a child's root
+ * element) — that mechanism has no SSR-rendered counterpart at all
+ * regardless of prop name, so an attribute fallback there would itself
+ * plant a fresh SSR/hydrate divergence; see `emitChildValueMirrorStatements`.
+ */
+function emitValueUpdateStatements(target: string, expression: string): string[] {
+  return [
+    `const __val = String(${expression})`,
+    `if ('value' in ${target}) { if (${target}.value !== __val) ${target}.value = __val } else { ${target}.setAttribute('value', __val) }`,
+  ]
+}
+
+/**
+ * `value`-prop write for the CHILD-ROOT MIRROR mechanism
+ * (`emitReactivePropBindings` / `emitReactiveChildProps`, both reactively
+ * reflect a parent-passed NAMED PROP onto a child component's root DOM
+ * element). Unlike a developer-authored `value=` attribute
+ * (`emitValueUpdateStatements`), this mirror has NO SSR-rendered
+ * counterpart at all — SSR never puts a `value` attribute on a child's
+ * root just because the parent passed a `value` prop. So a non-form-control
+ * root gets NOTHING written (confirmed against the oracle's structural-HTML
+ * comparison, #2716: an attribute fallback here reintroduced a fresh
+ * SSR/hydrate divergence one layer down from the IDL-property expando this
+ * replaces). A genuine form-control root (`'value' in target`) still gets
+ * the live controlled-value property, same contract as the direct-attribute
+ * case.
+ */
+function emitChildValueMirrorStatements(target: string, expression: string): string[] {
+  return [
+    `if ('value' in ${target}) { const __val = String(${expression}); if (${target}.value !== __val) ${target}.value = __val }`,
+  ]
+}
+
+/**
  * Generate JS statements to update a DOM attribute reactively.
  * Centralizes the attribute-type dispatch (value, class, boolean, presence, generic)
  * so that new AttrMeta flags are handled in one place.
@@ -55,10 +104,7 @@ export function emitAttrUpdate(target: string, attrName: string, expression: str
     ]
   }
   if (htmlName === 'value') {
-    return [
-      `const __val = String(${expression})`,
-      `if (${target}.value !== __val) ${target}.value = __val`,
-    ]
+    return emitValueUpdateStatements(target, expression)
   }
   if (isBooleanAttr(htmlName)) {
     return [`${target}.${htmlName} = !!(${expression})`]
@@ -485,14 +531,16 @@ export function emitReactivePropBindings(lines: string[], ctx: ClientJsContext):
             lines.push(`      ${ref}.setAttribute('data-state', ${value} ? 'active' : 'inactive')`)
             lines.push(`      ${ref}.setAttribute('tabindex', ${value} ? '0' : '-1')`)
           }
-        // Use DOM property assignment for value and boolean attrs.
-        // setAttribute('value', x) only sets the initial HTML attribute; after user
-        // interaction the DOM property diverges, so .value = x is required.
+        // Use DOM property assignment for value and boolean attrs, but only
+        // on genuine form controls — see `emitChildValueMirrorStatements`'s
+        // docstring (#2716). `ref` here is a named prop's MIRROR target
+        // element (a child component's arbitrary root), not necessarily a
+        // form control, and this mirror has no SSR-rendered counterpart to
+        // fall back to.
         // Boolean attrs (disabled, checked, etc.) treat any attribute presence as
         // truthy, so setAttribute('disabled', 'false') still disables the element.
         } else if (prop.propName === 'value') {
-          lines.push(`      const __val = String(${value})`)
-          lines.push(`      if (${ref}.value !== __val) ${ref}.value = __val`)
+          for (const stmt of emitChildValueMirrorStatements(ref, value)) lines.push(`      ${stmt}`)
         } else if (isBooleanAttr(prop.propName)) {
           lines.push(`      ${ref}.${prop.propName} = !!(${value})`)
         } else {
@@ -537,7 +585,14 @@ export function emitReactiveChildProps(lines: string[], ctx: ClientJsContext): v
       }
       lines.push(`    if (${varName}) {`)
       for (const prop of props) {
-        for (const stmt of emitAttrUpdate(varName, prop.attrName, prop.expression, prop)) {
+        // `value` is the CHILD-ROOT MIRROR case, not a developer-authored
+        // attribute — route it through the no-SSR-fallback helper instead
+        // of `emitAttrUpdate`'s generic (attribute-fallback) dispatch;
+        // see `emitChildValueMirrorStatements`'s docstring (#2716).
+        const stmts = toHtmlAttrName(prop.attrName) === 'value'
+          ? emitChildValueMirrorStatements(varName, prop.expression)
+          : emitAttrUpdate(varName, prop.attrName, prop.expression, prop)
+        for (const stmt of stmts) {
           lines.push(`      ${stmt}`)
         }
       }


### PR DESCRIPTION
Fixes #2716.

A plain non-form root element (`<div>`) gained a live `.value` IDL property after hydration — absent from SSR and from the CSR-mount leg's pre-effect state — flagged by the oracle harness on `props-reactivity-comparison` / `reactive-props` / `tabs`. Beyond DOM-parity hygiene, a stray `.value` on arbitrary elements is a hazard for anything duck-typing form controls via `'value' in el`.

## Measured root cause (issue's guess was wrong)

The issue suspected `apply-rest-attrs.ts`'s unconditional `el.value` write — measurement cleared it (it was already `'value' in el`-gated). The real writers are two paths in `emit-reactive.ts`, confirmed by reading the generated client JS:

- `emitAttrUpdate`'s `value` branch — the shared dispatcher for developer-authored `value=` attributes (loop rows, branches, elements).
- `emitReactivePropBindings` / `emitReactiveChildProps` — the mechanism that reactively **mirrors a parent-passed named prop onto a child component's root element**, which wrote `target.value = …` unconditionally whatever the root element was.

## Fix — two deliberately different contracts

- **Developer-authored `value=` attribute** (`emitValueUpdateStatements`): SSR renders that same attribute, so hydration keeping it in sync is the contract — form controls get the live `.value` property (controlled-value semantics), anything else falls back to `setAttribute('value', …)`, matching SSR.
- **Child-root `value` mirror** (`emitChildValueMirrorStatements`): this mirror has **no SSR-rendered counterpart at all**, so a non-form root gets *nothing* written. The intermediate attribute-fallback design was tried and rejected **by oracle measurement**: it re-introduced a fresh SSR/hydrate divergence (an SSR-less `value="0"` attribute) one layer down from the expando it replaced. Form-control roots keep the live property.

## Graduations and one newly exposed bug

- `oracle-quarantine.ts`: `props-reactivity-comparison` and `reactive-props` **fully graduated** (all oracles pass bare); `tabs` graduated from `snap` — and un-blinding its `three-point` first comparison exposed a previously hidden divergence (CSR-mount's default-active-tab computation disagrees with hydration), filed as **#2728** and re-quarantined against it.
- `mutation-quarantine.ts`: G5 re-verified as unrelated to #2716 (reason corrected, kept); 3 rows added that merely re-observe the known #2722/#2723 classes now that the fixture-wide exclusions lifted.
- New regression pin `issue-2716-value-expando.test.ts` (verified red on the pre-fix runtime); `client-js-generation.test.ts` updated to the gated emission shape; snapshots regenerated via the canonical generator; changeset `@barefootjs/jsx` patch.

## Verification

`bun test packages/jsx packages/client packages/adapter-tests` 5924 pass / 0 fail; Playwright: fixture-hydrate 39 passed, oracle 120 passed / 1 skipped, mutation sweep (regenerated) 133 passed / 43 skipped. Independently re-verified on review: hydrate+oracle 159 passed / 1 skipped, adapter-tests unit 2146 pass / 0 fail. PR #2727's ledger corrections merged in cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198yG2px5ygfvmdoMkhRS13

---
_Generated by [Claude Code](https://claude.ai/code/session_0198yG2px5ygfvmdoMkhRS13)_