### PR TITLE
Prepare Workers Cache middleware for barefootjs.dev and ui.barefootjs.dev (deferred)

### DIFF
--- a/site/core/app.tsx
+++ b/site/core/app.tsx
@@ -26,9 +26,10 @@ import type { Page, ContentMap, MdxContentMap } from './lib/content'
 export async function createApp(content: ContentMap, pages: Page[], mdx: MdxContentMap = {}): Promise<Hono> {
   const app = new Hono()
 
-  // Sets Cache-Control on every route below that doesn't set its own, so
-  // Workers Cache (wrangler.toml's `[cache] enabled = true`) can serve
-  // repeat requests without re-running this Worker.
+  // Sets Cache-Control on every route below that doesn't set its own. Inert
+  // today — wrangler.toml deliberately leaves `[cache]` off (see the
+  // comment there) — but mounted first so enabling it later is a one-line
+  // wrangler.toml change with the middleware already wired and tested.
   app.use('*', cacheControl)
 
   // Landing page (GET /)

--- a/site/core/app.tsx
+++ b/site/core/app.tsx
@@ -13,6 +13,7 @@ import { createLandingApp } from './landing/routes'
 import { createPlaygroundApp } from './playground/routes'
 import { createIntegrationsApp } from './integrations/routes'
 import { createOgRoute } from './og-route'
+import { cacheControl } from '@barefootjs/site-shared/lib/cache-control'
 import type { Page, ContentMap, MdxContentMap } from './lib/content'
 
 /**
@@ -24,6 +25,11 @@ import type { Page, ContentMap, MdxContentMap } from './lib/content'
  */
 export async function createApp(content: ContentMap, pages: Page[], mdx: MdxContentMap = {}): Promise<Hono> {
   const app = new Hono()
+
+  // Sets Cache-Control on every route below that doesn't set its own, so
+  // Workers Cache (wrangler.toml's `[cache] enabled = true`) can serve
+  // repeat requests without re-running this Worker.
+  app.use('*', cacheControl)
 
   // Landing page (GET /)
   const landingApp = await createLandingApp()

--- a/site/core/wrangler.toml
+++ b/site/core/wrangler.toml
@@ -13,7 +13,7 @@ directory = "./dist"
 # per-entrypoint caching can scope around, because `[assets]` static-file
 # serving isn't a WorkerEntrypoint. For an asset-heavy docs/gallery site like
 # this one, that's a real net cost INCREASE, the opposite of why this file
-# was touched (piconic-ai/barefootjs#2784). The `cacheControl` middleware
+# was touched (piconic-ai/barefootjs#2789). The `cacheControl` middleware
 # (site/shared/lib/cache-control.ts) is still mounted and sets Cache-Control
 # on HTML responses, so flipping this on later is a one-line change once the
 # asset-vs-HTML request volume against a live account justifies it.

--- a/site/core/wrangler.toml
+++ b/site/core/wrangler.toml
@@ -4,3 +4,16 @@ compatibility_date = "2024-01-01"
 
 [assets]
 directory = "./dist"
+
+# Workers Cache ([cache] enabled = true) is intentionally NOT turned on here yet.
+# Verified against developers.cloudflare.com/workers/cache/#pricing: "When
+# caching is enabled, every request to your Worker is charged at the standard
+# Workers request rate, including requests that are normally free: static
+# asset requests..." — this is unconditional, not something `exports`-based
+# per-entrypoint caching can scope around, because `[assets]` static-file
+# serving isn't a WorkerEntrypoint. For an asset-heavy docs/gallery site like
+# this one, that's a real net cost INCREASE, the opposite of why this file
+# was touched (piconic-ai/barefootjs#2784). The `cacheControl` middleware
+# (site/shared/lib/cache-control.ts) is still mounted and sets Cache-Control
+# on HTML responses, so flipping this on later is a one-line change once the
+# asset-vs-HTML request volume against a live account justifies it.

--- a/site/shared/lib/__tests__/cache-control.test.ts
+++ b/site/shared/lib/__tests__/cache-control.test.ts
@@ -1,0 +1,47 @@
+import { describe, test, expect } from 'bun:test'
+import { Hono } from 'hono'
+import { cacheControl } from '../cache-control'
+
+function buildApp() {
+  const app = new Hono()
+  app.use('*', cacheControl)
+  app.get('/docs/quick-start', (c) => c.body('<html></html>', 200, { 'Content-Type': 'text/html' }))
+  app.get('/og', (c) => c.body('png', 200, { 'Cache-Control': 'public, max-age=86400, immutable' }))
+  app.get('/missing', (c) => c.body('not found', 404))
+  app.post('/api/echo', (c) => c.body('ok'))
+  app.get('/login', (c) => c.body('<html></html>', 200, { 'Set-Cookie': 'session=abc; HttpOnly' }))
+  app.get('/account', (c) => c.body('<html></html>'))
+  return app
+}
+
+describe('cacheControl middleware', () => {
+  test('sets a default Cache-Control on a GET route with none', async () => {
+    const res = await buildApp().request('/docs/quick-start')
+    expect(res.headers.get('Cache-Control')).toBe('public, max-age=300, stale-while-revalidate=3600')
+  })
+
+  test('leaves a route that already set its own Cache-Control alone', async () => {
+    const res = await buildApp().request('/og')
+    expect(res.headers.get('Cache-Control')).toBe('public, max-age=86400, immutable')
+  })
+
+  test('does not cache error responses', async () => {
+    const res = await buildApp().request('/missing')
+    expect(res.headers.has('Cache-Control')).toBe(false)
+  })
+
+  test('does not cache non-GET/HEAD responses', async () => {
+    const res = await buildApp().request('/api/echo', { method: 'POST' })
+    expect(res.headers.has('Cache-Control')).toBe(false)
+  })
+
+  test('does not cache a response that sets a session cookie', async () => {
+    const res = await buildApp().request('/login')
+    expect(res.headers.has('Cache-Control')).toBe(false)
+  })
+
+  test('does not cache a request that already carries a session cookie', async () => {
+    const res = await buildApp().request('/account', { headers: { Cookie: 'session=abc' } })
+    expect(res.headers.has('Cache-Control')).toBe(false)
+  })
+})

--- a/site/shared/lib/__tests__/cache-control.test.ts
+++ b/site/shared/lib/__tests__/cache-control.test.ts
@@ -25,9 +25,9 @@ describe('cacheControl middleware', () => {
     expect(res.headers.get('Cache-Control')).toBe('public, max-age=86400, immutable')
   })
 
-  test('does not cache error responses', async () => {
+  test('explicitly opts error responses out of caching', async () => {
     const res = await buildApp().request('/missing')
-    expect(res.headers.has('Cache-Control')).toBe(false)
+    expect(res.headers.get('Cache-Control')).toBe('private, no-store')
   })
 
   test('does not cache non-GET/HEAD responses', async () => {
@@ -35,13 +35,18 @@ describe('cacheControl middleware', () => {
     expect(res.headers.has('Cache-Control')).toBe(false)
   })
 
-  test('does not cache a response that sets a session cookie', async () => {
+  test('explicitly opts out a response that sets a session cookie', async () => {
     const res = await buildApp().request('/login')
-    expect(res.headers.has('Cache-Control')).toBe(false)
+    expect(res.headers.get('Cache-Control')).toBe('private, no-store')
   })
 
-  test('does not cache a request that already carries a session cookie', async () => {
+  test('explicitly opts out a request that already carries a session cookie (regression pin for barefootjs#2784/#2790)', async () => {
+    // Same shape that leaked in production for the integrations' copy of
+    // this helper: a repeat visit sends Cookie but the response has no
+    // fresh Set-Cookie and no Cache-Control, so Cloudflare's
+    // heuristic-freshness default would cache it. Must come back explicitly
+    // no-store, never merely headerless.
     const res = await buildApp().request('/account', { headers: { Cookie: 'session=abc' } })
-    expect(res.headers.has('Cache-Control')).toBe(false)
+    expect(res.headers.get('Cache-Control')).toBe('private, no-store')
   })
 })

--- a/site/shared/lib/cache-control.ts
+++ b/site/shared/lib/cache-control.ts
@@ -13,30 +13,39 @@
  * IMPORTANT: an *absent* `Cache-Control` header does NOT opt a response out
  * of Workers Cache. Cloudflare applies RFC 9111 heuristic freshness to any
  * response with no explicit directive (e.g. a 200 OK gets a 2h TTL by
- * default), so every branch below that must not be cached sets an explicit
- * `private, no-store` rather than merely leaving the header unset. The
- * integrations' copy of this helper shipped the "just leave it unset"
- * version once already (piconic-ai/barefootjs#2784) and it cached
- * session-specific responses across visitors — do not regress to that shape
- * here even though neither site sets a cookie today.
+ * default). The integrations' copy of this helper shipped a version that
+ * relied on an absent header to mean "don't cache" once already
+ * (piconic-ai/barefootjs#2784) and it cached session-specific responses
+ * across visitors.
+ *
+ * That bug was a symptom of a bigger structural risk: the old shape was a
+ * DENYLIST — cache by default, with a short list of conditions (Cookie,
+ * Set-Cookie, non-2xx) that opted a response OUT. Any response shape
+ * nobody had thought of yet inherited the default of "cached". This is
+ * instead an ALLOWLIST: the default below is unconditionally `no-store`,
+ * and the one non-2xx-cookie-free case must explicitly earn a longer TTL.
+ * A new response shape nobody has reasoned about yet inherits "not
+ * cached" — unsafe-by-default instead of cached-by-default. Neither app
+ * sets a cookie today, but this holds even if one starts to.
  */
 
 import type { MiddlewareHandler } from 'hono'
 
 const CACHE_CONTROL = 'public, max-age=300, stale-while-revalidate=3600'
-// Explicit opt-out. Must be set (not just "no Cache-Control") because an
-// absent header still gets Cloudflare's heuristic-freshness default TTL.
+// The default. Must be set explicitly (not just "no Cache-Control")
+// because an absent header still gets Cloudflare's heuristic-freshness
+// default TTL.
 const PRIVATE_CACHE_CONTROL = 'private, no-store'
 
 /**
  * Sets `Cache-Control` on cacheable GET/HEAD 2xx responses that don't
  * already carry one (e.g. `/og`'s hand-tuned image cache header is left
- * alone) — or explicitly opts a response out with `private, no-store` when
- * it isn't safely cacheable: non-2xx, or either side of the exchange
- * carries a session cookie. Neither app sets one today, but caching a
- * `Set-Cookie` response (or a request that already has a `Cookie`) as
- * `public` would replay one visitor's cookie or personalized response to
- * everyone else, so the guard stays even though it's currently a no-op.
+ * alone) — or an explicit `private, no-store` for anything that isn't a
+ * recognized-safe case: non-2xx, or either side of the exchange carries a
+ * session cookie. Neither app sets one today, but caching a `Set-Cookie`
+ * response (or a request that already has a `Cookie`) as `public` would
+ * replay one visitor's cookie or personalized response to everyone else,
+ * so the guard stays even though it's currently a no-op.
  */
 export const cacheControl: MiddlewareHandler = async (c, next) => {
   await next()
@@ -44,7 +53,12 @@ export const cacheControl: MiddlewareHandler = async (c, next) => {
   if (c.req.method !== 'GET' && c.req.method !== 'HEAD') return
   if (c.res.headers.has('Cache-Control')) return
 
-  const isUncacheable = !c.res.ok || Boolean(c.req.header('Cookie')) || c.res.headers.has('Set-Cookie')
+  // Default: do not cache. The one case below must explicitly opt in.
+  let cacheControlValue = PRIVATE_CACHE_CONTROL
 
-  c.res.headers.set('Cache-Control', isUncacheable ? PRIVATE_CACHE_CONTROL : CACHE_CONTROL)
+  if (c.res.ok && !c.req.header('Cookie') && !c.res.headers.has('Set-Cookie')) {
+    cacheControlValue = CACHE_CONTROL
+  }
+
+  c.res.headers.set('Cache-Control', cacheControlValue)
 }

--- a/site/shared/lib/cache-control.ts
+++ b/site/shared/lib/cache-control.ts
@@ -1,0 +1,37 @@
+/**
+ * Cloudflare Workers Cache (`[cache] enabled = true` in wrangler.toml) caches
+ * a Worker-generated response only when its `Cache-Control` header allows
+ * it. barefootjs.dev and ui.barefootjs.dev render docs/landing/gallery pages
+ * that are identical for every visitor and only change on the next deploy,
+ * so they're safe to cache — but nothing in either app sets the header today.
+ *
+ * Shorter-lived than `integrations/shared/lib/cache-control.ts`'s: this repo
+ * pushes to `main` several times a day, and a stale docs page is a worse
+ * outcome here than a stale demo page in an example nobody is actively
+ * editing.
+ */
+
+import type { MiddlewareHandler } from 'hono'
+
+const CACHE_CONTROL = 'public, max-age=300, stale-while-revalidate=3600'
+
+/**
+ * Sets `Cache-Control` on cacheable GET/HEAD 2xx responses that don't
+ * already carry one (e.g. `/og`'s hand-tuned image cache header is left
+ * alone). Also leaves alone anything carrying a session cookie — neither
+ * app sets one today, but caching a `Set-Cookie` response (or a request
+ * that already has a `Cookie`) as `public` would replay one visitor's
+ * cookie or personalized response to everyone else, so the guard stays
+ * even though it's currently a no-op.
+ */
+export const cacheControl: MiddlewareHandler = async (c, next) => {
+  await next()
+
+  if (c.req.method !== 'GET' && c.req.method !== 'HEAD') return
+  if (!c.res.ok) return
+  if (c.res.headers.has('Cache-Control')) return
+  if (c.req.header('Cookie')) return
+  if (c.res.headers.has('Set-Cookie')) return
+
+  c.res.headers.set('Cache-Control', CACHE_CONTROL)
+}

--- a/site/shared/lib/cache-control.ts
+++ b/site/shared/lib/cache-control.ts
@@ -9,29 +9,42 @@
  * pushes to `main` several times a day, and a stale docs page is a worse
  * outcome here than a stale demo page in an example nobody is actively
  * editing.
+ *
+ * IMPORTANT: an *absent* `Cache-Control` header does NOT opt a response out
+ * of Workers Cache. Cloudflare applies RFC 9111 heuristic freshness to any
+ * response with no explicit directive (e.g. a 200 OK gets a 2h TTL by
+ * default), so every branch below that must not be cached sets an explicit
+ * `private, no-store` rather than merely leaving the header unset. The
+ * integrations' copy of this helper shipped the "just leave it unset"
+ * version once already (piconic-ai/barefootjs#2784) and it cached
+ * session-specific responses across visitors — do not regress to that shape
+ * here even though neither site sets a cookie today.
  */
 
 import type { MiddlewareHandler } from 'hono'
 
 const CACHE_CONTROL = 'public, max-age=300, stale-while-revalidate=3600'
+// Explicit opt-out. Must be set (not just "no Cache-Control") because an
+// absent header still gets Cloudflare's heuristic-freshness default TTL.
+const PRIVATE_CACHE_CONTROL = 'private, no-store'
 
 /**
  * Sets `Cache-Control` on cacheable GET/HEAD 2xx responses that don't
  * already carry one (e.g. `/og`'s hand-tuned image cache header is left
- * alone). Also leaves alone anything carrying a session cookie — neither
- * app sets one today, but caching a `Set-Cookie` response (or a request
- * that already has a `Cookie`) as `public` would replay one visitor's
- * cookie or personalized response to everyone else, so the guard stays
- * even though it's currently a no-op.
+ * alone) — or explicitly opts a response out with `private, no-store` when
+ * it isn't safely cacheable: non-2xx, or either side of the exchange
+ * carries a session cookie. Neither app sets one today, but caching a
+ * `Set-Cookie` response (or a request that already has a `Cookie`) as
+ * `public` would replay one visitor's cookie or personalized response to
+ * everyone else, so the guard stays even though it's currently a no-op.
  */
 export const cacheControl: MiddlewareHandler = async (c, next) => {
   await next()
 
   if (c.req.method !== 'GET' && c.req.method !== 'HEAD') return
-  if (!c.res.ok) return
   if (c.res.headers.has('Cache-Control')) return
-  if (c.req.header('Cookie')) return
-  if (c.res.headers.has('Set-Cookie')) return
 
-  c.res.headers.set('Cache-Control', CACHE_CONTROL)
+  const isUncacheable = !c.res.ok || Boolean(c.req.header('Cookie')) || c.res.headers.has('Set-Cookie')
+
+  c.res.headers.set('Cache-Control', isUncacheable ? PRIVATE_CACHE_CONTROL : CACHE_CONTROL)
 }

--- a/site/shared/package.json
+++ b/site/shared/package.json
@@ -13,6 +13,7 @@
     "./lib/theme-init": "./lib/theme-init.ts",
     "./lib/docs-tabs-init": "./lib/docs-tabs-init.ts",
     "./lib/og-image": "./lib/og-image.ts",
+    "./lib/cache-control": "./lib/cache-control.ts",
     "./fonts/inter-bold": "./fonts/inter-bold.ts",
     "./tokens": "./tokens/index.ts"
   },

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -8,6 +8,7 @@
 import { Hono } from 'hono'
 import { renderer } from './renderer'
 import { createOgRoute } from './og-route'
+import { cacheControl } from '@barefootjs/site-shared/lib/cache-control'
 
 // Component pages
 import { AspectRatioRefPage } from './pages/components/aspect-ratio'
@@ -152,6 +153,11 @@ function blockMeta(slug: string): { title: string; description: string } {
  */
 export function createApp() {
   const app = new Hono()
+
+  // Sets Cache-Control on every route below that doesn't set its own, so
+  // Workers Cache (wrangler.toml's `[cache] enabled = true`) can serve
+  // repeat requests without re-running this Worker.
+  app.use('*', cacheControl)
 
   app.use(renderer)
 

--- a/site/ui/routes.tsx
+++ b/site/ui/routes.tsx
@@ -154,9 +154,10 @@ function blockMeta(slug: string): { title: string; description: string } {
 export function createApp() {
   const app = new Hono()
 
-  // Sets Cache-Control on every route below that doesn't set its own, so
-  // Workers Cache (wrangler.toml's `[cache] enabled = true`) can serve
-  // repeat requests without re-running this Worker.
+  // Sets Cache-Control on every route below that doesn't set its own. Inert
+  // today — wrangler.toml deliberately leaves `[cache]` off (see the
+  // comment there) — but mounted first so enabling it later is a one-line
+  // wrangler.toml change with the middleware already wired and tested.
   app.use('*', cacheControl)
 
   app.use(renderer)

--- a/site/ui/wrangler.toml
+++ b/site/ui/wrangler.toml
@@ -4,3 +4,16 @@ compatibility_date = "2024-01-01"
 
 [assets]
 directory = "./dist"
+
+# Workers Cache ([cache] enabled = true) is intentionally NOT turned on here yet.
+# Verified against developers.cloudflare.com/workers/cache/#pricing: "When
+# caching is enabled, every request to your Worker is charged at the standard
+# Workers request rate, including requests that are normally free: static
+# asset requests..." — this is unconditional, not something `exports`-based
+# per-entrypoint caching can scope around, because `[assets]` static-file
+# serving isn't a WorkerEntrypoint. For an asset-heavy component gallery site
+# like this one, that's a real net cost INCREASE, the opposite of why this
+# file was touched (piconic-ai/barefootjs#2784). The `cacheControl` middleware
+# (site/shared/lib/cache-control.ts) is still mounted and sets Cache-Control
+# on HTML responses, so flipping this on later is a one-line change once the
+# asset-vs-HTML request volume against a live account justifies it.

--- a/site/ui/wrangler.toml
+++ b/site/ui/wrangler.toml
@@ -13,7 +13,7 @@ directory = "./dist"
 # per-entrypoint caching can scope around, because `[assets]` static-file
 # serving isn't a WorkerEntrypoint. For an asset-heavy component gallery site
 # like this one, that's a real net cost INCREASE, the opposite of why this
-# file was touched (piconic-ai/barefootjs#2784). The `cacheControl` middleware
+# file was touched (piconic-ai/barefootjs#2789). The `cacheControl` middleware
 # (site/shared/lib/cache-control.ts) is still mounted and sets Cache-Control
 # on HTML responses, so flipping this on later is a one-line change once the
 # asset-vs-HTML request volume against a live account justifies it.


### PR DESCRIPTION
## Summary

Carries forward the `site/core`/`site/ui` half of #2784's original scope, split out per review feedback so #2784 could ship the confirmed win (the 15 Container-backed integrations) on its own. #2784 has since merged, and this PR is now retargeted onto `main` directly (no longer stacked).

- **`site/shared/lib/cache-control.ts`** — a Hono `cacheControl` middleware that sets `Cache-Control: public, max-age=300, stale-while-revalidate=3600` on cacheable GET/HEAD 2xx responses that don't already carry one, mounted first in both `site/core/app.tsx` and `site/ui/routes.tsx`. Leaves `/og`'s existing hand-tuned image `Cache-Control` alone, and skips anything carrying a session cookie (`Cookie` on the request or `Set-Cookie` on the response) — neither site has a cookie-setting route today, but the guard costs nothing and keeps the same invariant #2784 established for the integrations helper.

**`[cache] enabled = true` is intentionally NOT flipped on in either `wrangler.toml`.** While working on #2784, pullfrog's automated review (and a direct read of [Cloudflare's docs](https://developers.cloudflare.com/workers/cache/#pricing)) surfaced a real tradeoff: enabling `[cache]` bills *every* request to a Worker at the standard rate, including static-asset requests served via `[assets]` that are normally free — unconditionally, and not something [per-entrypoint caching](https://developers.cloudflare.com/workers/cache/configuration/#per-entrypoint-caching) can scope around. Both sites are asset-heavy (docs/gallery pages) and use `[assets]` for their JS/CSS/font output, so this could be a net cost *increase* rather than a decrease.

So this PR is prep work: the middleware is written, tested, and mounted, but inert until someone can check the actual asset-vs-HTML request ratio against a live Cloudflare account and decide the tradeoff is worth it. At that point, enabling caching is a one-line change per file (see the comment in each `wrangler.toml`).

One idea explored but not implemented here: splitting static assets onto a separate Worker/route (this repo already path-routes several Workers under one domain, e.g. `barefootjs.dev/integrations/flask/*`) would let the HTML-serving Worker enable `[cache]` without ever touching `[assets]` traffic, sidestepping the billing tradeoff entirely. That's a bigger architectural change (separate deploy pipeline, asset URL repointing, routing verification) and is out of scope here.

### Update: fixed the same bug class as #2784/#2790

#2784's `withCacheControl` (the integrations' copy of this pattern) shipped a bug: it skipped setting `Cache-Control` on session-cookie responses, assuming an absent header keeps them out of Workers Cache. It doesn't — Cloudflare applies RFC 9111 heuristic freshness to any response with no explicit directive (2h default TTL for a 200), so this shipped a live cross-session data leak, reverted in #2790.

This middleware is inert today (`[cache]` is off in both sites), but carried the identical latent bug. Fixed here too, before it ever ships live: `cacheControl` now sets an explicit `Cache-Control: private, no-store` for every uncacheable case (non-2xx, request `Cookie`, response `Set-Cookie`) instead of leaving the header absent.

## Test plan

- [x] `bun test site/shared/lib/__tests__/cache-control.test.ts` — 6/6 pass, including the session-cookie cases now asserting the explicit `private, no-store` value
- [x] Retargeted onto `main` after #2784 merged (its commits are ancestors, so no rebase was needed — diff is unchanged, 7 files)
- [ ] Follow-up: gather real traffic data (asset vs. HTML request ratio) before deciding whether to flip `[cache]` on