### PR TITLE
ci: add repo-managed review instructions for Pullfrog

### DIFF
--- a/.github/pullfrog/review.md
+++ b/.github/pullfrog/review.md
@@ -1,56 +1,42 @@
-# PR レビュー指示（Pullfrog 用）
+# PR review instructions
 
-このファイルは Pullfrog のレビュー実行が読む、リポジトリ管理のレビュー指示。
-コンソール側の Review instructions にはこのファイルへのポインタ1行だけを置く。
+Read `CLAUDE.md` (symlinked as `AGENTS.md`) before reviewing. It is the design contract for this
+codebase, not style guidance — use it as review criteria. When you flag a violation, name the
+section instead of restating it.
 
-## 前提
+## Design conformance (must-address)
 
-`CLAUDE.md`（`AGENTS.md` として symlink）はコーディングガイドではなく、この
-コードベースの設計契約である。レビュー前に読み、diff をその基準に照らして判定
-すること。指摘時に規約を再説明しないこと — 該当セクション名を挙げるにとどめる。
+Check the diff against the four **"Never …"** conventions in CLAUDE.md's Code Conventions section.
+A violation is must-address even when the code works. Name the violated convention and point to the
+sanctioned alternative it prescribes (IR metadata / AST walk, structured IR through a single
+renderer, the lowering-plugin registry, `BindingScope`).
 
-## 設計適合（must-address）
+## Coverage coupling (must-address)
 
-diff を CLAUDE.md「Code Conventions」の4つの **Never** 規約と突き合わせる。
-どれも実際の regression から生まれた規約であり、動くコードでも違反は
-must-address として扱う。指摘には、違反した規約名と、規約が指定する正規の
-代替（IR metadata / AST walk、structured IR + 単一レンダラ、lowering-plugin
-registry、`BindingScope`）を添える。
+A PR that widens what the compiler accepts must add at least one conformance fixture under
+`packages/adapter-tests/fixtures/` in the same PR (`spec/subset-conformance.md`, change-time
+coupling rule). Fixture *existence* for the registered extension halves is CI-gated; review owns
+what CI cannot check:
 
-## カバレッジ結合（must-address）
+1. **Fixture meaningfulness.** Does the fixture exercise the essential shape of the extension?
+   Should adversarial cases (empty values, markup, multibyte) be added as data points?
+2. **New extension categories.** If a PR introduces an extension kind no registry anticipates,
+   require the registry and its coverage floor to land in the same PR as the first member.
 
-コンパイラの受理範囲を広げる PR は、同じ PR に
-`packages/adapter-tests/fixtures/` の conformance fixture を最低1つ含む
-（`spec/subset-conformance.md` の change-time coupling rule）。既知の4半身
-（`ParsedExpr` kind、array-method、builtin lowering plugin、sort-comparator
-形式）はすべて exhaustiveness pin + coverage-ledger floor で機械化済み
-（#2742）なので、fixture の**有無**は CI が落とす。レビューの仕事は2つ:
+## Test placement
 
-1. **fixture が意味を持つか。** 床は存在しか検査しない。拡張の本質的な形を
-   突いているか、adversarial なケース（空値・マークアップ・マルチバイト等）
-   を data points に足す余地はないか。
-2. **どのレジストリも想定しない新種の拡張カテゴリ**が現れたら、最初の PR に
-   レジストリ＋床の同梱を must-address として要求する。前例: レビューのみの
-   時代に queryHref は fixture ゼロで出荷され、最初の床が #2741 を即座に
-   暴いた。
+Flag tests at the wrong layer per CLAUDE.md's testing table: an E2E test for static-only
+attribute/class/ARIA changes (an explicit anti-pattern), event→setter wiring asserted anywhere but
+a component IR test, template HTML asserted outside adapter conformance fixtures.
 
-## テストの置き場所
+## Priorities
 
