### PR TITLE
Relay the caller's row key on provider-rooted components (#2753 regression)

### DIFF
--- a/.changeset/relay-row-key-on-provider-roots.md
+++ b/.changeset/relay-row-key-on-provider-roots.md
@@ -1,0 +1,20 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/hono": patch
+"@barefootjs/rust": patch
+"@barefootjs/mojolicious": patch
+"@barefootjs/xslate": patch
+"@barefootjs/twig": patch
+"@barefootjs/erb": patch
+"@barefootjs/blade": patch
+"@barefootjs/go-template": patch
+"@barefootjs/jinja": patch
+---
+
+Restore the caller-key relay (`IRElement.keyAttr`, #2753's "mechanism 2") on components whose root is a `<Ctx.Provider>`.
+
+`resolveRootKeyAttr` looked for the component's render root by walking down from the IR root through `element` / `if-statement` / `fragment` and stopping at anything else. A provider is none of those, but `transformProviderElement` passes `ctx.isRoot` through to its children — so the element under the provider IS a render root, carries `needsScope`/`bf-s`, and the walk never reached it. Every adapter then emitted that root without the relay, and a caller rendering such a component as a keyed loop row got a row with no key attribute for `mapArray` to reconcile against.
+
+The relay is now resolved by testing `needsScope` throughout the tree rather than by an enumeration of the constructs `ctx.isRoot` passes through, which is the same predicate the reference adapter applied at emit time before the decision moved into the IR, and matches the client runtime's own CSR half (`renderChild` / `materializeComponent` splice `data-key` onto the rendered markup's first element whatever wrapper nodes sit above it).
+
+Affects every provider-rooted component, including `select`, `popover`, `accordion`, `carousel`, `combobox`, `command`, `dropdown-menu` and `radio-group`. The DSL adapters had never emitted the relay for this shape; Hono had, and regressed when the decision was centralized.

