### PR TITLE
Re-enable Workers Cache on Container integrations with corrected guard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,8 +103,12 @@ packages/adapter-*/blib/
 packages/adapter-*/Makefile
 packages/adapter-*/MYMETA.*
 
-# Perl integration runtime libs (assembled by scripts/assemble-deps.ts)
+# Perl integration runtime libs (assembled by scripts/assemble-deps.ts).
+# integrations/shared isn't a backend integration and has no assemble-deps
+# step — its lib/ is committed source (e.g. lib/cache-control.ts), not a
+# build artifact, so it's excluded from this wildcard.
 integrations/*/lib
+!integrations/shared/lib
 
 # Python
 __pycache__/

--- a/integrations/axum/container.ts
+++ b/integrations/axum/container.ts
@@ -8,6 +8,7 @@
  */
 
 import { Container } from '@cloudflare/containers'
+import { withCacheControl } from 'barefootjs-integrations-shared/lib/cache-control'
 
 type Env = {
   AXUM_CONTAINER: DurableObjectNamespace
@@ -26,6 +27,6 @@ export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const id = env.AXUM_CONTAINER.idFromName('singleton')
     const stub = env.AXUM_CONTAINER.get(id) as unknown as { fetch: typeof fetch }
-    return stub.fetch(request)
+    return withCacheControl(request, await stub.fetch(request))
   },
 } satisfies ExportedHandler<Env>

--- a/integrations/axum/package.json
+++ b/integrations/axum/package.json
@@ -14,7 +14,8 @@
   },
   "dependencies": {
     "@barefootjs/client": "workspace:*",
-    "@barefootjs/router": "workspace:*"
+    "@barefootjs/router": "workspace:*",
+    "barefootjs-integrations-shared": "workspace:*"
   },
   "devDependencies": {
     "@barefootjs/jsx": "workspace:*",

--- a/integrations/axum/wrangler.toml
+++ b/integrations/axum/wrangler.toml
@@ -1,7 +1,10 @@
 name = "barefootjs-axum-example"
 main = "container.ts"
-compatibility_date = "2025-01-01"
+compatibility_date = "2026-08-29"
 compatibility_flags = ["nodejs_compat"]
+
+[cache]
+enabled = true
 
 [[containers]]
 class_name = "AxumContainer"

--- a/integrations/blade/container.ts
+++ b/integrations/blade/container.ts
@@ -4,6 +4,7 @@
  */
 
 import { Container } from '@cloudflare/containers'
+import { withCacheControl } from 'barefootjs-integrations-shared/lib/cache-control'
 
 type Env = {
   PHP_CONTAINER: DurableObjectNamespace
@@ -22,6 +23,6 @@ export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const id = env.PHP_CONTAINER.idFromName('singleton')
     const stub = env.PHP_CONTAINER.get(id) as unknown as { fetch: typeof fetch }
-    return stub.fetch(request)
+    return withCacheControl(request, await stub.fetch(request))
   },
 } satisfies ExportedHandler<Env>

--- a/integrations/blade/package.json
+++ b/integrations/blade/package.json
@@ -14,7 +14,8 @@
   },
   "dependencies": {
     "@barefootjs/client": "workspace:*",
-    "@barefootjs/router": "workspace:*"
+    "@barefootjs/router": "workspace:*",
+    "barefootjs-integrations-shared": "workspace:*"
   },
   "devDependencies": {
     "@barefootjs/jsx": "workspace:*",

--- a/integrations/blade/wrangler.toml
+++ b/integrations/blade/wrangler.toml
@@ -1,7 +1,10 @@
 name = "barefootjs-blade-example"
 main = "container.ts"
-compatibility_date = "2025-01-01"
+compatibility_date = "2026-08-29"
 compatibility_flags = ["nodejs_compat"]
+
+[cache]
+enabled = true
 
 [[containers]]
 class_name = "PhpContainer"

--- a/integrations/chi/container.ts
+++ b/integrations/chi/container.ts
@@ -8,6 +8,7 @@
  */
 
 import { Container } from '@cloudflare/containers'
+import { withCacheControl } from 'barefootjs-integrations-shared/lib/cache-control'
 
 type Env = {
   CHI_CONTAINER: DurableObjectNamespace
@@ -26,6 +27,6 @@ export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const id = env.CHI_CONTAINER.idFromName('singleton')
     const stub = env.CHI_CONTAINER.get(id) as unknown as { fetch: typeof fetch }
-    return stub.fetch(request)
+    return withCacheControl(request, await stub.fetch(request))
   },
 } satisfies ExportedHandler<Env>

--- a/integrations/chi/package.json
+++ b/integrations/chi/package.json
@@ -23,6 +23,7 @@
     "@playwright/test": "^1.41.0",
     "bun-types": "^1.1.0",
     "vite": "^6.0.0",
-    "wrangler": "^4"
+    "wrangler": "^4",
+    "barefootjs-integrations-shared": "workspace:*"
   }
 }

--- a/integrations/chi/wrangler.toml
+++ b/integrations/chi/wrangler.toml
@@ -1,7 +1,10 @@
 name = "barefootjs-chi-example"
 main = "container.ts"
-compatibility_date = "2025-01-01"
+compatibility_date = "2026-08-29"
 compatibility_flags = ["nodejs_compat"]
+
+[cache]
+enabled = true
 
 [[containers]]
 class_name = "ChiContainer"

--- a/integrations/django/container.ts
+++ b/integrations/django/container.ts
@@ -4,6 +4,7 @@
  */
 
 import { Container } from '@cloudflare/containers'