-CLAUDE.md のテスト表に照らして、層違いのテストを指摘する。典型:
-static のみの attribute / class / ARIA 変更への E2E テスト追加（明示的な
-アンチパターン）、event→setter 配線を component IR テスト以外で検証、
-テンプレート HTML 出力を adapter conformance fixture 以外で検証。
+The cardinal failure mode of this compiler is **silent divergence** — output that differs from the
+contract without an error (SSR/CSR mismatch, an emitter that drops content instead of refusing
+loudly). A silent-divergence risk outranks any style concern. When you find a reproducible
+divergence, steer it toward the three-piece set (known-limitation issue + fixture asserting the
+correct output + pins on the broken side), not a prose report.
 
-## 優先度
+## Output
 
-このコンパイラの最重要の欠陥クラスは **silent divergence** — エラーなしに
-契約と異なる出力を出すこと（SSR/CSR 不一致、拒否せず黙って内容を落とす
-emitter）。所見の重み付けはこれに従う: silent divergence の恐れは、どんな
-スタイル上の懸念よりも優先する。再現可能な divergence を見つけたら、prose の
-報告ではなく「known-limitation issue + 正しい出力を主張する pinned fixture +
-壊れている側の pin」の三点セットで残す形を提案する（CLAUDE.md「A reproducible
-defect lands as a fixture」）。
-
-## 出力
-
-レビューは英語で書く。
+Write reviews in English.

--- a/.github/pullfrog/review.md
+++ b/.github/pullfrog/review.md
@@ -1,0 +1,49 @@
+# PR レビュー指示（Pullfrog 用）
+
+このファイルは Pullfrog のレビュー実行が読む、リポジトリ管理のレビュー指示。
+コンソール側の Review instructions にはこのファイルへのポインタ1行だけを置く。
+
+## 前提
+
+`CLAUDE.md`（`AGENTS.md` として symlink）はコーディングガイドではなく、この
+コードベースの設計契約である。レビュー前に読み、diff をその基準に照らして判定
+すること。指摘時に規約を再説明しないこと — 該当セクション名を挙げるにとどめる。
+
+## 設計適合（must-address）
+
+diff を CLAUDE.md「Code Conventions」の4つの **Never** 規約と突き合わせる。
+どれも実際の regression から生まれた規約であり、動くコードでも違反は
+must-address として扱う。指摘には、違反した規約名と、規約が指定する正規の
+代替（IR metadata / AST walk、structured IR + 単一レンダラ、lowering-plugin
+registry、`BindingScope`）を添える。
+
+## カバレッジ結合（must-address — レビューが唯一の防壁）
+
+コンパイラの受理範囲を広げる PR — 新しい `ParsedExpr` kind やフィールド、
+array-method カタログ追加、builtin lowering plugin、sort-comparator 形式 —
+は、同じ PR に `packages/adapter-tests/fixtures/` の conformance fixture を
+最低1つ含まなければならない（`spec/subset-conformance.md` の change-time
+coupling rule）。kind / catalogue の2系統は CI が落とすが、**builtin lowering
+plugin と sort-comparator 形式には機械的な防壁がなく、レビューが唯一の
+ゲートである。** fixture 欠落は must-address として指摘する。
+
+## テストの置き場所
+
+CLAUDE.md のテスト表に照らして、層違いのテストを指摘する。典型:
+static のみの attribute / class / ARIA 変更への E2E テスト追加（明示的な
+アンチパターン）、event→setter 配線を component IR テスト以外で検証、
+テンプレート HTML 出力を adapter conformance fixture 以外で検証。
+
+## 優先度
+
+このコンパイラの最重要の欠陥クラスは **silent divergence** — エラーなしに
+契約と異なる出力を出すこと（SSR/CSR 不一致、拒否せず黙って内容を落とす
+emitter）。所見の重み付けはこれに従う: silent divergence の恐れは、どんな
+スタイル上の懸念よりも優先する。再現可能な divergence を見つけたら、prose の
+報告ではなく「known-limitation issue + 正しい出力を主張する pinned fixture +
+壊れている側の pin」の三点セットで残す形を提案する（CLAUDE.md「A reproducible
+defect lands as a fixture」）。
+
+## 出力
+
+レビューは英語で書く。