--- a/packages/adapter-tests/fixtures/__snapshots__/todo-app.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/todo-app.client.js
@@ -191,7 +191,7 @@ export function initTodoApp(__scope, _p = {}) {
   })
 
   insert(__scope, 's1', () => todos().length > 0, {
-    template: () => { const __slots = []; return { html: `<!--bf-cond-start:s1--><input id="toggle-all" class="toggle-all" type="checkbox" ${todos().every(t => t.done) ? 'checked' : ''} bf="s2" /><label for="toggle-all">Mark all as complete</label><!--bf-cond-end:s1-->`, slots: __slots } },
+    template: () => { const __slots = []; return { html: `<!--bf-cond-start:s1--><input id="toggle-all" class="toggle-all" type="checkbox" bf="s2" /><label for="toggle-all">Mark all as complete</label><!--bf-cond-end:s1-->`, slots: __slots } },
     bindEvents: (__branchScope, { isFirstRun: __bfFirstRun = false } = {}) => {
       const [_s2] = $(__branchScope, 's2')
       if (_s2) _s2.addEventListener('change', handleToggleAll)

--- a/packages/adapter-tests/src/__tests__/root-key-relay-cross-adapter.test.ts
+++ b/packages/adapter-tests/src/__tests__/root-key-relay-cross-adapter.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Render-root row-key relay, across both adapter families (#2753).
+ *
+ * `IRElement.keyAttr` with no `value` means "this element is one of THIS
+ * component's rendered roots; relay whatever key the caller supplies at
+ * runtime". Every SSR adapter must emit that relay on the SAME element it
+ * puts `bf-s` on — the client runtime reconciles keyed rows by reading the
+ * key attribute off the row's primary element, and it splices `data-key`
+ * onto the rendered markup's first element on the CSR side.
+ *
+ * The shape this guards is a component whose root is a `<Ctx.Provider>`
+ * (select, popover, accordion, carousel, combobox, command, dropdown-menu,
+ * radio-group all have it). The provider is not itself an element, so a
+ * resolver that walks down from the IR root and stops at the first
+ * non-element node never reaches the `bf-s` element underneath it and every
+ * adapter silently drops the relay. Asserting on the emitted TEMPLATE, not
+ * on rendered HTML, is deliberate: a standalone render passes no key, so the
+ * relay is invisible in `expectedHtml` and no HTML fixture can see this.
+ *
+ * Hono (the reference adapter) plus three DSL adapters — the two families
+ * that disagreed — is the coverage this needs; every remaining DSL adapter
+ * emits from the same `element.keyAttr` branch.
+ */
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '@barefootjs/jsx'
+import { HonoAdapter } from '@barefootjs/hono/adapter'
+import { GoTemplateAdapter } from '@barefootjs/go-template/adapter'
+import { MojoAdapter } from '@barefootjs/mojolicious/adapter'
+import { XslateAdapter } from '@barefootjs/xslate/adapter'
+import type { TemplateAdapter } from '@barefootjs/jsx'
+
+const PROVIDER_ROOT = `
+'use client'
+import { createContext, createSignal } from '@barefootjs/client'
+
+const SelectContext = createContext({ open: false })
+
+export function Select(props: { children?: unknown }) {
+  const [open, setOpen] = createSignal(false)
+  return (
+    <SelectContext.Provider value={{ open: open(), setOpen }}>
+      <div data-slot="select">{props.children}</div>
+    </SelectContext.Provider>
+  )
+}
+`
+
+const PLAIN_ROOT = `
+'use client'
+import { createSignal } from '@barefootjs/client'
+
+export function Select(props: { children?: unknown }) {
+  const [open, setOpen] = createSignal(false)
+  return <div data-slot="select" onClick={() => setOpen(!open())}>{props.children}</div>
+}
+`
+
+/**
+ * Per adapter: the relay token emitted for a valueless `keyAttr`, and the
+ * token that lowers `{props.children}`. Everything between `<div ` and the
+ * children token IS the opening tag — children are the first thing after
+ * `>` — so "relay before children" is exactly "relay inside the tag", without
+ * having to find the `>` through four different action syntaxes (`:>` and
+ * `%>` both contain one).
+ */
+interface AdapterCase {
+  name: string
+  make: () => TemplateAdapter
+  relay: string
+  children: string
+}
+
+const ADAPTERS: readonly AdapterCase[] = [
+  {
+    name: 'hono',
+    make: () => new HonoAdapter(),
+    relay: '"data-key": __dataKey',
+    children: '{props.children}',
+  },
+  {
+    name: 'go-template',
+    make: () => new GoTemplateAdapter(),
+    relay: '{{if .BfDataKey}} data-key="{{.BfDataKey}}"{{end}}',
+    children: '{{.Children}}',
+  },
+  {
+    name: 'mojolicious',
+    make: () => new MojoAdapter(),
+    relay: 'bf->data_key_attr',
+    children: '$children',
+  },
+  {
+    name: 'xslate',
+    make: () => new XslateAdapter(),
+    relay: '$bf.data_key_attr()',
+    children: '$children',
+  },
+]
+
+function markedTemplate(source: string, adapter: TemplateAdapter): string {
+  const result = compileJSX(source, 'Select.tsx', { adapter })
+  expect(result.errors.filter(e => e.severity === 'error')).toEqual([])
+  const file = result.files.find(f => f.type === 'markedTemplate')
+  expect(file).toBeDefined()
+  return file!.content
+}
+
+describe('render-root row-key relay is emitted by every adapter family (#2753)', () => {
+  for (const adapter of ADAPTERS) {
+    describe(adapter.name, () => {
+      test.each([
+        ['provider root', PROVIDER_ROOT],
+        ['plain element root', PLAIN_ROOT],
+      ])('%s: the bf-s element also carries the caller-key relay', (_label, source) => {
+        const template = markedTemplate(source, adapter.make())
+        const divAt = template.indexOf('<div ')
+        const childrenAt = template.indexOf(adapter.children, divAt)
+        const scopeAt = template.indexOf('bf-s', divAt)
+        const relayAt = template.indexOf(adapter.relay, divAt)
+        expect({ divAt: divAt >= 0, childrenAt: childrenAt >= 0 }).toEqual({ divAt: true, childrenAt: true })
+        // Both markers inside the same opening tag.
+        expect(scopeAt).toBeGreaterThan(divAt)
+        expect(scopeAt).toBeLessThan(childrenAt)
+        expect(relayAt).toBeGreaterThan(divAt)
+        expect(relayAt).toBeLessThan(childrenAt)
+      })
+    })
+  }
+})

--- a/packages/jsx/src/__tests__/root-key-relay.test.ts
+++ b/packages/jsx/src/__tests__/root-key-relay.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Render-root row-key relay (`IRElement.keyAttr` with no `value`) — #2753's
+ * "mechanism 2".
+ *
+ * A component's rendered root is whatever element carries `bf-s`
+ * (`needsScope`). When that component is used as a caller's keyed loop row,
+ * the caller's key has to land on THAT element: `mapArray` reconciles rows
+ * by reading the key attribute off the row's primary element, and the CSR
+ * half of the contract (`renderChild` / `materializeComponent` in
+ * `@barefootjs/client`) splices `data-key` onto the rendered markup's first
+ * element regardless of what wrapper nodes sit above it. `resolveRootKeyAttr`
+ * is the SSR half, and it must agree.
+ *
+ * The regression these tests exist for: resolving the relay by walking DOWN
+ * from the IR root and stopping at the first node that is not an
+ * element/fragment/if-statement. `<Ctx.Provider>` is neither, but
+ * `transformProviderElement` passes `ctx.isRoot` through to its children — so
+ * a provider-rooted component (select, popover, accordion, carousel,
+ * combobox, command, dropdown-menu, radio-group) has a `needsScope` element
+ * the walk never reaches, and every adapter silently stopped relaying its
+ * caller's key.
+ */
+import { describe, test, expect } from 'bun:test'
+import { analyzeComponent } from '../analyzer'
+import { jsxToIR } from '../jsx-to-ir'
+import type { IRElement, IRNode } from '../types'
+
+function compile(source: string, name = 'Test'): IRNode {
+  const ir = jsxToIR(analyzeComponent(source, `${name}.tsx`))
+  expect(ir).not.toBeNull()
+  return ir!
+}
+
+/** Every `element` node in the tree, in document order. */
+function allElements(node: IRNode): IRElement[] {
+  const out: IRElement[] = []
+  const visit = (n: IRNode | null | undefined): void => {
+    if (!n) return
+    if (n.type === 'element') out.push(n)
+    switch (n.type) {
+      case 'element':
+      case 'fragment':
+      case 'component':
+      case 'provider':
+      case 'loop':
+        for (const c of n.children) visit(c)
+        return
+      case 'async':
+        visit(n.fallback)
+        for (const c of n.children) visit(c)
+        return
+      case 'conditional':
+        visit(n.whenTrue)
+        visit(n.whenFalse)
+        return
+      case 'if-statement':
+        visit(n.consequent)
+        visit(n.alternate)
+        return
+    }
+  }
+  visit(node)
+  return out
+}
+
+const PROVIDER_ROOT = `
+'use client'
+import { createContext, createSignal } from '@barefootjs/client'
+
+const SelectContext = createContext({ open: false })
+
+export function Select(props: { children?: unknown }) {
+  const [open, setOpen] = createSignal(false)
+  return (
+    <SelectContext.Provider value={{ open: open(), setOpen }}>
+      <div data-slot="select">{props.children}</div>
+    </SelectContext.Provider>
+  )
+}
+`
+
+describe('render-root row-key relay (#2753)', () => {
+  test('a provider-rooted component relays the key on the element under the provider', () => {
+    const ir = compile(PROVIDER_ROOT, 'Select')
+
+    expect(ir.type).toBe('provider')
+    const div = allElements(ir).find(e => e.tag === 'div')
+    expect(div).toBeDefined()
+    // The element under the provider IS the rendered root: `ctx.isRoot`
+    // survives `transformProviderElement`.
+    expect(div!.needsScope).toBe(true)
+    // Relay marker: a name and no value — the value arrives at runtime from
+    // whoever renders this component as a keyed row.
+    expect(div!.keyAttr).toEqual({ name: 'data-key' })
+  })
+
+  test.each([
+    ['plain element root', `
+      export function C() { return <div class="root"><span>x</span></div> }
+    `],
+    ['early-return (if-statement) root — every branch top element', `
+      export function C(props: { on?: boolean }) {
+        if (props.on) return <section>on</section>
+        return <article>off</article>
+      }
+    `],
+    ['provider root', PROVIDER_ROOT],
+    ['provider wrapping an early-return root', `
+      'use client'
+      import { createContext } from '@barefootjs/client'
+      const Ctx = createContext(0)
+      export function C(props: { on?: boolean }) {
+        if (props.on) return <Ctx.Provider value={1}><section>on</section></Ctx.Provider>
+        return <Ctx.Provider value={0}><article>off</article></Ctx.Provider>
+      }
+    `],
+    ['nested providers around the root element', `
+      'use client'
+      import { createContext } from '@barefootjs/client'
+      const A = createContext(0)
+      const B = createContext(0)
+      export function C() {
+        return <A.Provider value={1}><B.Provider value={2}><div>x</div></B.Provider></A.Provider>
+      }
+    `],
+  ])('invariant: %s — every needsScope element carries a relay keyAttr', (_label, source) => {
+    const roots = allElements(compile(source)).filter(e => e.needsScope)
+    expect(roots.length).toBeGreaterThan(0)
+    for (const el of roots) {
+      expect({ tag: el.tag, keyAttr: el.keyAttr }).toEqual({
+        tag: el.tag,
+        keyAttr: { name: 'data-key' },
+      })
+    }
+  })
+
+  test('an inline .map() row root keeps its own resolved key expression', () => {
+    const ir = compile(`
+      export function List(props: { items: { id: number; name: string }[] }) {
+        return <ul>{props.items.map(i => <li key={i.id}>{i.name}</li>)}</ul>
+      }
+    `, 'List')
+
+    const li = allElements(ir).find(e => e.tag === 'li')
+    expect(li).toBeDefined()
+    // Mechanism 1 (a concretely-known local expression) wins over the relay
+    // marker; the relay pass must not overwrite it with a bare name.
+    expect(li!.needsScope).toBe(false)
+    expect(li!.keyAttr).toEqual({ name: 'data-key', value: 'i.id' })
+
+    const ul = allElements(ir).find(e => e.tag === 'ul')!
+    expect(ul.needsScope).toBe(true)
+    expect(ul.keyAttr).toEqual({ name: 'data-key' })
+  })
+
+  test('a scope-comment fragment root marks exactly one carrier, not every child', () => {
+    const ir = compile(`
+      export function C() {
+        return <><h1>title</h1><p>body</p></>
+      }
+    `)
+
+    expect(ir.type).toBe('fragment')
+    const els = allElements(ir)
+    // #2732: hydration markers moved to the wrapping comment, so no child is
+    // a `needsScope` element and the relay pass adds nothing of its own.
+    expect(els.every(e => !e.needsScope)).toBe(true)
+    expect(els.filter(e => e.keyAttr !== undefined).map(e => e.tag)).toEqual(['h1'])
+  })
+})

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -989,18 +989,29 @@ function attachParsedExpressions(node: IRNode, analyzer: AnalyzerContext, bound:
  * render root(s) relay a key value an external caller supplies at runtime
  * (a `data-key` prop / Rust `bf.data_key` field / client `createComponent`
  * key argument) when THIS component is itself invoked as a caller's keyed
- * loop row. Ported, once, from the byte-identical `collectRootScopeNodes`
- * previously duplicated in each of the 9 SSR adapters' own
- * `lib/ir-scope.ts` (mojolicious, xslate, twig, erb, blade, go-template,
- * jinja, minijinja) plus Hono's inline equivalent — each adapter then
- * intersected it with `element.needsScope` at EMIT time, on every compile.
- * Resolving it here means every adapter instead reads one IR field.
+ * loop row. Ported, once, from the `element.needsScope` test each of the 10
+ * SSR adapters previously applied at EMIT time, on every compile. Resolving
+ * it here means every adapter instead reads one IR field.
  *
- * A plain element root is itself; an if-statement (early-return) root
- * contributes the top element of each branch, since exactly one renders at
- * runtime (#1297) — mirrors the ported algorithm exactly, including
- * recursing into a fragment's children (a transparent fragment's real
- * content can still be "the root" in this sense).
+ * The relay belongs on exactly the elements carrying `needsScope` — the
+ * elements that also carry `bf-s`, i.e. this component's rendered root(s).
+ * That is the same predicate, evaluated at the same set of elements, as the
+ * reference (Hono) adapter applied before #2762, and it matches what the
+ * client runtime does for the CSR half of the contract: `renderChild` /
+ * `materializeComponent` splice `data-key` onto the rendered markup's FIRST
+ * element (component.ts), whatever wrapper nodes stand above it. A walk
+ * that stops at the first non-element node instead of testing `needsScope`
+ * throughout answers differently for every component whose root is a
+ * `<Ctx.Provider>` — `transformProviderElement` passes `ctx.isRoot` through
+ * to its children, so the provider's inner element is a rendered root and
+ * gets `needsScope`, but the walk never reaches it (#2753 regression).
+ *
+ * `needsScope` is `ctx.isRoot` at element-transform time, and `ctx.isRoot`
+ * is consumed by the first element/component/scope-comment fragment on the
+ * way down, so nothing inside a loop body or a child component's slot
+ * children can be true here. Visiting the whole tree therefore costs
+ * nothing in reach but cannot go stale the way an enumeration of
+ * "`isRoot`-transparent constructs" can.
  *
  * A `needsScopeComment` fragment root (#2732) is handled separately, at
  * `transformFragment` build time (`markDataKeyCarrier`): `ctx.isRoot` can be
@@ -1009,24 +1020,38 @@ function attachParsedExpressions(node: IRNode, analyzer: AnalyzerContext, bound:
  * need a second, tree-wide pass to find it again. Its children carry
  * `needsScope: false` by construction, so this walk's `n.needsScope` guard
  * naturally skips them without double-marking.
+ *
+ * The `!keyAttr` guard keeps mechanism 1 (`applyLoopKeyAttr`, an inline
+ * `.map()` row root's own concretely-known key expression, resolved during
+ * the transform) — strictly more useful than a relay marker — from being
+ * overwritten.
  */
-function resolveRootKeyAttr(root: IRNode): void {
-  const visit = (n: IRNode | null): void => {
-    if (!n) return
-    if (n.type === 'element') {
-      if (n.needsScope && !n.keyAttr) n.keyAttr = { name: BF_KEY }
+function resolveRootKeyAttr(node: IRNode | null): void {
+  if (!node) return
+  switch (node.type) {
+    case 'element':
+      if (node.needsScope && !node.keyAttr) node.keyAttr = { name: BF_KEY }
+      for (const c of node.children) resolveRootKeyAttr(c)
       return
-    }
-    if (n.type === 'if-statement') {
-      visit(n.consequent)
-      visit(n.alternate)
+    case 'fragment':
+    case 'component':
+    case 'provider':
+    case 'loop':
+      for (const c of node.children) resolveRootKeyAttr(c)
       return
-    }
-    if (n.type === 'fragment') {
-      for (const c of n.children) visit(c)
-    }
+    case 'async':
+      resolveRootKeyAttr(node.fallback)
+      for (const c of node.children) resolveRootKeyAttr(c)
+      return
+    case 'conditional':
+      resolveRootKeyAttr(node.whenTrue)
+      resolveRootKeyAttr(node.whenFalse)
+      return
+    case 'if-statement':
+      resolveRootKeyAttr(node.consequent)
+      resolveRootKeyAttr(node.alternate)
+      return
   }
-  visit(root)
 }
 
 export function jsxToIR(analyzer: AnalyzerContext): IRNode | null {


### PR DESCRIPTION
**Fixes a regression on `main`.** `update-expected-html` is currently red there; this restores it.

## What broke

Eight production components whose root is a Context Provider — select, popover, accordion, carousel, combobox, command, dropdown-menu, radio-group — stopped relaying the caller-supplied row key from the element that carries their scope:

```diff
-  const { …, "data-key": __dataKey, …props } = __allProps
+  const { …, "data-key": _dataKey, …props } = __allProps
-    <div data-slot="select" … bf-s={__scopeId} … {...(__dataKey !== undefined ? { "data-key": __dataKey } : {})}>
+    <div data-slot="select" … bf-s={__scopeId} …>
```

That is #2753's own shape — a keyed loop row whose root carries no key — reintroduced by the PR that set out to close it.

### Bisect

`generate-expected-html.ts` run at each commit, counting drifting files:

| commit | drift |
|---|---|
| `724411118` — before the three merges | 0 |
| `2ced28129` — #2761 merged | 0 |
| `935d6eadb` — **#2762 branch head, pre-merge** | **8** |
| `4ad1c0bbb` — #2762 merged | 8 |
| `50b2fa90a` — current `main` | 9 |

#2762 was already drifting on its own branch head. Its `update-expected-html` was not checked by name before merge.

## Root cause

#2762 collapsed sixteen duplicated row-key decisions onto one IR field, `IRElement.keyAttr` — correct in intent. But the two adapter families **already disagreed** on this shape, and the collapse took the answer from the wrong one:

| | pre-#2762 gate |
|---|---|
| Hono (reference) | `if (element.needsScope)` — relay emitted unconditionally |
| the 9 DSL adapters | `(rootScopeNodes.has(element) && element.needsScope) \|\| carriesDataKey` |

`collectRootScopeNodes` never descended into a wrapper node, so on a provider-rooted component Hono emitted the relay and the DSL adapters did not. `resolveRootKeyAttr` inherited that walk and therefore the DSL answer, changing the **reference** adapter's output.

The specific node is `provider`, not `component`: `transformProviderElement` is the only root transform that does not clear `ctx.isRoot`, so the element under a provider is a genuine render root with `needsScope: true` — and the walk stopped one node above it.

## Which family is correct — Hono, on three independent grounds

1. Hono is the reference adapter; every fixture's `expectedHtml` is generated from it.
2. Semantically the element carrying `bf-s` **is** the component's rendered root. If a caller uses the component as a keyed loop row, that element must carry the key or `mapArray` cannot reconcile it.
3. **The client runtime already behaves this way.** `renderChild` / `materializeComponent` splice `data-key` onto the rendered markup's *first element* via `spliceAttrsAfterFirstTag`, whatever wrapper nodes stand above it. So CSR always stamps the inner element; SSR omitting it there is a hydration divergence, not a stylistic difference.

The third is the strongest: it is not a judgement about which adapter to prefer, it is an existing half of the contract that already picked a side.

## The fix

`resolveRootKeyAttr` no longer enumerates the constructs `isRoot` passes through. It tests `needsScope` over the whole tree — byte-for-byte the predicate the reference adapter evaluated at every `renderElement` before #2762, so equivalence is provable rather than argued. `needsScope` cannot be true inside a loop body or a child's slot children (the first element / scope-comment fragment consumes `isRoot`), so the wider walk costs no reach.

`markDataKeyCarrier` (#2732) is unaffected — a `needsScopeComment` fragment's children are `needsScope: false` by construction, so the guard skips them with no double-marking. `applyLoopKeyAttr` (mechanism 1) is protected by the pre-existing `!keyAttr` guard and runs during the transform, before this post-pass. Both are pinned.

**The eight snapshots are restored by the fix alone** — no regeneration. `generate-expected-html.ts` leaves `git diff` empty.

## Tests

Two new files, because the defect is invisible to the fixture layer: a standalone render passes no key, so the relay never appears in `expectedHtml`. That is exactly why only `update-expected-html` caught it. Both assert on the emitted *template*, checking the relay lands inside the same opening tag as `bf-s`.

- `packages/jsx/src/__tests__/root-key-relay.test.ts` — compiler layer.
- `packages/adapter-tests/src/__tests__/root-key-relay-cross-adapter.test.ts` — **pins Hono and three DSL adapters to the same answer for the same shape**, which is the class of drift that made this invisible for as long as both families have existed.

### Perturbation

Reverting only `resolveRootKeyAttr` to the pre-fix walk, tests untouched:

| file | result |
|---|---|
| `root-key-relay.test.ts` | 4 pass / **4 fail** — the provider-root rows; non-provider rows stay green |
| `root-key-relay-cross-adapter.test.ts` | 4 pass / **4 fail** — all four provider-root rows across hono / go-template / mojolicious / xslate; plain-element-root rows stay green |

## Second commit: the `todo-app` snapshot #2764 left stale

Separate cause, same job caught it. #2764 made the conditional-branch builder honour `clientOnly`, which correctly stopped it baking `checked` onto `#toggle-all` — but the snapshot was not regenerated.

Regenerating is right rather than reverting the emission, on measurement:

- SSR has never emitted it. `todo-app.html` has zero matches for `toggle-all…checked` at `724411118`, `4ad1c0bbb` and `50b2fa90a` alike.
- The branch registers an unconditional effect that sets it on both the hydrate and rebuild paths: `__ra_s2.checked = !!(todos().every(t => t.done))`.

So the baked attribute was surplus that only a reconciler-rebuilt branch carried while a hydration-reused one did not — the divergence #2764 set out to close. Dropping it makes the three legs agree.

## Verification

| suite | result |
|---|---|
| `bun test packages/jsx/src` | 3205 ran / **0 fail** (+8 new) |
| `bun test packages/client/__tests__` | 664 pass / **0 fail** |
| `bun test packages/adapter-tests/src` | 2216 ran / **0 fail** (4 skip, +8 new) |
| `bun test packages/compat` | 508 pass / **0 fail** |
| `pairwise:generate` | 97 cases, ok=62 refused=35 broken=0 |
| pairwise Playwright sweep | 187 passed / 0 failed |
| `generate-expected-html` | **`git diff` empty** |

All nine adapter conformance suites pass, run sequentially: blade 1533 / erb 1504 / go-template 1826 / hono 1606 / jinja 1533 / mojolicious 1702 / rust 1531 / twig 1541 / xslate 1533, zero failures. No conformance test disagreed with the new output, so there was no "DSL `expectedHtml` diverged from Hono" case to adjudicate.

## What this says about the guard

`keyAttr` had **no compiler-layer test coverage**. #2762 introduced the field, deleted ten adapters' worth of emit-time logic onto it, and shipped with nothing asserting what it resolves to — which is why every unit suite was green on a broken branch and only a snapshot job noticed.

Worth a follow-up sweep: other places where a DSL `lib/ir-scope.ts` copy diverged from Hono's inline equivalent before #2762 deleted them. That class of drift had no test that could see it either, and the cross-adapter test added here covers only this one shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198yG2px5ygfvmdoMkhRS13

---
_Generated by [Claude Code](https://claude.ai/code/session_0198yG2px5ygfvmdoMkhRS13)_