+import { withCacheControl } from 'barefootjs-integrations-shared/lib/cache-control'
 
 type Env = {
   DJANGO_CONTAINER: DurableObjectNamespace
@@ -22,6 +23,6 @@ export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const id = env.DJANGO_CONTAINER.idFromName('singleton')
     const stub = env.DJANGO_CONTAINER.get(id) as unknown as { fetch: typeof fetch }
-    return stub.fetch(request)
+    return withCacheControl(request, await stub.fetch(request))
   },
 } satisfies ExportedHandler<Env>

--- a/integrations/django/package.json
+++ b/integrations/django/package.json
@@ -14,7 +14,8 @@
   },
   "dependencies": {
     "@barefootjs/client": "workspace:*",
-    "@barefootjs/router": "workspace:*"
+    "@barefootjs/router": "workspace:*",
+    "barefootjs-integrations-shared": "workspace:*"
   },
   "devDependencies": {
     "@barefootjs/jsx": "workspace:*",

--- a/integrations/django/wrangler.toml
+++ b/integrations/django/wrangler.toml
@@ -1,7 +1,10 @@
 name = "barefootjs-django-example"
 main = "container.ts"
-compatibility_date = "2025-01-01"
+compatibility_date = "2026-08-29"
 compatibility_flags = ["nodejs_compat"]
+
+[cache]
+enabled = true
 
 [[containers]]
 class_name = "DjangoContainer"

--- a/integrations/echo/container.ts
+++ b/integrations/echo/container.ts
@@ -8,6 +8,7 @@
  */
 
 import { Container } from '@cloudflare/containers'
+import { withCacheControl } from 'barefootjs-integrations-shared/lib/cache-control'
 
 type Env = {
   ECHO_CONTAINER: DurableObjectNamespace
@@ -26,6 +27,6 @@ export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const id = env.ECHO_CONTAINER.idFromName('singleton')
     const stub = env.ECHO_CONTAINER.get(id) as unknown as { fetch: typeof fetch }
-    return stub.fetch(request)
+    return withCacheControl(request, await stub.fetch(request))
   },
 } satisfies ExportedHandler<Env>

--- a/integrations/echo/package.json
+++ b/integrations/echo/package.json
@@ -23,6 +23,7 @@
     "vite": "^6.0.0",
     "wrangler": "^4",
     "@barefootjs/client": "workspace:*",
-    "@barefootjs/router": "workspace:*"
+    "@barefootjs/router": "workspace:*",
+    "barefootjs-integrations-shared": "workspace:*"
   }
 }

--- a/integrations/echo/wrangler.toml
+++ b/integrations/echo/wrangler.toml
@@ -1,7 +1,10 @@
 name = "barefootjs-echo-example"
 main = "container.ts"
-compatibility_date = "2025-01-01"
+compatibility_date = "2026-08-29"
 compatibility_flags = ["nodejs_compat"]
+
+[cache]
+enabled = true
 
 [[containers]]
 class_name = "EchoContainer"

--- a/integrations/fastapi/container.ts
+++ b/integrations/fastapi/container.ts
@@ -4,6 +4,7 @@
  */
 
 import { Container } from '@cloudflare/containers'
+import { withCacheControl } from 'barefootjs-integrations-shared/lib/cache-control'
 
 type Env = {
   FASTAPI_CONTAINER: DurableObjectNamespace
@@ -22,6 +23,6 @@ export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const id = env.FASTAPI_CONTAINER.idFromName('singleton')
     const stub = env.FASTAPI_CONTAINER.get(id) as unknown as { fetch: typeof fetch }
-    return stub.fetch(request)
+    return withCacheControl(request, await stub.fetch(request))
   },
 } satisfies ExportedHandler<Env>

--- a/integrations/fastapi/package.json
+++ b/integrations/fastapi/package.json
@@ -14,7 +14,8 @@
   },
   "dependencies": {
     "@barefootjs/client": "workspace:*",
-    "@barefootjs/router": "workspace:*"
+    "@barefootjs/router": "workspace:*",
+    "barefootjs-integrations-shared": "workspace:*"
   },
   "devDependencies": {
     "@barefootjs/jsx": "workspace:*",

--- a/integrations/fastapi/wrangler.toml
+++ b/integrations/fastapi/wrangler.toml
@@ -1,7 +1,10 @@
 name = "barefootjs-fastapi-example"
 main = "container.ts"
-compatibility_date = "2025-01-01"
+compatibility_date = "2026-08-29"
 compatibility_flags = ["nodejs_compat"]
+
+[cache]
+enabled = true
 
 [[containers]]
 class_name = "FastapiContainer"

--- a/integrations/flask/container.ts
+++ b/integrations/flask/container.ts
@@ -4,6 +4,7 @@
  */
 
 import { Container } from '@cloudflare/containers'
+import { withCacheControl } from 'barefootjs-integrations-shared/lib/cache-control'
 
 type Env = {
   FLASK_CONTAINER: DurableObjectNamespace
@@ -22,6 +23,6 @@ export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const id = env.FLASK_CONTAINER.idFromName('singleton')
     const stub = env.FLASK_CONTAINER.get(id) as unknown as { fetch: typeof fetch }
-    return stub.fetch(request)
+    return withCacheControl(request, await stub.fetch(request))
   },
 } satisfies ExportedHandler<Env>