--- a/.github/pullfrog/review.md
+++ b/.github/pullfrog/review.md
@@ -17,15 +17,22 @@ must-address として扱う。指摘には、違反した規約名と、規約�
 代替（IR metadata / AST walk、structured IR + 単一レンダラ、lowering-plugin
 registry、`BindingScope`）を添える。
 
-## カバレッジ結合（must-address — レビューが唯一の防壁）
+## カバレッジ結合（must-address）
 
-コンパイラの受理範囲を広げる PR — 新しい `ParsedExpr` kind やフィールド、
-array-method カタログ追加、builtin lowering plugin、sort-comparator 形式 —
-は、同じ PR に `packages/adapter-tests/fixtures/` の conformance fixture を
-最低1つ含まなければならない（`spec/subset-conformance.md` の change-time
-coupling rule）。kind / catalogue の2系統は CI が落とすが、**builtin lowering
-plugin と sort-comparator 形式には機械的な防壁がなく、レビューが唯一の
-ゲートである。** fixture 欠落は must-address として指摘する。
+コンパイラの受理範囲を広げる PR は、同じ PR に
+`packages/adapter-tests/fixtures/` の conformance fixture を最低1つ含む
+（`spec/subset-conformance.md` の change-time coupling rule）。既知の4半身
+（`ParsedExpr` kind、array-method、builtin lowering plugin、sort-comparator
+形式）はすべて exhaustiveness pin + coverage-ledger floor で機械化済み
+（#2742）なので、fixture の**有無**は CI が落とす。レビューの仕事は2つ:
+
+1. **fixture が意味を持つか。** 床は存在しか検査しない。拡張の本質的な形を
+   突いているか、adversarial なケース（空値・マークアップ・マルチバイト等）
+   を data points に足す余地はないか。
+2. **どのレジストリも想定しない新種の拡張カテゴリ**が現れたら、最初の PR に
+   レジストリ＋床の同梱を must-address として要求する。前例: レビューのみの
+   時代に queryHref は fixture ゼロで出荷され、最初の床が #2741 を即座に
+   暴いた。
 
 ## テストの置き場所
 

--- a/.github/pullfrog/review.md
+++ b/.github/pullfrog/review.md
@@ -27,7 +27,9 @@ what CI cannot check:
 
 Flag tests at the wrong layer per CLAUDE.md's testing table: an E2E test for static-only
 attribute/class/ARIA changes (an explicit anti-pattern), event→setter wiring asserted anywhere but
-a component IR test, template HTML asserted outside adapter conformance fixtures.
+a component IR test, template HTML asserted outside adapter conformance fixtures, client JS
+behavior asserted outside CSR conformance fixtures, and hydration-correctness fixes not verified
+with an E2E test.
 
 ## Priorities
 


### PR DESCRIPTION
Adds `.github/pullfrog/review.md` — the review prompt for Pullfrog, versioned in the repo.

## How it wires up

The Pullfrog console's **Review instructions** field should carry only this one line:

```
Read .github/pullfrog/review.md in the repository checkout and follow it.
```

The actual content then lives here, PR-reviewed and versioned like everything else, instead of sitting only in the console.

## Why it doesn't restate CLAUDE.md

Pullfrog's built-in system prompt already directs the agent to read `AGENTS.md` (symlinked to `CLAUDE.md`) on every run, so the design contract is loaded regardless. Duplicating its rules into the review prompt would only create drift. Instead the file:

- reframes `CLAUDE.md` as **review criteria**: the four "Never" conventions are must-address findings, cited by section rather than restated
- scopes the change-time coupling check to what CI cannot gate: fixture *meaningfulness*, and requiring registry + floor in the same PR when a genuinely new extension category appears (the registered halves are mechanically floored since [#2742](https://github.com/piconic-ai/barefootjs/pull/2742))
- flags test-layer misplacement per the testing table (e.g. E2E for static-only changes)
- sets the priority order: silent divergence outranks style, and reproducible divergences are steered toward the fixture three-piece set, not prose reports

The file is written in English, directives only, and instructs reviews to be written in English.

## Verification

- Markdown only; no workflow or source changes, so no CI surface and no changeset needed.
- The pointer line for the console is not yet set — do that when enabling the review trigger.