### PR TITLE
Ungate generated-artifact drift jobs from branches: [main]

### DIFF
--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -3,6 +3,17 @@ name: Changeset check
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
+    # Kept gated, unlike the three drift jobs (#2780): those diff the
+    # head tree against itself, so a stacked base is not an input to
+    # the question they ask. This check is different — it diffs
+    # `base.sha...head.sha` for both published source and added
+    # changesets. On a stack where the base PR carries the changeset
+    # and the upper PR carries the source change, `BASE_SHA` already
+    # contains that changeset, so the added-changeset diff comes back
+    # empty while the source diff doesn't — a false failure on a stack
+    # that is collectively fine. Making this stack-correct means
+    # deciding what "a stacked PR inherits its base's changeset"
+    # should mean, which is a separate design question. See #2780.
     branches: [main]
 
 permissions:

--- a/.github/workflows/update-doc-snapshots.yml
+++ b/.github/workflows/update-doc-snapshots.yml
@@ -15,10 +15,13 @@ name: Update Doc Snapshots
 # inspect the bot's diff in the same way they inspect `update-fixtures`
 # bot commits — an unintended snap drift is a compiler regression
 # disguised as a passing test, not a "fix forward" signal.
+#
+# No `branches` filter: a stacked PR's head can drift from the
+# doc-examples snapshot the same as a main-based one, and this is the
+# only check that would catch it. See #2780.
 
 on:
   pull_request:
-    branches: [main]
     paths:
       - 'docs/core/**'
       - 'packages/jsx/**'

--- a/.github/workflows/update-fixtures.yml
+++ b/.github/workflows/update-fixtures.yml
@@ -1,8 +1,10 @@
 name: Update Fixtures
 
+# No `branches` filter: a stacked PR's head can carry the same
+# undetected fixture drift as a main-based one, and this is the only
+# check that would catch it. See #2780.
 on:
   pull_request:
-    branches: [main]
     paths:
       - 'packages/jsx/**'
       - 'packages/adapter-hono/**'

--- a/.github/workflows/update-fixtures.yml
+++ b/.github/workflows/update-fixtures.yml
@@ -11,6 +11,7 @@ on:
       - 'packages/client/**'
       - 'packages/adapter-tests/src/**'
       - 'packages/adapter-tests/scripts/**'
+      - '.github/workflows/update-fixtures.yml'
       # Shared-component fixture sources (fixture-hydrate corpus inputs).
       # Editing a `*.tsx` here regenerates the `__snapshots__/<id>.{html,client.js}` pair.
       - 'integrations/shared/components/**'

--- a/.github/workflows/update-meta.yml
+++ b/.github/workflows/update-meta.yml
@@ -8,10 +8,13 @@ name: Update Meta
 # regenerations. Issue #1435 was the visible symptom — `bf add
 # checkbox` lost its `icon` dependency because `ui/meta/checkbox.json`
 # still said `dependencies.internal: []`.
+#
+# No `branches` filter: a stacked PR's head can drift from
+# `ui/components/ui/` the same as a main-based one, and this is the
+# only check that would catch it. See #2780.
 
 on:
   pull_request:
-    branches: [main]
     paths:
       - 'packages/cli/**'
       - 'packages/jsx/**'


### PR DESCRIPTION
Fixes #2780.

## What changed

Three of the four workflows gated to `pull_request: branches: [main]` are the generated-artifact drift family: `update-fixtures.yml`, `update-meta.yml`, `update-doc-snapshots.yml`. Each of them checks out the PR head, regenerates the artifact, and diffs it against what's committed — a property of the head tree alone. The base branch is not an input to that question, so gating them to a `main` base only meant the check silently never ran on a stacked PR. That is the mechanism by which #2762's fixture-drift regression reached `main` undetected (see the issue for the measurement: `update-fixtures.yml` had `total_count: 0` across five pushes to that branch, while the ungated `ci.yml` ran every time).

This PR drops the `branches: [main]` line from those three workflows' `on: pull_request:` blocks, and adds a short comment to each recording why the filter isn't there.

`changeset-check.yml` is intentionally left alone. Unlike the three drift jobs, its check *is* base-relative — it diffs `base.sha...head.sha` for both published source and added changesets. On a stack where the base PR carries the changeset and the upper PR carries the source change, the added-changeset diff comes back empty while the source diff doesn't, which would be a false failure. Making that stack-correct is a separate design question (per the issue's design-note comment), so this PR only adds a comment above its `branches: [main]` line recording that the gate is deliberate and pointing back at #2780.

**Also:** `update-fixtures.yml` didn't list its own workflow file in `paths`, unlike its two siblings (`update-meta.yml`, `update-doc-snapshots.yml`, which do list themselves). That meant it was the one drift workflow not exercised by a PR that edits it — including this PR itself, before the fix. That's part of why the separate stacked demo PR below was necessary to prove the `branches: [main]` removal actually took effect, rather than this PR's own checks showing it directly. Added `.github/workflows/update-fixtures.yml` to its own `paths` list to close that gap too.

## Verification

A YAML diff alone doesn't prove a previously-non-existent job now runs. This is verified with a real stacked-PR demonstration: a second draft PR (branch `claude/barefootjs-drift-gate-demo`, #2782) is stacked on top of this branch, deliberately corrupting one fixture's `expectedHtml`. The measurement — whether `update-fixtures.yml`'s `update-expected-html` job exists and fails on that stacked PR — is posted as a comment on this PR.