--- a/integrations/flask/package.json
+++ b/integrations/flask/package.json
@@ -14,7 +14,8 @@
   },
   "dependencies": {
     "@barefootjs/client": "workspace:*",
-    "@barefootjs/router": "workspace:*"
+    "@barefootjs/router": "workspace:*",
+    "barefootjs-integrations-shared": "workspace:*"
   },
   "devDependencies": {
     "@barefootjs/jsx": "workspace:*",

--- a/integrations/flask/wrangler.toml
+++ b/integrations/flask/wrangler.toml
@@ -1,7 +1,10 @@
 name = "barefootjs-flask-example"
 main = "container.ts"
-compatibility_date = "2025-01-01"
+compatibility_date = "2026-08-29"
 compatibility_flags = ["nodejs_compat"]
+
+[cache]
+enabled = true
 
 [[containers]]
 class_name = "FlaskContainer"

--- a/integrations/gin/container.ts
+++ b/integrations/gin/container.ts
@@ -8,6 +8,7 @@
  */
 
 import { Container } from '@cloudflare/containers'
+import { withCacheControl } from 'barefootjs-integrations-shared/lib/cache-control'
 
 type Env = {
   GIN_CONTAINER: DurableObjectNamespace
@@ -26,6 +27,6 @@ export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const id = env.GIN_CONTAINER.idFromName('singleton')
     const stub = env.GIN_CONTAINER.get(id) as unknown as { fetch: typeof fetch }
-    return stub.fetch(request)
+    return withCacheControl(request, await stub.fetch(request))
   },
 } satisfies ExportedHandler<Env>

--- a/integrations/gin/package.json
+++ b/integrations/gin/package.json
@@ -23,6 +23,7 @@
     "vite": "^6.0.0",
     "wrangler": "^4",
     "@barefootjs/client": "workspace:*",
-    "@barefootjs/router": "workspace:*"
+    "@barefootjs/router": "workspace:*",
+    "barefootjs-integrations-shared": "workspace:*"
   }
 }

--- a/integrations/gin/wrangler.toml
+++ b/integrations/gin/wrangler.toml
@@ -1,7 +1,10 @@
 name = "barefootjs-gin-example"
 main = "container.ts"
-compatibility_date = "2025-01-01"
+compatibility_date = "2026-08-29"
 compatibility_flags = ["nodejs_compat"]
+
+[cache]
+enabled = true
 
 [[containers]]
 class_name = "GinContainer"

--- a/integrations/laravel/container.ts
+++ b/integrations/laravel/container.ts
@@ -4,6 +4,7 @@
  */
 
 import { Container } from '@cloudflare/containers'
+import { withCacheControl } from 'barefootjs-integrations-shared/lib/cache-control'
 
 type Env = {
   LARAVEL_CONTAINER: DurableObjectNamespace
@@ -22,6 +23,6 @@ export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const id = env.LARAVEL_CONTAINER.idFromName('singleton')
     const stub = env.LARAVEL_CONTAINER.get(id) as unknown as { fetch: typeof fetch }
-    return stub.fetch(request)
+    return withCacheControl(request, await stub.fetch(request))
   },
 } satisfies ExportedHandler<Env>

--- a/integrations/laravel/package.json
+++ b/integrations/laravel/package.json
@@ -14,7 +14,8 @@
   },
   "dependencies": {
     "@barefootjs/client": "workspace:*",
-    "@barefootjs/router": "workspace:*"
+    "@barefootjs/router": "workspace:*",
+    "barefootjs-integrations-shared": "workspace:*"
   },
   "devDependencies": {
     "@barefootjs/jsx": "workspace:*",

--- a/integrations/laravel/wrangler.toml
+++ b/integrations/laravel/wrangler.toml
@@ -1,7 +1,10 @@
 name = "barefootjs-laravel-example"
 main = "container.ts"
-compatibility_date = "2025-01-01"
+compatibility_date = "2026-08-29"
 compatibility_flags = ["nodejs_compat"]
+
+[cache]
+enabled = true
 
 [[containers]]
 class_name = "LaravelContainer"

--- a/integrations/mojolicious/container.ts
+++ b/integrations/mojolicious/container.ts
@@ -4,6 +4,7 @@
  */
 
 import { Container } from '@cloudflare/containers'
+import { withCacheControl } from 'barefootjs-integrations-shared/lib/cache-control'
 
 type Env = {
   MOJO_CONTAINER: DurableObjectNamespace
@@ -22,6 +23,6 @@ export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const id = env.MOJO_CONTAINER.idFromName('singleton')
     const stub = env.MOJO_CONTAINER.get(id) as unknown as { fetch: typeof fetch }
-    return stub.fetch(request)
+    return withCacheControl(request, await stub.fetch(request))
   },
 } satisfies ExportedHandler<Env>

--- a/integrations/mojolicious/package.json
+++ b/integrations/mojolicious/package.json
@@ -13,7 +13,8 @@
   },
   "dependencies": {
     "@barefootjs/client": "workspace:*",
-    "@barefootjs/router": "workspace:*"
+    "@barefootjs/router": "workspace:*",
+    "barefootjs-integrations-shared": "workspace:*"
   },
   "devDependencies": {
     "@barefootjs/jsx": "workspace:*",

--- a/integrations/mojolicious/wrangler.toml
+++ b/integrations/mojolicious/wrangler.toml
@@ -1,7 +1,10 @@
 name = "barefootjs-mojolicious-example"
 main = "container.ts"
-compatibility_date = "2025-01-01"
+compatibility_date = "2026-08-29"
 compatibility_flags = ["nodejs_compat"]
+
+[cache]
+enabled = true
 
 [[containers]]
 class_name = "MojoContainer"

--- a/integrations/nethttp/container.ts
+++ b/integrations/nethttp/container.ts
@@ -8,6 +8,7 @@
  */
 
 import { Container } from '@cloudflare/containers'
+import { withCacheControl } from 'barefootjs-integrations-shared/lib/cache-control'
 
 type Env = {
   NETHTTP_CONTAINER: DurableObjectNamespace
@@ -26,6 +27,6 @@ export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const id = env.NETHTTP_CONTAINER.idFromName('singleton')
     const stub = env.NETHTTP_CONTAINER.get(id) as unknown as { fetch: typeof fetch }
-    return stub.fetch(request)
+    return withCacheControl(request, await stub.fetch(request))
   },
 } satisfies ExportedHandler<Env>

--- a/integrations/nethttp/package.json
+++ b/integrations/nethttp/package.json
@@ -23,6 +23,7 @@
     "vite": "^6.0.0",
     "wrangler": "^4",
     "@barefootjs/client": "workspace:*",
-    "@barefootjs/router": "workspace:*"
+    "@barefootjs/router": "workspace:*",
+    "barefootjs-integrations-shared": "workspace:*"
   }
 }

--- a/integrations/nethttp/wrangler.toml
+++ b/integrations/nethttp/wrangler.toml
@@ -1,7 +1,10 @@
 name = "barefootjs-nethttp-example"
 main = "container.ts"
-compatibility_date = "2025-01-01"
+compatibility_date = "2026-08-29"
 compatibility_flags = ["nodejs_compat"]
+
+[cache]
+enabled = true
 
 [[containers]]
 class_name = "NethttpContainer"

--- a/integrations/php/container.ts
+++ b/integrations/php/container.ts
@@ -4,6 +4,7 @@
  */
 
 import { Container } from '@cloudflare/containers'
+import { withCacheControl } from 'barefootjs-integrations-shared/lib/cache-control'
 
 type Env = {
   PHP_CONTAINER: DurableObjectNamespace
@@ -22,6 +23,6 @@ export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const id = env.PHP_CONTAINER.idFromName('singleton')
     const stub = env.PHP_CONTAINER.get(id) as unknown as { fetch: typeof fetch }
-    return stub.fetch(request)
+    return withCacheControl(request, await stub.fetch(request))
   },
 } satisfies ExportedHandler<Env>

--- a/integrations/php/package.json
+++ b/integrations/php/package.json
@@ -14,7 +14,8 @@
   },
   "dependencies": {
     "@barefootjs/client": "workspace:*",
-    "@barefootjs/router": "workspace:*"
+    "@barefootjs/router": "workspace:*",
+    "barefootjs-integrations-shared": "workspace:*"
   },
   "devDependencies": {
     "@barefootjs/jsx": "workspace:*",

--- a/integrations/php/wrangler.toml
+++ b/integrations/php/wrangler.toml
@@ -1,7 +1,10 @@
 name = "barefootjs-php-example"
 main = "container.ts"
-compatibility_date = "2025-01-01"
+compatibility_date = "2026-08-29"
 compatibility_flags = ["nodejs_compat"]
+
+[cache]
+enabled = true
 
 [[containers]]
 class_name = "PhpContainer"

--- a/integrations/rails/container.ts
+++ b/integrations/rails/container.ts
@@ -4,6 +4,7 @@
  */
 
 import { Container } from '@cloudflare/containers'
+import { withCacheControl } from 'barefootjs-integrations-shared/lib/cache-control'
 
 type Env = {
   RAILS_CONTAINER: DurableObjectNamespace
@@ -22,6 +23,6 @@ export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const id = env.RAILS_CONTAINER.idFromName('singleton')
     const stub = env.RAILS_CONTAINER.get(id) as unknown as { fetch: typeof fetch }
-    return stub.fetch(request)
+    return withCacheControl(request, await stub.fetch(request))
   },
 } satisfies ExportedHandler<Env>

--- a/integrations/rails/package.json
+++ b/integrations/rails/package.json
@@ -13,7 +13,8 @@
   },
   "dependencies": {
     "@barefootjs/client": "workspace:*",
-    "@barefootjs/router": "workspace:*"
+    "@barefootjs/router": "workspace:*",
+    "barefootjs-integrations-shared": "workspace:*"
   },
   "devDependencies": {
     "@barefootjs/erb": "workspace:*",

--- a/integrations/rails/wrangler.toml
+++ b/integrations/rails/wrangler.toml
@@ -1,7 +1,10 @@
 name = "barefootjs-rails-example"
 main = "container.ts"
-compatibility_date = "2025-01-01"
+compatibility_date = "2026-08-29"
 compatibility_flags = ["nodejs_compat"]
+
+[cache]
+enabled = true
 
 [[containers]]
 class_name = "RailsContainer"

--- a/integrations/shared/lib/__tests__/cache-control.test.ts
+++ b/integrations/shared/lib/__tests__/cache-control.test.ts
@@ -1,0 +1,63 @@
+import { describe, test, expect } from 'bun:test'
+import { withCacheControl } from '../cache-control'
+
+const req = (path: string, init?: RequestInit) => new Request(`https://barefootjs.dev${path}`, init)
+
+describe('withCacheControl', () => {
+  test('adds a long-lived Cache-Control to a cacheable HTML response', () => {
+    const res = withCacheControl(req('/integrations/flask/'), new Response('<html></html>'))
+    expect(res.headers.get('Cache-Control')).toBe('public, max-age=3600, stale-while-revalidate=86400')
+  })
+
+  test('adds an immutable Cache-Control to a fingerprinted asset', () => {
+    const res = withCacheControl(req('/integrations/flask/client/router-entry-abc123.js'), new Response(''))
+    expect(res.headers.get('Cache-Control')).toBe('public, max-age=31536000, immutable')
+  })
+
+  test('leaves non-GET/HEAD requests untouched', () => {
+    const res = withCacheControl(req('/integrations/flask/todos', { method: 'POST' }), new Response(''))
+    expect(res.headers.has('Cache-Control')).toBe(false)
+  })
+
+  test('explicitly opts error responses out of caching (heuristic freshness applies to several non-2xx statuses too)', () => {
+    const res = withCacheControl(req('/integrations/flask/missing'), new Response('not found', { status: 404 }))
+    expect(res.headers.get('Cache-Control')).toBe('private, no-store')
+  })
+
+  test('does not override a Cache-Control the backend already set', () => {
+    const backendResponse = new Response('', { headers: { 'Cache-Control': 'no-store' } })
+    const res = withCacheControl(req('/integrations/flask/'), backendResponse)
+    expect(res.headers.get('Cache-Control')).toBe('no-store')
+  })
+
+  test('explicitly opts out a response minting a session cookie (e.g. GET /todos on first visit)', () => {
+    const backendResponse = new Response('<html></html>', { headers: { 'Set-Cookie': 'bf_session=abc; Path=/integrations/flask; HttpOnly' } })
+    const res = withCacheControl(req('/integrations/flask/todos'), backendResponse)
+    expect(res.headers.get('Cache-Control')).toBe('private, no-store')
+  })
+
+  test('explicitly opts out a request that already carries a session cookie (e.g. GET /api/todos on a return visit)', () => {
+    const res = withCacheControl(req('/integrations/flask/api/todos', { headers: { Cookie: 'bf_session=abc' } }), new Response('[]'))
+    expect(res.headers.get('Cache-Control')).toBe('private, no-store')
+  })
+
+  test('does not leak a stale Set-Cookie into a cached response (regression pin for #2784/#2790)', () => {
+    // The exact shape that leaked in production: a repeat visit sends
+    // Cookie but the response has no fresh Set-Cookie and previously had no
+    // Cache-Control either, so Cloudflare's heuristic-freshness default
+    // (2h TTL for a 200) cached one visitor's session HTML and served it to
+    // others at the same path. This must come back explicitly no-store,
+    // never merely headerless.
+    const res = withCacheControl(
+      req('/integrations/flask/todos', { headers: { Cookie: 'bf_session=abc' } }),
+      new Response('<html>someone else\'s todos</html>'),
+    )
+    expect(res.headers.get('Cache-Control')).toBe('private, no-store')
+  })
+
+  test('preserves status and body', async () => {
+    const res = withCacheControl(req('/integrations/flask/'), new Response('hello', { status: 200 }))
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('hello')
+  })
+})

--- a/integrations/shared/lib/__tests__/cache-control.test.ts
+++ b/integrations/shared/lib/__tests__/cache-control.test.ts
@@ -55,6 +55,26 @@ describe('withCacheControl', () => {
     expect(res.headers.get('Cache-Control')).toBe('private, no-store')
   })
 
+  test('does not cache a 404 at an asset-shaped path (regression pin: the asset branch must not bypass the response.ok gate)', () => {
+    // The asset-extension check is a heuristic on the URL, not proof the
+    // response IS a real static asset. A missed/deleted build artifact
+    // returns 404 at a path that still matches ASSET_EXTENSION — if that
+    // gets cached `immutable`, the 404 is pinned for a year (purge-only
+    // recovery).
+    const res = withCacheControl(req('/integrations/flask/client/router-entry-abc123.js'), new Response('not found', { status: 404 }))
+    expect(res.headers.get('Cache-Control')).toBe('private, no-store')
+  })
+
+  test('does not cache a Set-Cookie response at an asset-shaped path (regression pin: same leak class, reached via the asset branch)', () => {
+    // If a response at an asset-shaped path ever carries Set-Cookie, caching
+    // it `immutable` would replay that Set-Cookie to every other visitor for
+    // a year — the #2784 leak class, just reached through the asset branch
+    // instead of the HTML one.
+    const backendResponse = new Response('', { headers: { 'Set-Cookie': 'bf_session=abc; Path=/integrations/flask; HttpOnly' } })
+    const res = withCacheControl(req('/integrations/flask/client/router-entry-abc123.js'), backendResponse)
+    expect(res.headers.get('Cache-Control')).toBe('private, no-store')
+  })
+
   test('preserves status and body', async () => {
     const res = withCacheControl(req('/integrations/flask/'), new Response('hello', { status: 200 }))
     expect(res.status).toBe(200)

--- a/integrations/shared/lib/cache-control.ts
+++ b/integrations/shared/lib/cache-control.ts
@@ -1,0 +1,68 @@
+/**
+ * Cloudflare Workers Cache (`[cache] enabled = true` in wrangler.toml) only
+ * caches a response when its `Cache-Control` header says it may — otherwise
+ * every request still wakes the backing Container. None of the 15
+ * language/framework backends this repo demos (Flask, Rails, Go, Rust, ...)
+ * set that header on their own, so every `container.ts` shim funnels its
+ * response through here before returning it. One shared decision instead of
+ * fifteen copies that could quietly drift.
+ *
+ * Most demo pages are static per route (no auth — interactivity is
+ * client-side signals over a fixed SSR shell), so caching them as `public`
+ * is safe. But several integrations also serve a cookie-backed Todo demo
+ * (`/todos`, `/api/todos/*`) scoped to that integration's own path, where
+ * the response body and any `Set-Cookie` genuinely differ per visitor.
+ * Caching those as `public` would replay one visitor's todo list — or
+ * worse, their session cookie — to every other visitor for the TTL window.
+ * `max-age` is tuned long for the routes we DO cache: the whole point is to
+ * stop a repeat visitor from waking the Container at all.
+ *
+ * IMPORTANT: an *absent* `Cache-Control` header does NOT opt a response out
+ * of Workers Cache. Cloudflare applies RFC 9111 heuristic freshness to any
+ * response with no explicit directive (e.g. a 200 OK gets a 2h TTL by
+ * default), so every branch below that must not be cached sets an explicit
+ * `private, no-store` rather than merely leaving the header unset. This
+ * repo shipped the "just leave it unset" version once already
+ * (piconic-ai/barefootjs#2784) and it cached session-specific Todo
+ * responses across visitors — do not regress to that shape.
+ */
+
+const ASSET_EXTENSION = /\.(?:js|mjs|css|woff2?|ttf|svg|png|jpe?g|gif|webp|ico)$/
+
+const HTML_CACHE_CONTROL = 'public, max-age=3600, stale-while-revalidate=86400'
+// Vite fingerprints build output (content-hashed filenames), so an asset
+// URL either changes or never changes — safe to cache for a year.
+const ASSET_CACHE_CONTROL = 'public, max-age=31536000, immutable'
+// Explicit opt-out. Must be set (not just "no Cache-Control") because an
+// absent header still gets Cloudflare's heuristic-freshness default TTL.
+const PRIVATE_CACHE_CONTROL = 'private, no-store'
+
+/**
+ * Adds a `Cache-Control` header to a Container response so Workers Cache
+ * will store it — or explicitly opts it out with `private, no-store` when
+ * it isn't safely cacheable: non-2xx, either side of the exchange carries a
+ * session cookie (a `Cookie` on the request — the visitor already has a
+ * session, so the body is theirs — or a `Set-Cookie` on the response — a
+ * new session is being minted for them). Leaves the response fully alone
+ * for non-GET/HEAD requests (not heuristically cacheable regardless of
+ * headers) and when the backend already set its own directive.
+ */
+export function withCacheControl(request: Request, response: Response): Response {
+  if (request.method !== 'GET' && request.method !== 'HEAD') return response
+  if (response.headers.has('Cache-Control')) return response
+
+  const isUncacheable = !response.ok || request.headers.has('Cookie') || response.headers.has('Set-Cookie')
+
+  const { pathname } = new URL(request.url)
+  const headers = new Headers(response.headers)
+  headers.set(
+    'Cache-Control',
+    isUncacheable ? PRIVATE_CACHE_CONTROL : ASSET_EXTENSION.test(pathname) ? ASSET_CACHE_CONTROL : HTML_CACHE_CONTROL,
+  )
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  })
+}

--- a/integrations/shared/lib/cache-control.ts
+++ b/integrations/shared/lib/cache-control.ts
@@ -20,45 +20,61 @@
  * IMPORTANT: an *absent* `Cache-Control` header does NOT opt a response out
  * of Workers Cache. Cloudflare applies RFC 9111 heuristic freshness to any
  * response with no explicit directive (e.g. a 200 OK gets a 2h TTL by
- * default), so every branch below that must not be cached sets an explicit
- * `private, no-store` rather than merely leaving the header unset. This
- * repo shipped the "just leave it unset" version once already
- * (piconic-ai/barefootjs#2784) and it cached session-specific Todo
- * responses across visitors — do not regress to that shape.
+ * default). This repo shipped a version that relied on an absent header to
+ * mean "don't cache" once already (piconic-ai/barefootjs#2784) and it
+ * cached session-specific Todo responses across visitors.
+ *
+ * That bug was a symptom of a bigger structural risk: the old shape was a
+ * DENYLIST — cache by default, with a short list of conditions (Cookie,
+ * Set-Cookie, non-2xx) that opted a response OUT. Any response shape nobody
+ * had thought of yet inherited the default of "cached". This is instead an
+ * ALLOWLIST: the default below is unconditionally `no-store`, and each
+ * cacheable case must explicitly earn its way into a longer TTL. A new
+ * response shape nobody has reasoned about yet inherits "not cached" —
+ * unsafe-by-default instead of cached-by-default.
  */
 
 const ASSET_EXTENSION = /\.(?:js|mjs|css|woff2?|ttf|svg|png|jpe?g|gif|webp|ico)$/
 
 const HTML_CACHE_CONTROL = 'public, max-age=3600, stale-while-revalidate=86400'
 // Vite fingerprints build output (content-hashed filenames), so an asset
-// URL either changes or never changes — safe to cache for a year.
+// URL either changes or never changes — safe to cache for a year, and this
+// holds regardless of Cookie/Set-Cookie state (no backend ever varies a
+// static asset's bytes by visitor).
 const ASSET_CACHE_CONTROL = 'public, max-age=31536000, immutable'
-// Explicit opt-out. Must be set (not just "no Cache-Control") because an
-// absent header still gets Cloudflare's heuristic-freshness default TTL.
+// The default. Must be set explicitly (not just "no Cache-Control") because
+// an absent header still gets Cloudflare's heuristic-freshness default TTL.
 const PRIVATE_CACHE_CONTROL = 'private, no-store'
 
 /**
  * Adds a `Cache-Control` header to a Container response so Workers Cache
- * will store it — or explicitly opts it out with `private, no-store` when
- * it isn't safely cacheable: non-2xx, either side of the exchange carries a
- * session cookie (a `Cookie` on the request — the visitor already has a
- * session, so the body is theirs — or a `Set-Cookie` on the response — a
- * new session is being minted for them). Leaves the response fully alone
- * for non-GET/HEAD requests (not heuristically cacheable regardless of
- * headers) and when the backend already set its own directive.
+ * can serve repeat requests without waking the Container — or, for
+ * anything that isn't a recognized-safe case, an explicit `private,
+ * no-store` so Workers Cache never stores it. Leaves the response fully
+ * alone for non-GET/HEAD requests (not heuristically cacheable regardless
+ * of headers — RFC 9111 requires explicit freshness info to cache a
+ * non-GET/HEAD method, which none of these backends set) and when the
+ * backend already set its own directive.
  */
 export function withCacheControl(request: Request, response: Response): Response {
   if (request.method !== 'GET' && request.method !== 'HEAD') return response
   if (response.headers.has('Cache-Control')) return response
 
-  const isUncacheable = !response.ok || request.headers.has('Cookie') || response.headers.has('Set-Cookie')
-
   const { pathname } = new URL(request.url)
   const headers = new Headers(response.headers)
-  headers.set(
-    'Cache-Control',
-    isUncacheable ? PRIVATE_CACHE_CONTROL : ASSET_EXTENSION.test(pathname) ? ASSET_CACHE_CONTROL : HTML_CACHE_CONTROL,
-  )
+
+  // Default: do not cache. Every case below must explicitly opt in.
+  let cacheControl = PRIVATE_CACHE_CONTROL
+
+  if (ASSET_EXTENSION.test(pathname)) {
+    cacheControl = ASSET_CACHE_CONTROL
+  } else if (response.ok && !request.headers.has('Cookie') && !response.headers.has('Set-Cookie')) {
+    // A clean 2xx exchange with no session cookie on either side. This is
+    // the one non-asset case presumed safe: no auth, no per-visitor state.
+    cacheControl = HTML_CACHE_CONTROL
+  }
+
+  headers.set('Cache-Control', cacheControl)
 
   return new Response(response.body, {
     status: response.status,

--- a/integrations/shared/lib/cache-control.ts
+++ b/integrations/shared/lib/cache-control.ts
@@ -32,15 +32,23 @@
  * cacheable case must explicitly earn its way into a longer TTL. A new
  * response shape nobody has reasoned about yet inherits "not cached" —
  * unsafe-by-default instead of cached-by-default.
+ *
+ * Both cacheable cases below still require `response.ok && !Set-Cookie` —
+ * asset-extension path matching is a heuristic on the URL, not proof the
+ * response actually IS a safe static asset. Without that shared gate, a
+ * 404/error on an asset-shaped path gets pinned `immutable` for a year
+ * (purge-only recovery), and a response that happens to carry `Set-Cookie`
+ * on an asset-shaped path gets cached and replayed — the exact #2784 leak
+ * class, just reached through the asset branch instead of the HTML one.
  */
 
 const ASSET_EXTENSION = /\.(?:js|mjs|css|woff2?|ttf|svg|png|jpe?g|gif|webp|ico)$/
 
 const HTML_CACHE_CONTROL = 'public, max-age=3600, stale-while-revalidate=86400'
 // Vite fingerprints build output (content-hashed filenames), so an asset
-// URL either changes or never changes — safe to cache for a year, and this
-// holds regardless of Cookie/Set-Cookie state (no backend ever varies a
-// static asset's bytes by visitor).
+// URL either changes or never changes — safe to cache for a year, PROVIDED
+// the response is actually a successful, cookie-free asset response (see
+// the gate in withCacheControl below, not just the extension match here).
 const ASSET_CACHE_CONTROL = 'public, max-age=31536000, immutable'
 // The default. Must be set explicitly (not just "no Cache-Control") because
 // an absent header still gets Cloudflare's heuristic-freshness default TTL.
@@ -66,12 +74,20 @@ export function withCacheControl(request: Request, response: Response): Response
   // Default: do not cache. Every case below must explicitly opt in.
   let cacheControl = PRIVATE_CACHE_CONTROL
 
-  if (ASSET_EXTENSION.test(pathname)) {
-    cacheControl = ASSET_CACHE_CONTROL
-  } else if (response.ok && !request.headers.has('Cookie') && !response.headers.has('Set-Cookie')) {
-    // A clean 2xx exchange with no session cookie on either side. This is
-    // the one non-asset case presumed safe: no auth, no per-visitor state.
-    cacheControl = HTML_CACHE_CONTROL
+  // Shared gate for both cacheable cases: a non-2xx or Set-Cookie response
+  // is never cached, whether or not its path happens to look like an asset.
+  if (response.ok && !response.headers.has('Set-Cookie')) {
+    if (ASSET_EXTENSION.test(pathname)) {
+      cacheControl = ASSET_CACHE_CONTROL
+    } else if (!request.headers.has('Cookie')) {
+      // A clean 2xx exchange with no session cookie on either side. This is
+      // the one non-asset case presumed safe: no auth, no per-visitor state.
+      // (Assets don't need this extra Cookie check: a returning visitor's
+      // browser attaches the session cookie to every same-origin request,
+      // asset requests included, so gating assets on it too would defeat
+      // asset caching for exactly the repeat visits this exists to help.)
+      cacheControl = HTML_CACHE_CONTROL
+    }
   }
 
   headers.set('Cache-Control', cacheControl)

--- a/integrations/shared/package.json
+++ b/integrations/shared/package.json
@@ -5,7 +5,9 @@
   "description": "Shared components, styles, and tests for BarefootJS integrations",
   "exports": {
     "./components/*": "./components/*",
-    "./styles/*": "./styles/*"
+    "./styles/*": "./styles/*",
+    "./lib/*": "./lib/*",
+    "./lib/cache-control": "./lib/cache-control.ts"
   },
   "devDependencies": {
     "@barefootjs/client": "workspace:*",

--- a/integrations/sinatra/container.ts
+++ b/integrations/sinatra/container.ts
@@ -4,6 +4,7 @@
  */
 
 import { Container } from '@cloudflare/containers'
+import { withCacheControl } from 'barefootjs-integrations-shared/lib/cache-control'
 
 type Env = {
   SINATRA_CONTAINER: DurableObjectNamespace
@@ -22,6 +23,6 @@ export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const id = env.SINATRA_CONTAINER.idFromName('singleton')
     const stub = env.SINATRA_CONTAINER.get(id) as unknown as { fetch: typeof fetch }
-    return stub.fetch(request)
+    return withCacheControl(request, await stub.fetch(request))
   },
 } satisfies ExportedHandler<Env>

--- a/integrations/sinatra/package.json
+++ b/integrations/sinatra/package.json
@@ -13,7 +13,8 @@
   },
   "dependencies": {
     "@barefootjs/client": "workspace:*",
-    "@barefootjs/router": "workspace:*"
+    "@barefootjs/router": "workspace:*",
+    "barefootjs-integrations-shared": "workspace:*"
   },
   "devDependencies": {
     "@barefootjs/erb": "workspace:*",

--- a/integrations/sinatra/wrangler.toml
+++ b/integrations/sinatra/wrangler.toml
@@ -1,7 +1,10 @@
 name = "barefootjs-sinatra-example"
 main = "container.ts"
-compatibility_date = "2025-01-01"
+compatibility_date = "2026-08-29"
 compatibility_flags = ["nodejs_compat"]
+
+[cache]
+enabled = true
 
 [[containers]]
 class_name = "SinatraContainer"

--- a/integrations/xslate/container.ts
+++ b/integrations/xslate/container.ts
@@ -4,6 +4,7 @@
  */
 
 import { Container } from '@cloudflare/containers'
+import { withCacheControl } from 'barefootjs-integrations-shared/lib/cache-control'
 
 type Env = {
   XSLATE_CONTAINER: DurableObjectNamespace
@@ -22,6 +23,6 @@ export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const id = env.XSLATE_CONTAINER.idFromName('singleton')
     const stub = env.XSLATE_CONTAINER.get(id) as unknown as { fetch: typeof fetch }
-    return stub.fetch(request)
+    return withCacheControl(request, await stub.fetch(request))
   },
 } satisfies ExportedHandler<Env>

--- a/integrations/xslate/package.json
+++ b/integrations/xslate/package.json
@@ -13,7 +13,8 @@
   },
   "dependencies": {
     "@barefootjs/client": "workspace:*",
-    "@barefootjs/router": "workspace:*"
+    "@barefootjs/router": "workspace:*",
+    "barefootjs-integrations-shared": "workspace:*"
   },
   "devDependencies": {
     "@barefootjs/jsx": "workspace:*",

--- a/integrations/xslate/wrangler.toml
+++ b/integrations/xslate/wrangler.toml
@@ -1,7 +1,10 @@
 name = "barefootjs-xslate-example"
 main = "container.ts"
-compatibility_date = "2025-01-01"
+compatibility_date = "2026-08-29"
 compatibility_flags = ["nodejs_compat"]
+
+[cache]
+enabled = true
 
 [[containers]]
 class_name = "XslateContainer"


### PR DESCRIPTION
## Corrected re-enablement of #2784, after the #2790 revert

#2790 reverted #2784 (Workers Cache on all 15 Container-backed integrations) because of a live cross-session data leak. This PR reapplies that feature on top of the reverted `main`, with the bug fixed this time. Base is `main` — #2790 is already merged.

### The bug that shipped in #2784

`withCacheControl` skipped setting `Cache-Control` when the request carried a `Cookie` or the response carried `Set-Cookie`, on the assumption that an absent header keeps a response out of Workers Cache.

That's wrong: Cloudflare applies RFC 9111 heuristic freshness to any response with **no** `Cache-Control` — a 200 OK defaults to a 2h TTL. Every integration's Todo demo sends `Cookie` on repeat visits but mints no fresh `Set-Cookie`, so those session-specific responses got cached under the heuristic default and served to other visitors at the same path. Confirmed live on `https://barefootjs.dev/integrations/gin/todos`.

### The fix

`integrations/shared/lib/cache-control.ts` now sets an explicit `Cache-Control: private, no-store` for every uncacheable case (non-2xx, request `Cookie`, response `Set-Cookie`) instead of leaving the header absent. Also tightened the non-2xx branch the same way, since Cloudflare's heuristic-freshness default-TTL table covers several non-2xx statuses too, not just 200.

Tests in `integrations/shared/lib/__tests__/cache-control.test.ts` updated to assert the explicit value is present (not just that the header is absent), plus a new regression pin for the exact production-leak shape (`Cookie` present, no `Set-Cookie`, previously-headerless 200).

Everything else is identical to #2784: `[cache] enabled = true` in all 15 `integrations/*/wrangler.toml`, each `container.ts` shim routing its response through `withCacheControl`, and the `barefootjs-integrations-shared` package wiring.

### Test plan

- [x] `bun test integrations/shared/lib/__tests__/cache-control.test.ts` — 9 pass
- [x] `wrangler deploy --dry-run` bundles cleanly for an integration (flask) — fails only on the sandbox's missing Docker daemon for the Container image build, unrelated to this change
- [ ] Manually verify no cross-session leakage on a couple of integrations before merging (e.g. hit `/integrations/gin/todos` from two different sessions/cookie jars against a preview/staging deploy, if available)