### PR TITLE
Explicitly cache session-free routes across all 15 integrations

### DIFF
--- a/integrations/axum/src/ai_chat.rs
+++ b/integrations/axum/src/ai_chat.rs
@@ -6,7 +6,7 @@
 //! of a blocking one, so other in-flight requests aren't stalled).
 
 use crate::render::{empty_obj, jarr, jb, jobj, js, new_session, render_component};
-use crate::{app_static_href, html_response, layout, render_error, AppState, LayoutOpts};
+use crate::{app_static_href, html_response_cached, layout, render_error, AppState, LayoutOpts};
 use axum::extract::State;
 use axum::response::sse::{Event, Sse};
 use axum::response::Response;
@@ -32,7 +32,7 @@ pub async fn page_route(State(state): State<AppState>) -> Response {
     ]);
     let extra_css = format!(r#"<link rel="stylesheet" href="{}">"#, app_static_href(&state, "styles/ai-chat.css"));
     match render_component(&state, &session, "AIChatInteractive", empty_obj(), stash) {
-        Ok((body, scripts)) => html_response(layout(
+        Ok((body, scripts)) => html_response_cached(layout(
             &state,
             LayoutOpts {
                 title: "AI Chat -- SSE Streaming (Axum)".to_string(),

--- a/integrations/axum/src/blog.rs
+++ b/integrations/axum/src/blog.rs
@@ -30,7 +30,7 @@
 //! app.py`'s `blog_index_route` exactly (down to `as_sort_key`).
 
 use crate::render::{empty_obj, jarr, jn, jobj, js, new_session, render_component_with_raw_children, render_island, scripts_html};
-use crate::{html_response, AppState};
+use crate::{html_response_cached, AppState};
 use axum::extract::{Path, RawQuery, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
@@ -243,7 +243,7 @@ pub async fn index_route(State(state): State<AppState>, RawQuery(query): RawQuer
 
     let title = if tag.is_empty() { "Barefoot Blog \u{2014} Latest posts".to_string() } else { format!("#{tag} \u{2014} Barefoot Blog") };
     match blog_page(&state, &session, &title, &format!("{post_list}{now_playing}")) {
-        Ok(html) => html_response(html),
+        Ok(html) => html_response_cached(html),
         Err(e) => crate::render_error(e),
     }
 }
@@ -291,7 +291,7 @@ pub async fn post_route(State(state): State<AppState>, Path(slug): Path<String>)
         Err(e) => return crate::render_error(e),
     };
     match blog_page(&state, &session, &format!("{} \u{2014} Barefoot Blog", post.title), &content) {
-        Ok(html) => html_response(html),
+        Ok(html) => html_response_cached(html),
         Err(e) => crate::render_error(e),
     }
 }

--- a/integrations/axum/src/main.rs
+++ b/integrations/axum/src/main.rs
@@ -225,6 +225,27 @@ pub(crate) fn html_response(html: String) -> Response {
     (StatusCode::OK, [(header::CONTENT_TYPE, "text/html; charset=utf-8")], html).into_response()
 }
 
+/// Like [`html_response`], but for routes confirmed session-free (no cookie
+/// read, no per-visitor state) -- sets `Cache-Control` explicitly so
+/// `integrations/shared/lib/cache-control.ts`'s `withCacheControl` (which
+/// leaves a response alone once the backend has already set its own
+/// `Cache-Control`) makes this route cacheable even when the visitor's
+/// browser happens to still be carrying a stale `bf_session` cookie from an
+/// earlier `/todos` visit (that cookie's `Path` is the whole integration,
+/// not `/todos` -- see the container.ts cache-control docstring). The value
+/// MUST match `HTML_CACHE_CONTROL` in that file verbatim.
+pub(crate) fn html_response_cached(html: String) -> Response {
+    (
+        StatusCode::OK,
+        [
+            (header::CONTENT_TYPE, "text/html; charset=utf-8"),
+            (header::CACHE_CONTROL, "public, max-age=3600, stale-while-revalidate=86400"),
+        ],
+        html,
+    )
+        .into_response()
+}
+
 pub fn render_error(err: String) -> Response {
     eprintln!("barefoot: render error: {err}");
     (StatusCode::INTERNAL_SERVER_ERROR, [(header::CONTENT_TYPE, "text/plain; charset=utf-8")], err).into_response()
@@ -251,7 +272,7 @@ runtime crate (minijinja) as the rendering backend.</p>
     <li><a href="{base}/blog">Blog (@barefootjs/router - partial navigation)</a></li>
 </ul>"#
     );
-    html_response(layout(
+    html_response_cached(layout(
         &state,
         LayoutOpts {
             title: "BarefootJS + Axum Example".to_string(),
@@ -267,7 +288,7 @@ runtime crate (minijinja) as the rendering backend.</p>
 async fn counter_route(State(state): State<AppState>) -> Response {
     let session = new_session(&state, &Default::default());
     match render_component(&state, &session, "Counter", empty_obj(), empty_obj()) {
-        Ok((body, scripts)) => html_response(layout(
+        Ok((body, scripts)) => html_response_cached(layout(
             &state,
             LayoutOpts {
                 title: "Counter - BarefootJS".to_string(),
@@ -288,7 +309,7 @@ async fn toggle_route(State(state): State<AppState>) -> Response {
     let props = jobj([("toggleItems", items.clone())]);
     let stash = jobj([("toggleItems", items)]);
     match render_component(&state, &session, "Toggle", props, stash) {
-        Ok((body, scripts)) => html_response(layout(
+        Ok((body, scripts)) => html_response_cached(layout(
             &state,
             LayoutOpts {
                 title: "Toggle - BarefootJS".to_string(),
@@ -315,7 +336,7 @@ async fn form_route(State(state): State<AppState>) -> Response {
     let session = new_session(&state, &Default::default());
     let stash = jobj([("accepted", jb(false))]);
     match render_component(&state, &session, "Form", empty_obj(), stash) {
-        Ok((body, scripts)) => html_response(layout(
+        Ok((body, scripts)) => html_response_cached(layout(
             &state,
             LayoutOpts {
                 title: "Form - BarefootJS".to_string(),
@@ -334,7 +355,7 @@ async fn portal_route(State(state): State<AppState>) -> Response {
     let session = new_session(&state, &Default::default());
     let stash = jobj([("open", jb(false))]);
     match render_component(&state, &session, "PortalExample", empty_obj(), stash) {
-        Ok((body, scripts)) => html_response(layout(
+        Ok((body, scripts)) => html_response_cached(layout(
             &state,
             LayoutOpts {
                 title: "Portal - BarefootJS".to_string(),
@@ -353,7 +374,7 @@ async fn reactive_props_route(State(state): State<AppState>) -> Response {
     let session = new_session(&state, &Default::default());
     let stash = jobj([("count", jn(0.0)), ("doubled", jn(0.0))]);
     match render_component(&state, &session, "ReactiveProps", empty_obj(), stash) {
-        Ok((body, scripts)) => html_response(layout(
+        Ok((body, scripts)) => html_response_cached(layout(
             &state,
             LayoutOpts {
                 title: "Reactive Props - BarefootJS".to_string(),
@@ -376,7 +397,7 @@ async fn props_reactivity_route(State(state): State<AppState>) -> Response {
     let session = new_session(&state, &Default::default());
     let stash = jobj([("count", jn(1.0))]);
     match render_component(&state, &session, "PropsReactivityComparison", empty_obj(), stash) {
-        Ok((body, scripts)) => html_response(layout(
+        Ok((body, scripts)) => html_response_cached(layout(
             &state,
             LayoutOpts {
                 title: "Props Reactivity - BarefootJS".to_string(),
@@ -415,7 +436,7 @@ async fn render_conditional_return(state: AppState, variant: &str) -> Response {
     };
     match render_component(&state, &session, "ConditionalReturn", props, stash) {
         Ok((body, scripts)) => {
-            html_response(layout(&state, LayoutOpts { title, heading, body, scripts, extra_css: String::new(), back: None }))
+            html_response_cached(layout(&state, LayoutOpts { title, heading, body, scripts, extra_css: String::new(), back: None }))
         }
         Err(e) => render_error(e),
     }

--- a/integrations/blade/index.php
+++ b/integrations/blade/index.php
@@ -172,6 +172,7 @@ function stash_from_ssr_defaults(string $component, array $props): array
 // ---------------------------------------------------------------------------
 const SESSION_COOKIE = 'bf_session';
 const SESSION_TTL_SEC = 60 * 60 * 24 * 30;
+const CACHE_CONTROL_HEADER = 'Cache-Control: public, max-age=3600, stale-while-revalidate=86400';
 
 function seed_todos(): array
 {
@@ -675,7 +676,7 @@ function blog_index_route(): void
     );
     $now = blog_island($root, 'NowPlaying', [], ['Math' => ['min' => 0]]);
     $title = $tag !== '' ? "#{$tag} \u{2014} Barefoot Blog" : 'Barefoot Blog \u{2014} Latest posts';
-    header('Cache-Control: public, max-age=3600, stale-while-revalidate=86400');
+    header(CACHE_CONTROL_HEADER);
     html_response(blog_page($root, $title, $base, $postList . $now));
 }
 
@@ -727,7 +728,7 @@ function blog_post_route(string $slug): void
             'now_playing' => ['NowPlaying', ['Math' => ['min' => 0]]],
         ],
     );
-    header('Cache-Control: public, max-age=3600, stale-while-revalidate=86400');
+    header(CACHE_CONTROL_HEADER);
     html_response(blog_page($root, "{$p['title']} \u{2014} Barefoot Blog", $base, $content));
 }
 
@@ -932,12 +933,12 @@ if ($method === 'GET') {
             // regardless of a stale bf_session cookie the visitor's browser
             // may still be sending from an earlier /todos visit (see
             // integrations/shared/lib/cache-control.ts).
-            header('Cache-Control: public, max-age=3600, stale-while-revalidate=86400');
+            header(CACHE_CONTROL_HEADER);
             html_response(home_page());
             exit;
 
         case $route === '/counter':
-            header('Cache-Control: public, max-age=3600, stale-while-revalidate=86400');
+            header(CACHE_CONTROL_HEADER);
             html_response(render_component('Counter', heading: 'Counter Component'));
             exit;
 
@@ -947,7 +948,7 @@ if ($method === 'GET') {
                 ['label' => 'Setting 2', 'defaultOn' => false],
                 ['label' => 'Setting 3', 'defaultOn' => false],
             ];
-            header('Cache-Control: public, max-age=3600, stale-while-revalidate=86400');
+            header(CACHE_CONTROL_HEADER);
             html_response(render_component(
                 'Toggle',
                 heading: 'Toggle Component',
@@ -958,12 +959,12 @@ if ($method === 'GET') {
             exit;
 
         case $route === '/form':
-            header('Cache-Control: public, max-age=3600, stale-while-revalidate=86400');
+            header(CACHE_CONTROL_HEADER);
             html_response(render_component('Form', heading: 'Form Example', props: [], stash: ['accepted' => false]));
             exit;
 
         case $route === '/reactive-props':
-            header('Cache-Control: public, max-age=3600, stale-while-revalidate=86400');
+            header(CACHE_CONTROL_HEADER);
             html_response(render_component(
                 'ReactiveProps',
                 heading: 'Reactive Props Test',
@@ -982,7 +983,7 @@ if ($method === 'GET') {
             // signal_init override needed here: PropsStyleChild /
             // DestructuredStyleChild's compiled templates already derive
             // `displayValue` in-template (`{% set displayValue = value * 10 %}`).
-            header('Cache-Control: public, max-age=3600, stale-while-revalidate=86400');
+            header(CACHE_CONTROL_HEADER);
             html_response(render_component(
                 'PropsReactivityComparison',
                 heading: 'Props Reactivity Comparison',
@@ -997,7 +998,7 @@ if ($method === 'GET') {
 
         case $route === '/conditional-return' || $route === '/conditional-return-link':
             $variant = str_ends_with($route, '-link') ? 'link' : '';
-            header('Cache-Control: public, max-age=3600, stale-while-revalidate=86400');
+            header(CACHE_CONTROL_HEADER);
             html_response(render_component(
                 'ConditionalReturn',
                 heading: 'Conditional Return Example' . ($variant !== '' ? ' (Link)' : ''),
@@ -1007,12 +1008,12 @@ if ($method === 'GET') {
             exit;
 
         case $route === '/portal':
-            header('Cache-Control: public, max-age=3600, stale-while-revalidate=86400');
+            header(CACHE_CONTROL_HEADER);
             html_response(render_component('PortalExample', heading: 'Portal Example', props: [], stash: ['open' => false]));
             exit;
 
         case $route === '/ai-chat':
-            header('Cache-Control: public, max-age=3600, stale-while-revalidate=86400');
+            header(CACHE_CONTROL_HEADER);
             html_response(render_component(
                 'AIChatInteractive',
                 title: 'AI Chat -- SSE Streaming (Blade)',

--- a/integrations/blade/index.php
+++ b/integrations/blade/index.php
@@ -675,6 +675,7 @@ function blog_index_route(): void
     );
     $now = blog_island($root, 'NowPlaying', [], ['Math' => ['min' => 0]]);
     $title = $tag !== '' ? "#{$tag} \u{2014} Barefoot Blog" : 'Barefoot Blog \u{2014} Latest posts';
+    header('Cache-Control: public, max-age=3600, stale-while-revalidate=86400');
     html_response(blog_page($root, $title, $base, $postList . $now));
 }
 
@@ -726,6 +727,7 @@ function blog_post_route(string $slug): void
             'now_playing' => ['NowPlaying', ['Math' => ['min' => 0]]],
         ],
     );
+    header('Cache-Control: public, max-age=3600, stale-while-revalidate=86400');
     html_response(blog_page($root, "{$p['title']} \u{2014} Barefoot Blog", $base, $content));
 }
 
@@ -926,10 +928,16 @@ if (preg_match('#^/blog/posts/([^/]+)$#', $route, $m) && $method === 'GET') {
 if ($method === 'GET') {
     switch (true) {
         case $route === '/':
+            // Session-free demo route: cacheable at the Workers Cache layer
+            // regardless of a stale bf_session cookie the visitor's browser
+            // may still be sending from an earlier /todos visit (see
+            // integrations/shared/lib/cache-control.ts).
+            header('Cache-Control: public, max-age=3600, stale-while-revalidate=86400');
             html_response(home_page());
             exit;
 
         case $route === '/counter':
+            header('Cache-Control: public, max-age=3600, stale-while-revalidate=86400');
             html_response(render_component('Counter', heading: 'Counter Component'));
             exit;
 
@@ -939,6 +947,7 @@ if ($method === 'GET') {
                 ['label' => 'Setting 2', 'defaultOn' => false],
                 ['label' => 'Setting 3', 'defaultOn' => false],
             ];
+            header('Cache-Control: public, max-age=3600, stale-while-revalidate=86400');
             html_response(render_component(
                 'Toggle',
                 heading: 'Toggle Component',
@@ -949,10 +958,12 @@ if ($method === 'GET') {
             exit;
 
         case $route === '/form':
+            header('Cache-Control: public, max-age=3600, stale-while-revalidate=86400');
             html_response(render_component('Form', heading: 'Form Example', props: [], stash: ['accepted' => false]));
             exit;
 
         case $route === '/reactive-props':
+            header('Cache-Control: public, max-age=3600, stale-while-revalidate=86400');
             html_response(render_component(
                 'ReactiveProps',
                 heading: 'Reactive Props Test',
@@ -971,6 +982,7 @@ if ($method === 'GET') {
             // signal_init override needed here: PropsStyleChild /
             // DestructuredStyleChild's compiled templates already derive
             // `displayValue` in-template (`{% set displayValue = value * 10 %}`).
+            header('Cache-Control: public, max-age=3600, stale-while-revalidate=86400');
             html_response(render_component(
                 'PropsReactivityComparison',
                 heading: 'Props Reactivity Comparison',
@@ -985,6 +997,7 @@ if ($method === 'GET') {
 
         case $route === '/conditional-return' || $route === '/conditional-return-link':
             $variant = str_ends_with($route, '-link') ? 'link' : '';
+            header('Cache-Control: public, max-age=3600, stale-while-revalidate=86400');
             html_response(render_component(
                 'ConditionalReturn',
                 heading: 'Conditional Return Example' . ($variant !== '' ? ' (Link)' : ''),
@@ -994,10 +1007,12 @@ if ($method === 'GET') {
             exit;
 
         case $route === '/portal':
+            header('Cache-Control: public, max-age=3600, stale-while-revalidate=86400');
             html_response(render_component('PortalExample', heading: 'Portal Example', props: [], stash: ['open' => false]));
             exit;
 
         case $route === '/ai-chat':
+            header('Cache-Control: public, max-age=3600, stale-while-revalidate=86400');
             html_response(render_component(
                 'AIChatInteractive',
                 title: 'AI Chat -- SSE Streaming (Blade)',

--- a/integrations/chi/blog.go
+++ b/integrations/chi/blog.go
@@ -209,7 +209,7 @@ func validSortKey(raw string) string {
 // via searchParams() on the client; on the server the same query drives both
 // `NewPostListProps` (active highlight + hrefs) and the SSR row order/visibility.
 func blogIndexHandler(w http.ResponseWriter, req *http.Request) {
-	w.Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
+	w.Header().Set("Cache-Control", cacheableCacheControl)
 	sp := bf.NewSearchParams(req.URL.RawQuery)
 	sortKey := validSortKey(sp.Get("sort"))
 	tag := sp.Get("tag")
@@ -251,7 +251,7 @@ func blogPostHandler(w http.ResponseWriter, req *http.Request) {
 		http.NotFound(w, req)
 		return
 	}
-	w.Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
+	w.Header().Set("Cache-Control", cacheableCacheControl)
 	in := PostArticleInput{
 		Slug:      a.Post.Slug,
 		Title:     a.Post.Title,

--- a/integrations/chi/blog.go
+++ b/integrations/chi/blog.go
@@ -209,6 +209,7 @@ func validSortKey(raw string) string {
 // via searchParams() on the client; on the server the same query drives both
 // `NewPostListProps` (active highlight + hrefs) and the SSR row order/visibility.
 func blogIndexHandler(w http.ResponseWriter, req *http.Request) {
+	w.Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
 	sp := bf.NewSearchParams(req.URL.RawQuery)
 	sortKey := validSortKey(sp.Get("sort"))
 	tag := sp.Get("tag")
@@ -250,6 +251,7 @@ func blogPostHandler(w http.ResponseWriter, req *http.Request) {
 		http.NotFound(w, req)
 		return
 	}
+	w.Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
 	in := PostArticleInput{
 		Slug:      a.Post.Slug,
 		Title:     a.Post.Title,

--- a/integrations/chi/main.go
+++ b/integrations/chi/main.go
@@ -326,6 +326,7 @@ func main() {
 }
 
 func indexHandler(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
 	body := fmt.Sprintf(`
     <h1>BarefootJS + Chi Example</h1>
     <p>This example demonstrates server-side rendering with Go Chi and BarefootJS.</p>
@@ -356,6 +357,7 @@ func indexHandler(w http.ResponseWriter, _ *http.Request) {
 }
 
 func counterHandler(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
 	props := NewCounterProps(CounterInput{Initial: 0})
 	render(w, http.StatusOK, "Counter", bf.RenderOptions{
 		Props:   &props,
@@ -365,6 +367,7 @@ func counterHandler(w http.ResponseWriter, _ *http.Request) {
 }
 
 func toggleHandler(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
 	props := NewToggleProps(ToggleInput{
 		ToggleItems: []ToggleItemInput{
 			{Label: "Setting 1", DefaultOn: true},
@@ -428,6 +431,7 @@ func todosSSRHandler(w http.ResponseWriter, req *http.Request) {
 }
 
 func reactivePropsHandler(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
 	props := NewReactivePropsProps(ReactivePropsInput{})
 	render(w, http.StatusOK, "ReactiveProps", bf.RenderOptions{
 		Props:   &props,
@@ -437,6 +441,7 @@ func reactivePropsHandler(w http.ResponseWriter, _ *http.Request) {
 }
 
 func propsReactivityHandler(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
 	props := NewPropsReactivityComparisonProps(PropsReactivityComparisonInput{})
 	render(w, http.StatusOK, "PropsReactivityComparison", bf.RenderOptions{
 		Props:   &props,
@@ -446,6 +451,7 @@ func propsReactivityHandler(w http.ResponseWriter, _ *http.Request) {
 }
 
 func formHandler(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
 	props := NewFormProps(FormInput{})
 	render(w, http.StatusOK, "Form", bf.RenderOptions{
 		Props:   &props,
@@ -455,6 +461,7 @@ func formHandler(w http.ResponseWriter, _ *http.Request) {
 }
 
 func portalHandler(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
 	props := NewPortalExampleProps(PortalExampleInput{})
 	render(w, http.StatusOK, "PortalExample", bf.RenderOptions{
 		Props:   &props,
@@ -464,6 +471,7 @@ func portalHandler(w http.ResponseWriter, _ *http.Request) {
 }
 
 func conditionalReturnHandler(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
 	props := NewConditionalReturnProps(ConditionalReturnInput{})
 	render(w, http.StatusOK, "ConditionalReturn", bf.RenderOptions{
 		Props:   &props,
@@ -473,6 +481,7 @@ func conditionalReturnHandler(w http.ResponseWriter, _ *http.Request) {
 }
 
 func conditionalReturnLinkHandler(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
 	props := NewConditionalReturnProps(ConditionalReturnInput{Variant: "link"})
 	render(w, http.StatusOK, "ConditionalReturn", bf.RenderOptions{
 		Props:   &props,
@@ -589,6 +598,7 @@ var fakeResponses = []string{
 }
 
 func aiChatHandler(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
 	props := NewAIChatInteractiveProps(AIChatInteractiveInput{})
 	render(w, http.StatusOK, "AIChatInteractive", bf.RenderOptions{
 		Props:   &props,

--- a/integrations/chi/main.go
+++ b/integrations/chi/main.go
@@ -158,9 +158,10 @@ func writeJSON(w http.ResponseWriter, status int, v interface{}) {
 // visitor's list is never visible to another. LRU-bounded to keep memory
 // usage predictable.
 const (
-	sessionCookieName = "bf_session"
-	sessionTTLSeconds = 60 * 60 * 24 * 30 // 30d
-	sessionStoreMax   = 1000
+	sessionCookieName     = "bf_session"
+	sessionTTLSeconds     = 60 * 60 * 24 * 30 // 30d
+	sessionStoreMax       = 1000
+	cacheableCacheControl = "public, max-age=3600, stale-while-revalidate=86400"
 )
 
 type sessionState struct {
@@ -326,7 +327,7 @@ func main() {
 }
 
 func indexHandler(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
+	w.Header().Set("Cache-Control", cacheableCacheControl)
 	body := fmt.Sprintf(`
     <h1>BarefootJS + Chi Example</h1>
     <p>This example demonstrates server-side rendering with Go Chi and BarefootJS.</p>
@@ -357,7 +358,7 @@ func indexHandler(w http.ResponseWriter, _ *http.Request) {
 }
 
 func counterHandler(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
+	w.Header().Set("Cache-Control", cacheableCacheControl)
 	props := NewCounterProps(CounterInput{Initial: 0})
 	render(w, http.StatusOK, "Counter", bf.RenderOptions{
 		Props:   &props,
@@ -367,7 +368,7 @@ func counterHandler(w http.ResponseWriter, _ *http.Request) {
 }
 
 func toggleHandler(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
+	w.Header().Set("Cache-Control", cacheableCacheControl)
 	props := NewToggleProps(ToggleInput{
 		ToggleItems: []ToggleItemInput{
 			{Label: "Setting 1", DefaultOn: true},
@@ -431,7 +432,7 @@ func todosSSRHandler(w http.ResponseWriter, req *http.Request) {
 }
 
 func reactivePropsHandler(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
+	w.Header().Set("Cache-Control", cacheableCacheControl)
 	props := NewReactivePropsProps(ReactivePropsInput{})
 	render(w, http.StatusOK, "ReactiveProps", bf.RenderOptions{
 		Props:   &props,
@@ -441,7 +442,7 @@ func reactivePropsHandler(w http.ResponseWriter, _ *http.Request) {
 }
 
 func propsReactivityHandler(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
+	w.Header().Set("Cache-Control", cacheableCacheControl)
 	props := NewPropsReactivityComparisonProps(PropsReactivityComparisonInput{})
 	render(w, http.StatusOK, "PropsReactivityComparison", bf.RenderOptions{
 		Props:   &props,
@@ -451,7 +452,7 @@ func propsReactivityHandler(w http.ResponseWriter, _ *http.Request) {
 }
 
 func formHandler(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
+	w.Header().Set("Cache-Control", cacheableCacheControl)
 	props := NewFormProps(FormInput{})
 	render(w, http.StatusOK, "Form", bf.RenderOptions{
 		Props:   &props,
@@ -461,7 +462,7 @@ func formHandler(w http.ResponseWriter, _ *http.Request) {
 }
 
 func portalHandler(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
+	w.Header().Set("Cache-Control", cacheableCacheControl)
 	props := NewPortalExampleProps(PortalExampleInput{})
 	render(w, http.StatusOK, "PortalExample", bf.RenderOptions{
 		Props:   &props,
@@ -471,7 +472,7 @@ func portalHandler(w http.ResponseWriter, _ *http.Request) {
 }
 
 func conditionalReturnHandler(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
+	w.Header().Set("Cache-Control", cacheableCacheControl)
 	props := NewConditionalReturnProps(ConditionalReturnInput{})
 	render(w, http.StatusOK, "ConditionalReturn", bf.RenderOptions{
 		Props:   &props,
@@ -481,7 +482,7 @@ func conditionalReturnHandler(w http.ResponseWriter, _ *http.Request) {
 }
 
 func conditionalReturnLinkHandler(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
+	w.Header().Set("Cache-Control", cacheableCacheControl)
 	props := NewConditionalReturnProps(ConditionalReturnInput{Variant: "link"})
 	render(w, http.StatusOK, "ConditionalReturn", bf.RenderOptions{
 		Props:   &props,
@@ -598,7 +599,7 @@ var fakeResponses = []string{
 }
 
 func aiChatHandler(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
+	w.Header().Set("Cache-Control", cacheableCacheControl)
 	props := NewAIChatInteractiveProps(AIChatInteractiveInput{})
 	render(w, http.StatusOK, "AIChatInteractive", bf.RenderOptions{
 		Props:   &props,

--- a/integrations/django/app.py
+++ b/integrations/django/app.py
@@ -378,16 +378,18 @@ AI_RESPONSES = [
 CACHEABLE_CACHE_CONTROL = "public, max-age=3600, stale-while-revalidate=86400"
 
 
-def home_route(request):
-    response = html_response(home_page())
+def html_response_cached(html: str, status: int = 200) -> HttpResponse:
+    response = html_response(html, status)
     response["Cache-Control"] = CACHEABLE_CACHE_CONTROL
     return response
+
+
+def home_route(request):
+    return html_response_cached(home_page())
 
 
 def counter_route(request):
-    response = html_response(render_component("Counter", heading="Counter Component"))
-    response["Cache-Control"] = CACHEABLE_CACHE_CONTROL
-    return response
+    return html_response_cached(render_component("Counter", heading="Counter Component"))
 
 
 def toggle_route(request):
@@ -396,7 +398,7 @@ def toggle_route(request):
         {"label": "Setting 2", "defaultOn": False},
         {"label": "Setting 3", "defaultOn": False},
     ]
-    response = html_response(
+    return html_response_cached(
         render_component(
             "Toggle",
             heading="Toggle Component",
@@ -405,18 +407,14 @@ def toggle_route(request):
             stash={"toggleItems": items},
         )
     )
-    response["Cache-Control"] = CACHEABLE_CACHE_CONTROL
-    return response
 
 
 def form_route(request):
-    response = html_response(render_component("Form", heading="Form Example", props={}, stash={"accepted": False}))
-    response["Cache-Control"] = CACHEABLE_CACHE_CONTROL
-    return response
+    return html_response_cached(render_component("Form", heading="Form Example", props={}, stash={"accepted": False}))
 
 
 def reactive_props_route(request):
-    response = html_response(
+    return html_response_cached(
         render_component(
             "ReactiveProps",
             heading="Reactive Props Test",
@@ -425,8 +423,6 @@ def reactive_props_route(request):
             stash={"count": 0, "doubled": 0},
         )
     )
-    response["Cache-Control"] = CACHEABLE_CACHE_CONTROL
-    return response
 
 
 def props_reactivity_route(request):
@@ -438,7 +434,7 @@ def props_reactivity_route(request):
     # override is needed here (unlike app.psgi's Kolon port): PropsStyleChild
     # / DestructuredStyleChild's compiled templates already derive
     # `displayValue` in-template (`{% set displayValue = value * 10 %}`).
-    response = html_response(
+    return html_response_cached(
         render_component(
             "PropsReactivityComparison",
             heading="Props Reactivity Comparison",
@@ -450,13 +446,11 @@ def props_reactivity_route(request):
             stash={"count": 1},
         )
     )
-    response["Cache-Control"] = CACHEABLE_CACHE_CONTROL
-    return response
 
 
 def conditional_return_route(request):
     variant = "link" if request.path.endswith("-link") else ""
-    response = html_response(
+    return html_response_cached(
         render_component(
             "ConditionalReturn",
             heading="Conditional Return Example" + (" (Link)" if variant else ""),
@@ -464,18 +458,14 @@ def conditional_return_route(request):
             stash={"variant": variant, "count": 0},
         )
     )
-    response["Cache-Control"] = CACHEABLE_CACHE_CONTROL
-    return response
 
 
 def portal_route(request):
-    response = html_response(render_component("PortalExample", heading="Portal Example", props={}, stash={"open": False}))
-    response["Cache-Control"] = CACHEABLE_CACHE_CONTROL
-    return response
+    return html_response_cached(render_component("PortalExample", heading="Portal Example", props={}, stash={"open": False}))
 
 
 def ai_chat_route(request):
-    response = html_response(
+    return html_response_cached(
         render_component(
             "AIChatInteractive",
             title="AI Chat -- SSE Streaming (Django)",
@@ -484,8 +474,6 @@ def ai_chat_route(request):
             extra_css=f'<link rel="stylesheet" href="{BASE}/styles/ai-chat.css">',
         )
     )
-    response["Cache-Control"] = CACHEABLE_CACHE_CONTROL
-    return response
 
 
 def todos_route(request):
@@ -796,9 +784,7 @@ def blog_index_route(request):
     )
     now = blog_island(root, "NowPlaying", {}, {"Math": {"min": 0}})
     title = f"#{tag} — Barefoot Blog" if tag else "Barefoot Blog — Latest posts"
-    response = html_response(blog_page(root, title, base, post_list + now))
-    response["Cache-Control"] = CACHEABLE_CACHE_CONTROL
-    return response
+    return html_response_cached(blog_page(root, title, base, post_list + now))
 
 
 def blog_post_route(request, slug: str):
@@ -834,9 +820,7 @@ def blog_post_route(request, slug: str):
             "now_playing": ("NowPlaying", {"Math": {"min": 0}}),
         },
     )
-    response = html_response(blog_page(root, f"{p['title']} — Barefoot Blog", base, content))
-    response["Cache-Control"] = CACHEABLE_CACHE_CONTROL
-    return response
+    return html_response_cached(blog_page(root, f"{p['title']} — Barefoot Blog", base, content))
 
 
 def home_page() -> str:

--- a/integrations/django/app.py
+++ b/integrations/django/app.py
@@ -367,12 +367,27 @@ AI_RESPONSES = [
 # ---------------------------------------------------------------------------
 
 
+# These routes never touch SESSIONS / the bf_session cookie, but a visitor
+# who has EVER hit /todos in this integration still sends that cookie on
+# every later request here (its Path is the whole integration base, not
+# scoped to /todos -- see cache-control.ts). Setting Cache-Control explicitly
+# opts them back into Workers Cache regardless of a stale session cookie,
+# without weakening the shared helper's default for any route that doesn't
+# opt in. Must match HTML_CACHE_CONTROL in
+# integrations/shared/lib/cache-control.ts verbatim.
+CACHEABLE_CACHE_CONTROL = "public, max-age=3600, stale-while-revalidate=86400"
+
+
 def home_route(request):
-    return html_response(home_page())
+    response = html_response(home_page())
+    response["Cache-Control"] = CACHEABLE_CACHE_CONTROL
+    return response
 
 
 def counter_route(request):
-    return html_response(render_component("Counter", heading="Counter Component"))
+    response = html_response(render_component("Counter", heading="Counter Component"))
+    response["Cache-Control"] = CACHEABLE_CACHE_CONTROL
+    return response
 
 
 def toggle_route(request):
@@ -381,7 +396,7 @@ def toggle_route(request):
         {"label": "Setting 2", "defaultOn": False},
         {"label": "Setting 3", "defaultOn": False},
     ]
-    return html_response(
+    response = html_response(
         render_component(
             "Toggle",
             heading="Toggle Component",
@@ -390,14 +405,18 @@ def toggle_route(request):
             stash={"toggleItems": items},
         )
     )
+    response["Cache-Control"] = CACHEABLE_CACHE_CONTROL
+    return response
 
 
 def form_route(request):
-    return html_response(render_component("Form", heading="Form Example", props={}, stash={"accepted": False}))
+    response = html_response(render_component("Form", heading="Form Example", props={}, stash={"accepted": False}))
+    response["Cache-Control"] = CACHEABLE_CACHE_CONTROL
+    return response
 
 
 def reactive_props_route(request):
-    return html_response(
+    response = html_response(
         render_component(
             "ReactiveProps",
             heading="Reactive Props Test",
@@ -406,6 +425,8 @@ def reactive_props_route(request):
             stash={"count": 0, "doubled": 0},
         )
     )
+    response["Cache-Control"] = CACHEABLE_CACHE_CONTROL
+    return response
 
 
 def props_reactivity_route(request):
@@ -417,7 +438,7 @@ def props_reactivity_route(request):
     # override is needed here (unlike app.psgi's Kolon port): PropsStyleChild
     # / DestructuredStyleChild's compiled templates already derive
     # `displayValue` in-template (`{% set displayValue = value * 10 %}`).
-    return html_response(
+    response = html_response(
         render_component(
             "PropsReactivityComparison",
             heading="Props Reactivity Comparison",
@@ -429,11 +450,13 @@ def props_reactivity_route(request):
             stash={"count": 1},
         )
     )
+    response["Cache-Control"] = CACHEABLE_CACHE_CONTROL
+    return response
 
 
 def conditional_return_route(request):
     variant = "link" if request.path.endswith("-link") else ""
-    return html_response(
+    response = html_response(
         render_component(
             "ConditionalReturn",
             heading="Conditional Return Example" + (" (Link)" if variant else ""),
@@ -441,14 +464,18 @@ def conditional_return_route(request):
             stash={"variant": variant, "count": 0},
         )
     )
+    response["Cache-Control"] = CACHEABLE_CACHE_CONTROL
+    return response
 
 
 def portal_route(request):
-    return html_response(render_component("PortalExample", heading="Portal Example", props={}, stash={"open": False}))
+    response = html_response(render_component("PortalExample", heading="Portal Example", props={}, stash={"open": False}))
+    response["Cache-Control"] = CACHEABLE_CACHE_CONTROL
+    return response
 
 
 def ai_chat_route(request):
-    return html_response(
+    response = html_response(
         render_component(
             "AIChatInteractive",
             title="AI Chat -- SSE Streaming (Django)",
@@ -457,6 +484,8 @@ def ai_chat_route(request):
             extra_css=f'<link rel="stylesheet" href="{BASE}/styles/ai-chat.css">',
         )
     )
+    response["Cache-Control"] = CACHEABLE_CACHE_CONTROL
+    return response
 
 
 def todos_route(request):
@@ -767,7 +796,9 @@ def blog_index_route(request):
     )
     now = blog_island(root, "NowPlaying", {}, {"Math": {"min": 0}})
     title = f"#{tag} — Barefoot Blog" if tag else "Barefoot Blog — Latest posts"
-    return html_response(blog_page(root, title, base, post_list + now))
+    response = html_response(blog_page(root, title, base, post_list + now))
+    response["Cache-Control"] = CACHEABLE_CACHE_CONTROL
+    return response
 
 
 def blog_post_route(request, slug: str):
@@ -803,7 +834,9 @@ def blog_post_route(request, slug: str):
             "now_playing": ("NowPlaying", {"Math": {"min": 0}}),
         },
     )
-    return html_response(blog_page(root, f"{p['title']} — Barefoot Blog", base, content))
+    response = html_response(blog_page(root, f"{p['title']} — Barefoot Blog", base, content))
+    response["Cache-Control"] = CACHEABLE_CACHE_CONTROL
+    return response
 
 
 def home_page() -> str:

--- a/integrations/echo/blog.go
+++ b/integrations/echo/blog.go
@@ -202,6 +202,7 @@ func validSortKey(raw string) string {
 // via searchParams() on the client; on the server the same query drives both
 // `NewPostListProps` (active highlight + hrefs) and the SSR row order/visibility.
 func blogIndexHandler(c echo.Context) error {
+	c.Response().Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
 	sp := bf.NewSearchParams(c.Request().URL.RawQuery)
 	sortKey := validSortKey(sp.Get("sort"))
 	tag := sp.Get("tag")
@@ -242,6 +243,7 @@ func blogPostHandler(c echo.Context) error {
 	if !a.Found {
 		return echo.NewHTTPError(http.StatusNotFound)
 	}
+	c.Response().Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
 	in := PostArticleInput{
 		Slug:      a.Post.Slug,
 		Title:     a.Post.Title,

--- a/integrations/echo/blog.go
+++ b/integrations/echo/blog.go
@@ -202,7 +202,7 @@ func validSortKey(raw string) string {
 // via searchParams() on the client; on the server the same query drives both
 // `NewPostListProps` (active highlight + hrefs) and the SSR row order/visibility.
 func blogIndexHandler(c echo.Context) error {
-	c.Response().Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
+	c.Response().Header().Set("Cache-Control", cacheableCacheControl)
 	sp := bf.NewSearchParams(c.Request().URL.RawQuery)
 	sortKey := validSortKey(sp.Get("sort"))
 	tag := sp.Get("tag")
@@ -243,7 +243,7 @@ func blogPostHandler(c echo.Context) error {
 	if !a.Found {
 		return echo.NewHTTPError(http.StatusNotFound)
 	}
-	c.Response().Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
+	c.Response().Header().Set("Cache-Control", cacheableCacheControl)
 	in := PostArticleInput{
 		Slug:      a.Post.Slug,
 		Title:     a.Post.Title,

--- a/integrations/echo/main.go
+++ b/integrations/echo/main.go
@@ -129,9 +129,10 @@ func defaultLayout(ctx *bf.RenderContext) string {
 // visitor's list is never visible to another. LRU-bounded to keep memory
 // usage predictable; oldest sessions get evicted past sessionStoreMax.
 const (
-	sessionCookieName = "bf_session"
-	sessionTTLSeconds = 60 * 60 * 24 * 30 // 30d
-	sessionStoreMax   = 1000
+	sessionCookieName     = "bf_session"
+	sessionTTLSeconds     = 60 * 60 * 24 * 30 // 30d
+	sessionStoreMax       = 1000
+	cacheableCacheControl = "public, max-age=3600, stale-while-revalidate=86400"
 )
 
 type sessionState struct {
@@ -303,7 +304,7 @@ func main() {
 }
 
 func indexHandler(c echo.Context) error {
-	c.Response().Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
+	c.Response().Header().Set("Cache-Control", cacheableCacheControl)
 	body := fmt.Sprintf(`
     <h1>BarefootJS + Echo Example</h1>
     <p>This example demonstrates server-side rendering with Go Echo and BarefootJS.</p>
@@ -333,7 +334,7 @@ func indexHandler(c echo.Context) error {
 }
 
 func counterHandler(c echo.Context) error {
-	c.Response().Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
+	c.Response().Header().Set("Cache-Control", cacheableCacheControl)
 	props := NewCounterProps(CounterInput{Initial: 0})
 	return c.Render(http.StatusOK, "Counter", bf.RenderOptions{
 		Props:   &props,
@@ -343,7 +344,7 @@ func counterHandler(c echo.Context) error {
 }
 
 func toggleHandler(c echo.Context) error {
-	c.Response().Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
+	c.Response().Header().Set("Cache-Control", cacheableCacheControl)
 	props := NewToggleProps(ToggleInput{
 		ToggleItems: []ToggleItemInput{
 			{Label: "Setting 1", DefaultOn: true},
@@ -388,7 +389,7 @@ func todosHandler(c echo.Context) error {
 }
 
 func reactivePropsHandler(c echo.Context) error {
-	c.Response().Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
+	c.Response().Header().Set("Cache-Control", cacheableCacheControl)
 	props := NewReactivePropsProps(ReactivePropsInput{})
 	return c.Render(http.StatusOK, "ReactiveProps", bf.RenderOptions{
 		Props:   &props,
@@ -398,7 +399,7 @@ func reactivePropsHandler(c echo.Context) error {
 }
 
 func propsReactivityHandler(c echo.Context) error {
-	c.Response().Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
+	c.Response().Header().Set("Cache-Control", cacheableCacheControl)
 	props := NewPropsReactivityComparisonProps(PropsReactivityComparisonInput{})
 	return c.Render(http.StatusOK, "PropsReactivityComparison", bf.RenderOptions{
 		Props:   &props,
@@ -408,7 +409,7 @@ func propsReactivityHandler(c echo.Context) error {
 }
 
 func formHandler(c echo.Context) error {
-	c.Response().Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
+	c.Response().Header().Set("Cache-Control", cacheableCacheControl)
 	props := NewFormProps(FormInput{})
 	return c.Render(http.StatusOK, "Form", bf.RenderOptions{
 		Props:   &props,
@@ -418,7 +419,7 @@ func formHandler(c echo.Context) error {
 }
 
 func portalHandler(c echo.Context) error {
-	c.Response().Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
+	c.Response().Header().Set("Cache-Control", cacheableCacheControl)
 	props := NewPortalExampleProps(PortalExampleInput{})
 	return c.Render(http.StatusOK, "PortalExample", bf.RenderOptions{
 		Props:   &props,
@@ -428,7 +429,7 @@ func portalHandler(c echo.Context) error {
 }
 
 func conditionalReturnHandler(c echo.Context) error {
-	c.Response().Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
+	c.Response().Header().Set("Cache-Control", cacheableCacheControl)
 	props := NewConditionalReturnProps(ConditionalReturnInput{})
 	return c.Render(http.StatusOK, "ConditionalReturn", bf.RenderOptions{
 		Props:   &props,
@@ -438,7 +439,7 @@ func conditionalReturnHandler(c echo.Context) error {
 }
 
 func conditionalReturnLinkHandler(c echo.Context) error {
-	c.Response().Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
+	c.Response().Header().Set("Cache-Control", cacheableCacheControl)
 	props := NewConditionalReturnProps(ConditionalReturnInput{Variant: "link"})
 	return c.Render(http.StatusOK, "ConditionalReturn", bf.RenderOptions{
 		Props:   &props,
@@ -580,7 +581,7 @@ var fakeResponses = []string{
 }
 
 func aiChatHandler(c echo.Context) error {
-	c.Response().Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
+	c.Response().Header().Set("Cache-Control", cacheableCacheControl)
 	props := NewAIChatInteractiveProps(AIChatInteractiveInput{})
 	return c.Render(http.StatusOK, "AIChatInteractive", bf.RenderOptions{
 		Props:   &props,

--- a/integrations/echo/main.go
+++ b/integrations/echo/main.go
@@ -303,6 +303,7 @@ func main() {
 }
 
 func indexHandler(c echo.Context) error {
+	c.Response().Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
 	body := fmt.Sprintf(`
     <h1>BarefootJS + Echo Example</h1>
     <p>This example demonstrates server-side rendering with Go Echo and BarefootJS.</p>
@@ -332,6 +333,7 @@ func indexHandler(c echo.Context) error {
 }
 
 func counterHandler(c echo.Context) error {
+	c.Response().Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
 	props := NewCounterProps(CounterInput{Initial: 0})
 	return c.Render(http.StatusOK, "Counter", bf.RenderOptions{
 		Props:   &props,
@@ -341,6 +343,7 @@ func counterHandler(c echo.Context) error {
 }
 
 func toggleHandler(c echo.Context) error {
+	c.Response().Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
 	props := NewToggleProps(ToggleInput{
 		ToggleItems: []ToggleItemInput{
 			{Label: "Setting 1", DefaultOn: true},
@@ -385,6 +388,7 @@ func todosHandler(c echo.Context) error {
 }
 
 func reactivePropsHandler(c echo.Context) error {
+	c.Response().Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
 	props := NewReactivePropsProps(ReactivePropsInput{})
 	return c.Render(http.StatusOK, "ReactiveProps", bf.RenderOptions{
 		Props:   &props,
@@ -394,6 +398,7 @@ func reactivePropsHandler(c echo.Context) error {
 }
 
 func propsReactivityHandler(c echo.Context) error {
+	c.Response().Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
 	props := NewPropsReactivityComparisonProps(PropsReactivityComparisonInput{})
 	return c.Render(http.StatusOK, "PropsReactivityComparison", bf.RenderOptions{
 		Props:   &props,
@@ -403,6 +408,7 @@ func propsReactivityHandler(c echo.Context) error {
 }
 
 func formHandler(c echo.Context) error {
+	c.Response().Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
 	props := NewFormProps(FormInput{})
 	return c.Render(http.StatusOK, "Form", bf.RenderOptions{
 		Props:   &props,
@@ -412,6 +418,7 @@ func formHandler(c echo.Context) error {
 }
 
 func portalHandler(c echo.Context) error {
+	c.Response().Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
 	props := NewPortalExampleProps(PortalExampleInput{})
 	return c.Render(http.StatusOK, "PortalExample", bf.RenderOptions{
 		Props:   &props,
@@ -421,6 +428,7 @@ func portalHandler(c echo.Context) error {
 }
 
 func conditionalReturnHandler(c echo.Context) error {
+	c.Response().Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
 	props := NewConditionalReturnProps(ConditionalReturnInput{})
 	return c.Render(http.StatusOK, "ConditionalReturn", bf.RenderOptions{
 		Props:   &props,
@@ -430,6 +438,7 @@ func conditionalReturnHandler(c echo.Context) error {
 }
 
 func conditionalReturnLinkHandler(c echo.Context) error {
+	c.Response().Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
 	props := NewConditionalReturnProps(ConditionalReturnInput{Variant: "link"})
 	return c.Render(http.StatusOK, "ConditionalReturn", bf.RenderOptions{
 		Props:   &props,
@@ -571,6 +580,7 @@ var fakeResponses = []string{
 }
 
 func aiChatHandler(c echo.Context) error {
+	c.Response().Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
 	props := NewAIChatInteractiveProps(AIChatInteractiveInput{})
 	return c.Render(http.StatusOK, "AIChatInteractive", bf.RenderOptions{
 		Props:   &props,

--- a/integrations/fastapi/app.py
+++ b/integrations/fastapi/app.py
@@ -328,14 +328,29 @@ AI_RESPONSES = [
 router = APIRouter(prefix=BASE)
 
 
+# These routes never touch SESSIONS / the bf_session cookie, but a visitor
+# who has EVER hit /todos in this integration still sends that cookie on
+# every later request here (its Path is the whole integration base, not
+# scoped to /todos -- see cache-control.ts). Setting Cache-Control explicitly
+# opts them back into Workers Cache regardless of a stale session cookie,
+# without weakening the shared helper's default for any route that doesn't
+# opt in. Must match HTML_CACHE_CONTROL in
+# integrations/shared/lib/cache-control.ts verbatim.
+CACHEABLE_CACHE_CONTROL = "public, max-age=3600, stale-while-revalidate=86400"
+
+
 @router.get("/")
 async def home_route() -> Response:
-    return html_response(home_page())
+    response = html_response(home_page())
+    response.headers["Cache-Control"] = CACHEABLE_CACHE_CONTROL
+    return response
 
 
 @router.get("/counter")
 async def counter_route() -> Response:
-    return html_response(render_component("Counter", heading="Counter Component"))
+    response = html_response(render_component("Counter", heading="Counter Component"))
+    response.headers["Cache-Control"] = CACHEABLE_CACHE_CONTROL
+    return response
 
 
 @router.get("/toggle")
@@ -345,7 +360,7 @@ async def toggle_route() -> Response:
         {"label": "Setting 2", "defaultOn": False},
         {"label": "Setting 3", "defaultOn": False},
     ]
-    return html_response(
+    response = html_response(
         render_component(
             "Toggle",
             heading="Toggle Component",
@@ -354,16 +369,20 @@ async def toggle_route() -> Response:
             stash={"toggleItems": items},
         )
     )
+    response.headers["Cache-Control"] = CACHEABLE_CACHE_CONTROL
+    return response
 
 
 @router.get("/form")
 async def form_route() -> Response:
-    return html_response(render_component("Form", heading="Form Example", props={}, stash={"accepted": False}))
+    response = html_response(render_component("Form", heading="Form Example", props={}, stash={"accepted": False}))
+    response.headers["Cache-Control"] = CACHEABLE_CACHE_CONTROL
+    return response
 
 
 @router.get("/reactive-props")
 async def reactive_props_route() -> Response:
-    return html_response(
+    response = html_response(
         render_component(
             "ReactiveProps",
             heading="Reactive Props Test",
@@ -372,6 +391,8 @@ async def reactive_props_route() -> Response:
             stash={"count": 0, "doubled": 0},
         )
     )
+    response.headers["Cache-Control"] = CACHEABLE_CACHE_CONTROL
+    return response
 
 
 @router.get("/props-reactivity")
@@ -384,7 +405,7 @@ async def props_reactivity_route() -> Response:
     # override is needed here (unlike app.psgi's Kolon port): PropsStyleChild
     # / DestructuredStyleChild's compiled templates already derive
     # `displayValue` in-template (`{% set displayValue = value * 10 %}`).
-    return html_response(
+    response = html_response(
         render_component(
             "PropsReactivityComparison",
             heading="Props Reactivity Comparison",
@@ -396,13 +417,15 @@ async def props_reactivity_route() -> Response:
             stash={"count": 1},
         )
     )
+    response.headers["Cache-Control"] = CACHEABLE_CACHE_CONTROL
+    return response
 
 
 @router.get("/conditional-return")
 @router.get("/conditional-return-link")
 async def conditional_return_route(request: Request) -> Response:
     variant = "link" if request.url.path.endswith("-link") else ""
-    return html_response(
+    response = html_response(
         render_component(
             "ConditionalReturn",
             heading="Conditional Return Example" + (" (Link)" if variant else ""),
@@ -410,16 +433,20 @@ async def conditional_return_route(request: Request) -> Response:
             stash={"variant": variant, "count": 0},
         )
     )
+    response.headers["Cache-Control"] = CACHEABLE_CACHE_CONTROL
+    return response
 
 
 @router.get("/portal")
 async def portal_route() -> Response:
-    return html_response(render_component("PortalExample", heading="Portal Example", props={}, stash={"open": False}))
+    response = html_response(render_component("PortalExample", heading="Portal Example", props={}, stash={"open": False}))
+    response.headers["Cache-Control"] = CACHEABLE_CACHE_CONTROL
+    return response
 
 
 @router.get("/ai-chat")
 async def ai_chat_route() -> Response:
-    return html_response(
+    response = html_response(
         render_component(
             "AIChatInteractive",
             title="AI Chat -- SSE Streaming (FastAPI)",
@@ -428,6 +455,8 @@ async def ai_chat_route() -> Response:
             extra_css=f'<link rel="stylesheet" href="{BASE}/styles/ai-chat.css">',
         )
     )
+    response.headers["Cache-Control"] = CACHEABLE_CACHE_CONTROL
+    return response
 
 
 @router.get("/todos")
@@ -716,7 +745,9 @@ async def blog_index_route(request: Request) -> Response:
     )
     now = blog_island(root, "NowPlaying", {}, {"Math": {"min": 0}})
     title = f"#{tag} — Barefoot Blog" if tag else "Barefoot Blog — Latest posts"
-    return html_response(blog_page(root, title, base, post_list + now))
+    response = html_response(blog_page(root, title, base, post_list + now))
+    response.headers["Cache-Control"] = CACHEABLE_CACHE_CONTROL
+    return response
 
 
 @router.get("/blog/posts/{slug}")
@@ -753,7 +784,9 @@ async def blog_post_route(slug: str) -> Response:
             "now_playing": ("NowPlaying", {"Math": {"min": 0}}),
         },
     )
-    return html_response(blog_page(root, f"{p['title']} — Barefoot Blog", base, content))
+    response = html_response(blog_page(root, f"{p['title']} — Barefoot Blog", base, content))
+    response.headers["Cache-Control"] = CACHEABLE_CACHE_CONTROL
+    return response
 
 
 def home_page() -> str:

--- a/integrations/fastapi/app.py
+++ b/integrations/fastapi/app.py
@@ -339,18 +339,20 @@ router = APIRouter(prefix=BASE)
 CACHEABLE_CACHE_CONTROL = "public, max-age=3600, stale-while-revalidate=86400"
 
 
-@router.get("/")
-async def home_route() -> Response:
-    response = html_response(home_page())
+def html_response_cached(html: str, status: int = 200) -> Response:
+    response = html_response(html, status)
     response.headers["Cache-Control"] = CACHEABLE_CACHE_CONTROL
     return response
+
+
+@router.get("/")
+async def home_route() -> Response:
+    return html_response_cached(home_page())
 
 
 @router.get("/counter")
 async def counter_route() -> Response:
-    response = html_response(render_component("Counter", heading="Counter Component"))
-    response.headers["Cache-Control"] = CACHEABLE_CACHE_CONTROL
-    return response
+    return html_response_cached(render_component("Counter", heading="Counter Component"))
 
 
 @router.get("/toggle")
@@ -360,7 +362,7 @@ async def toggle_route() -> Response:
         {"label": "Setting 2", "defaultOn": False},
         {"label": "Setting 3", "defaultOn": False},
     ]
-    response = html_response(
+    return html_response_cached(
         render_component(
             "Toggle",
             heading="Toggle Component",
@@ -369,20 +371,16 @@ async def toggle_route() -> Response:
             stash={"toggleItems": items},
         )
     )
-    response.headers["Cache-Control"] = CACHEABLE_CACHE_CONTROL
-    return response
 
 
 @router.get("/form")
 async def form_route() -> Response:
-    response = html_response(render_component("Form", heading="Form Example", props={}, stash={"accepted": False}))
-    response.headers["Cache-Control"] = CACHEABLE_CACHE_CONTROL
-    return response
+    return html_response_cached(render_component("Form", heading="Form Example", props={}, stash={"accepted": False}))
 
 
 @router.get("/reactive-props")
 async def reactive_props_route() -> Response:
-    response = html_response(
+    return html_response_cached(
         render_component(
             "ReactiveProps",
             heading="Reactive Props Test",
@@ -391,8 +389,6 @@ async def reactive_props_route() -> Response:
             stash={"count": 0, "doubled": 0},
         )
     )
-    response.headers["Cache-Control"] = CACHEABLE_CACHE_CONTROL
-    return response
 
 
 @router.get("/props-reactivity")
@@ -405,7 +401,7 @@ async def props_reactivity_route() -> Response:
     # override is needed here (unlike app.psgi's Kolon port): PropsStyleChild
     # / DestructuredStyleChild's compiled templates already derive
     # `displayValue` in-template (`{% set displayValue = value * 10 %}`).
-    response = html_response(
+    return html_response_cached(
         render_component(
             "PropsReactivityComparison",
             heading="Props Reactivity Comparison",
@@ -417,15 +413,13 @@ async def props_reactivity_route() -> Response:
             stash={"count": 1},
         )
     )
-    response.headers["Cache-Control"] = CACHEABLE_CACHE_CONTROL
-    return response
 
 
 @router.get("/conditional-return")
 @router.get("/conditional-return-link")
 async def conditional_return_route(request: Request) -> Response:
     variant = "link" if request.url.path.endswith("-link") else ""
-    response = html_response(
+    return html_response_cached(
         render_component(
             "ConditionalReturn",
             heading="Conditional Return Example" + (" (Link)" if variant else ""),
@@ -433,20 +427,16 @@ async def conditional_return_route(request: Request) -> Response:
             stash={"variant": variant, "count": 0},
         )
     )
-    response.headers["Cache-Control"] = CACHEABLE_CACHE_CONTROL
-    return response
 
 
 @router.get("/portal")
 async def portal_route() -> Response:
-    response = html_response(render_component("PortalExample", heading="Portal Example", props={}, stash={"open": False}))
-    response.headers["Cache-Control"] = CACHEABLE_CACHE_CONTROL
-    return response
+    return html_response_cached(render_component("PortalExample", heading="Portal Example", props={}, stash={"open": False}))
 
 
 @router.get("/ai-chat")
 async def ai_chat_route() -> Response:
-    response = html_response(
+    return html_response_cached(
         render_component(
             "AIChatInteractive",
             title="AI Chat -- SSE Streaming (FastAPI)",
@@ -455,8 +445,6 @@ async def ai_chat_route() -> Response:
             extra_css=f'<link rel="stylesheet" href="{BASE}/styles/ai-chat.css">',
         )
     )
-    response.headers["Cache-Control"] = CACHEABLE_CACHE_CONTROL
-    return response
 
 
 @router.get("/todos")
@@ -745,9 +733,7 @@ async def blog_index_route(request: Request) -> Response:
     )
     now = blog_island(root, "NowPlaying", {}, {"Math": {"min": 0}})
     title = f"#{tag} — Barefoot Blog" if tag else "Barefoot Blog — Latest posts"
-    response = html_response(blog_page(root, title, base, post_list + now))
-    response.headers["Cache-Control"] = CACHEABLE_CACHE_CONTROL
-    return response
+    return html_response_cached(blog_page(root, title, base, post_list + now))
 
 
 @router.get("/blog/posts/{slug}")
@@ -784,9 +770,7 @@ async def blog_post_route(slug: str) -> Response:
             "now_playing": ("NowPlaying", {"Math": {"min": 0}}),
         },
     )
-    response = html_response(blog_page(root, f"{p['title']} — Barefoot Blog", base, content))
-    response.headers["Cache-Control"] = CACHEABLE_CACHE_CONTROL
-    return response
+    return html_response_cached(blog_page(root, f"{p['title']} — Barefoot Blog", base, content))
 
 
 def home_page() -> str:

--- a/integrations/flask/app.py
+++ b/integrations/flask/app.py
@@ -320,15 +320,29 @@ AI_RESPONSES = [
 # ---------------------------------------------------------------------------
 bp = Blueprint("flask_example", __name__, url_prefix=BASE)
 
+# These routes never touch SESSIONS / the bf_session cookie, but a visitor
+# who has EVER hit /todos in this integration still sends that cookie on
+# every later request here (its Path is the whole integration base, not
+# scoped to /todos -- see cache-control.ts). Setting Cache-Control explicitly
+# opts them back into Workers Cache regardless of a stale session cookie,
+# without weakening the shared helper's default for any route that doesn't
+# opt in. Must match HTML_CACHE_CONTROL in
+# integrations/shared/lib/cache-control.ts verbatim.
+CACHEABLE_CACHE_CONTROL = "public, max-age=3600, stale-while-revalidate=86400"
+
 
 @bp.get("/")
 def home_route():
-    return html_response(home_page())
+    response = html_response(home_page())
+    response.headers["Cache-Control"] = CACHEABLE_CACHE_CONTROL
+    return response
 
 
 @bp.get("/counter")
 def counter_route():
-    return html_response(render_component("Counter", heading="Counter Component"))
+    response = html_response(render_component("Counter", heading="Counter Component"))
+    response.headers["Cache-Control"] = CACHEABLE_CACHE_CONTROL
+    return response
 
 
 @bp.get("/toggle")
@@ -338,7 +352,7 @@ def toggle_route():
         {"label": "Setting 2", "defaultOn": False},
         {"label": "Setting 3", "defaultOn": False},
     ]
-    return html_response(
+    response = html_response(
         render_component(
             "Toggle",
             heading="Toggle Component",
@@ -347,16 +361,20 @@ def toggle_route():
             stash={"toggleItems": items},
         )
     )
+    response.headers["Cache-Control"] = CACHEABLE_CACHE_CONTROL
+    return response
 
 
 @bp.get("/form")
 def form_route():
-    return html_response(render_component("Form", heading="Form Example", props={}, stash={"accepted": False}))
+    response = html_response(render_component("Form", heading="Form Example", props={}, stash={"accepted": False}))
+    response.headers["Cache-Control"] = CACHEABLE_CACHE_CONTROL
+    return response
 
 
 @bp.get("/reactive-props")
 def reactive_props_route():
-    return html_response(
+    response = html_response(
         render_component(
             "ReactiveProps",
             heading="Reactive Props Test",
@@ -365,6 +383,8 @@ def reactive_props_route():
             stash={"count": 0, "doubled": 0},
         )
     )
+    response.headers["Cache-Control"] = CACHEABLE_CACHE_CONTROL
+    return response
 
 
 @bp.get("/props-reactivity")
@@ -377,7 +397,7 @@ def props_reactivity_route():
     # override is needed here (unlike app.psgi's Kolon port): PropsStyleChild
     # / DestructuredStyleChild's compiled templates already derive
     # `displayValue` in-template (`{% set displayValue = value * 10 %}`).
-    return html_response(
+    response = html_response(
         render_component(
             "PropsReactivityComparison",
             heading="Props Reactivity Comparison",
@@ -389,13 +409,15 @@ def props_reactivity_route():
             stash={"count": 1},
         )
     )
+    response.headers["Cache-Control"] = CACHEABLE_CACHE_CONTROL
+    return response
 
 
 @bp.get("/conditional-return")
 @bp.get("/conditional-return-link")
 def conditional_return_route():
     variant = "link" if request.path.endswith("-link") else ""
-    return html_response(
+    response = html_response(
         render_component(
             "ConditionalReturn",
             heading="Conditional Return Example" + (" (Link)" if variant else ""),
@@ -403,16 +425,20 @@ def conditional_return_route():
             stash={"variant": variant, "count": 0},
         )
     )
+    response.headers["Cache-Control"] = CACHEABLE_CACHE_CONTROL
+    return response
 
 
 @bp.get("/portal")
 def portal_route():
-    return html_response(render_component("PortalExample", heading="Portal Example", props={}, stash={"open": False}))
+    response = html_response(render_component("PortalExample", heading="Portal Example", props={}, stash={"open": False}))
+    response.headers["Cache-Control"] = CACHEABLE_CACHE_CONTROL
+    return response
 
 
 @bp.get("/ai-chat")
 def ai_chat_route():
-    return html_response(
+    response = html_response(
         render_component(
             "AIChatInteractive",
             title="AI Chat -- SSE Streaming (Flask)",
@@ -421,6 +447,8 @@ def ai_chat_route():
             extra_css=f'<link rel="stylesheet" href="{BASE}/styles/ai-chat.css">',
         )
     )
+    response.headers["Cache-Control"] = CACHEABLE_CACHE_CONTROL
+    return response
 
 
 @bp.get("/todos")
@@ -715,7 +743,9 @@ def blog_index_route():
     )
     now = blog_island(root, "NowPlaying", {}, {"Math": {"min": 0}})
     title = f"#{tag} — Barefoot Blog" if tag else "Barefoot Blog — Latest posts"
-    return html_response(blog_page(root, title, base, post_list + now))
+    response = html_response(blog_page(root, title, base, post_list + now))
+    response.headers["Cache-Control"] = CACHEABLE_CACHE_CONTROL
+    return response
 
 
 @bp.get("/blog/posts/<slug>")
@@ -752,7 +782,9 @@ def blog_post_route(slug: str):
             "now_playing": ("NowPlaying", {"Math": {"min": 0}}),
         },
     )
-    return html_response(blog_page(root, f"{p['title']} — Barefoot Blog", base, content))
+    response = html_response(blog_page(root, f"{p['title']} — Barefoot Blog", base, content))
+    response.headers["Cache-Control"] = CACHEABLE_CACHE_CONTROL
+    return response
 
 
 def home_page() -> str:

--- a/integrations/flask/app.py
+++ b/integrations/flask/app.py
@@ -331,18 +331,20 @@ bp = Blueprint("flask_example", __name__, url_prefix=BASE)
 CACHEABLE_CACHE_CONTROL = "public, max-age=3600, stale-while-revalidate=86400"
 
 
-@bp.get("/")
-def home_route():
-    response = html_response(home_page())
+def html_response_cached(html: str, status: int = 200) -> Response:
+    response = html_response(html, status)
     response.headers["Cache-Control"] = CACHEABLE_CACHE_CONTROL
     return response
+
+
+@bp.get("/")
+def home_route():
+    return html_response_cached(home_page())
 
 
 @bp.get("/counter")
 def counter_route():
-    response = html_response(render_component("Counter", heading="Counter Component"))
-    response.headers["Cache-Control"] = CACHEABLE_CACHE_CONTROL
-    return response
+    return html_response_cached(render_component("Counter", heading="Counter Component"))
 
 
 @bp.get("/toggle")
@@ -352,7 +354,7 @@ def toggle_route():
         {"label": "Setting 2", "defaultOn": False},
         {"label": "Setting 3", "defaultOn": False},
     ]
-    response = html_response(
+    return html_response_cached(
         render_component(
             "Toggle",
             heading="Toggle Component",
@@ -361,20 +363,16 @@ def toggle_route():
             stash={"toggleItems": items},
         )
     )
-    response.headers["Cache-Control"] = CACHEABLE_CACHE_CONTROL
-    return response
 
 
 @bp.get("/form")
 def form_route():
-    response = html_response(render_component("Form", heading="Form Example", props={}, stash={"accepted": False}))
-    response.headers["Cache-Control"] = CACHEABLE_CACHE_CONTROL
-    return response
+    return html_response_cached(render_component("Form", heading="Form Example", props={}, stash={"accepted": False}))
 
 
 @bp.get("/reactive-props")
 def reactive_props_route():
-    response = html_response(
+    return html_response_cached(
         render_component(
             "ReactiveProps",
             heading="Reactive Props Test",
@@ -383,8 +381,6 @@ def reactive_props_route():
             stash={"count": 0, "doubled": 0},
         )
     )
-    response.headers["Cache-Control"] = CACHEABLE_CACHE_CONTROL
-    return response
 
 
 @bp.get("/props-reactivity")
@@ -397,7 +393,7 @@ def props_reactivity_route():
     # override is needed here (unlike app.psgi's Kolon port): PropsStyleChild
     # / DestructuredStyleChild's compiled templates already derive
     # `displayValue` in-template (`{% set displayValue = value * 10 %}`).
-    response = html_response(
+    return html_response_cached(
         render_component(
             "PropsReactivityComparison",
             heading="Props Reactivity Comparison",
@@ -409,15 +405,13 @@ def props_reactivity_route():
             stash={"count": 1},
         )
     )
-    response.headers["Cache-Control"] = CACHEABLE_CACHE_CONTROL
-    return response
 
 
 @bp.get("/conditional-return")
 @bp.get("/conditional-return-link")
 def conditional_return_route():
     variant = "link" if request.path.endswith("-link") else ""
-    response = html_response(
+    return html_response_cached(
         render_component(
             "ConditionalReturn",
             heading="Conditional Return Example" + (" (Link)" if variant else ""),
@@ -425,20 +419,16 @@ def conditional_return_route():
             stash={"variant": variant, "count": 0},
         )
     )
-    response.headers["Cache-Control"] = CACHEABLE_CACHE_CONTROL
-    return response
 
 
 @bp.get("/portal")
 def portal_route():
-    response = html_response(render_component("PortalExample", heading="Portal Example", props={}, stash={"open": False}))
-    response.headers["Cache-Control"] = CACHEABLE_CACHE_CONTROL
-    return response
+    return html_response_cached(render_component("PortalExample", heading="Portal Example", props={}, stash={"open": False}))
 
 
 @bp.get("/ai-chat")
 def ai_chat_route():
-    response = html_response(
+    return html_response_cached(
         render_component(
             "AIChatInteractive",
             title="AI Chat -- SSE Streaming (Flask)",
@@ -447,8 +437,6 @@ def ai_chat_route():
             extra_css=f'<link rel="stylesheet" href="{BASE}/styles/ai-chat.css">',
         )
     )
-    response.headers["Cache-Control"] = CACHEABLE_CACHE_CONTROL
-    return response
 
 
 @bp.get("/todos")
@@ -743,9 +731,7 @@ def blog_index_route():
     )
     now = blog_island(root, "NowPlaying", {}, {"Math": {"min": 0}})
     title = f"#{tag} — Barefoot Blog" if tag else "Barefoot Blog — Latest posts"
-    response = html_response(blog_page(root, title, base, post_list + now))
-    response.headers["Cache-Control"] = CACHEABLE_CACHE_CONTROL
-    return response
+    return html_response_cached(blog_page(root, title, base, post_list + now))
 
 
 @bp.get("/blog/posts/<slug>")
@@ -782,9 +768,7 @@ def blog_post_route(slug: str):
             "now_playing": ("NowPlaying", {"Math": {"min": 0}}),
         },
     )
-    response = html_response(blog_page(root, f"{p['title']} — Barefoot Blog", base, content))
-    response.headers["Cache-Control"] = CACHEABLE_CACHE_CONTROL
-    return response
+    return html_response_cached(blog_page(root, f"{p['title']} — Barefoot Blog", base, content))
 
 
 def home_page() -> str:

--- a/integrations/gin/blog.go
+++ b/integrations/gin/blog.go
@@ -202,6 +202,7 @@ func validSortKey(raw string) string {
 // via searchParams() on the client; on the server the same query drives both
 // `NewPostListProps` (active highlight + hrefs) and the SSR row order/visibility.
 func blogIndexHandler(c *gin.Context) {
+	c.Header("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
 	sp := bf.NewSearchParams(c.Request.URL.RawQuery)
 	sortKey := validSortKey(sp.Get("sort"))
 	tag := sp.Get("tag")
@@ -243,6 +244,7 @@ func blogPostHandler(c *gin.Context) {
 		c.Status(http.StatusNotFound)
 		return
 	}
+	c.Header("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
 	in := PostArticleInput{
 		Slug:      a.Post.Slug,
 		Title:     a.Post.Title,

--- a/integrations/gin/blog.go
+++ b/integrations/gin/blog.go
@@ -202,7 +202,7 @@ func validSortKey(raw string) string {
 // via searchParams() on the client; on the server the same query drives both
 // `NewPostListProps` (active highlight + hrefs) and the SSR row order/visibility.
 func blogIndexHandler(c *gin.Context) {
-	c.Header("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
+	c.Header("Cache-Control", cacheableCacheControl)
 	sp := bf.NewSearchParams(c.Request.URL.RawQuery)
 	sortKey := validSortKey(sp.Get("sort"))
 	tag := sp.Get("tag")
@@ -244,7 +244,7 @@ func blogPostHandler(c *gin.Context) {
 		c.Status(http.StatusNotFound)
 		return
 	}
-	c.Header("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
+	c.Header("Cache-Control", cacheableCacheControl)
 	in := PostArticleInput{
 		Slug:      a.Post.Slug,
 		Title:     a.Post.Title,

--- a/integrations/gin/main.go
+++ b/integrations/gin/main.go
@@ -142,9 +142,10 @@ func render(c *gin.Context, status int, name string, opts bf.RenderOptions) {
 // visitor's list is never visible to another. LRU-bounded to keep memory
 // usage predictable.
 const (
-	sessionCookieName = "bf_session"
-	sessionTTLSeconds = 60 * 60 * 24 * 30 // 30d
-	sessionStoreMax   = 1000
+	sessionCookieName     = "bf_session"
+	sessionTTLSeconds     = 60 * 60 * 24 * 30 // 30d
+	sessionStoreMax       = 1000
+	cacheableCacheControl = "public, max-age=3600, stale-while-revalidate=86400"
 )
 
 type sessionState struct {
@@ -302,7 +303,7 @@ func main() {
 }
 
 func indexHandler(c *gin.Context) {
-	c.Header("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
+	c.Header("Cache-Control", cacheableCacheControl)
 	body := fmt.Sprintf(`
     <h1>BarefootJS + Gin Example</h1>
     <p>This example demonstrates server-side rendering with Go Gin and BarefootJS.</p>
@@ -332,7 +333,7 @@ func indexHandler(c *gin.Context) {
 }
 
 func counterHandler(c *gin.Context) {
-	c.Header("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
+	c.Header("Cache-Control", cacheableCacheControl)
 	props := NewCounterProps(CounterInput{Initial: 0})
 	render(c, http.StatusOK, "Counter", bf.RenderOptions{
 		Props:   &props,
@@ -342,7 +343,7 @@ func counterHandler(c *gin.Context) {
 }
 
 func toggleHandler(c *gin.Context) {
-	c.Header("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
+	c.Header("Cache-Control", cacheableCacheControl)
 	props := NewToggleProps(ToggleInput{
 		ToggleItems: []ToggleItemInput{
 			{Label: "Setting 1", DefaultOn: true},
@@ -406,7 +407,7 @@ func todosSSRHandler(c *gin.Context) {
 }
 
 func reactivePropsHandler(c *gin.Context) {
-	c.Header("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
+	c.Header("Cache-Control", cacheableCacheControl)
 	props := NewReactivePropsProps(ReactivePropsInput{})
 	render(c, http.StatusOK, "ReactiveProps", bf.RenderOptions{
 		Props:   &props,
@@ -416,7 +417,7 @@ func reactivePropsHandler(c *gin.Context) {
 }
 
 func propsReactivityHandler(c *gin.Context) {
-	c.Header("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
+	c.Header("Cache-Control", cacheableCacheControl)
 	props := NewPropsReactivityComparisonProps(PropsReactivityComparisonInput{})
 	render(c, http.StatusOK, "PropsReactivityComparison", bf.RenderOptions{
 		Props:   &props,
@@ -426,7 +427,7 @@ func propsReactivityHandler(c *gin.Context) {
 }
 
 func formHandler(c *gin.Context) {
-	c.Header("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
+	c.Header("Cache-Control", cacheableCacheControl)
 	props := NewFormProps(FormInput{})
 	render(c, http.StatusOK, "Form", bf.RenderOptions{
 		Props:   &props,
@@ -436,7 +437,7 @@ func formHandler(c *gin.Context) {
 }
 
 func portalHandler(c *gin.Context) {
-	c.Header("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
+	c.Header("Cache-Control", cacheableCacheControl)
 	props := NewPortalExampleProps(PortalExampleInput{})
 	render(c, http.StatusOK, "PortalExample", bf.RenderOptions{
 		Props:   &props,
@@ -446,7 +447,7 @@ func portalHandler(c *gin.Context) {
 }
 
 func conditionalReturnHandler(c *gin.Context) {
-	c.Header("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
+	c.Header("Cache-Control", cacheableCacheControl)
 	props := NewConditionalReturnProps(ConditionalReturnInput{})
 	render(c, http.StatusOK, "ConditionalReturn", bf.RenderOptions{
 		Props:   &props,
@@ -456,7 +457,7 @@ func conditionalReturnHandler(c *gin.Context) {
 }
 
 func conditionalReturnLinkHandler(c *gin.Context) {
-	c.Header("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
+	c.Header("Cache-Control", cacheableCacheControl)
 	props := NewConditionalReturnProps(ConditionalReturnInput{Variant: "link"})
 	render(c, http.StatusOK, "ConditionalReturn", bf.RenderOptions{
 		Props:   &props,
@@ -573,7 +574,7 @@ var fakeResponses = []string{
 }
 
 func aiChatHandler(c *gin.Context) {
-	c.Header("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
+	c.Header("Cache-Control", cacheableCacheControl)
 	props := NewAIChatInteractiveProps(AIChatInteractiveInput{})
 	render(c, http.StatusOK, "AIChatInteractive", bf.RenderOptions{
 		Props:   &props,

--- a/integrations/gin/main.go
+++ b/integrations/gin/main.go
@@ -302,6 +302,7 @@ func main() {
 }
 
 func indexHandler(c *gin.Context) {
+	c.Header("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
 	body := fmt.Sprintf(`
     <h1>BarefootJS + Gin Example</h1>
     <p>This example demonstrates server-side rendering with Go Gin and BarefootJS.</p>
@@ -331,6 +332,7 @@ func indexHandler(c *gin.Context) {
 }
 
 func counterHandler(c *gin.Context) {
+	c.Header("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
 	props := NewCounterProps(CounterInput{Initial: 0})
 	render(c, http.StatusOK, "Counter", bf.RenderOptions{
 		Props:   &props,
@@ -340,6 +342,7 @@ func counterHandler(c *gin.Context) {
 }
 
 func toggleHandler(c *gin.Context) {
+	c.Header("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
 	props := NewToggleProps(ToggleInput{
 		ToggleItems: []ToggleItemInput{
 			{Label: "Setting 1", DefaultOn: true},
@@ -403,6 +406,7 @@ func todosSSRHandler(c *gin.Context) {
 }
 
 func reactivePropsHandler(c *gin.Context) {
+	c.Header("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
 	props := NewReactivePropsProps(ReactivePropsInput{})
 	render(c, http.StatusOK, "ReactiveProps", bf.RenderOptions{
 		Props:   &props,
@@ -412,6 +416,7 @@ func reactivePropsHandler(c *gin.Context) {
 }
 
 func propsReactivityHandler(c *gin.Context) {
+	c.Header("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
 	props := NewPropsReactivityComparisonProps(PropsReactivityComparisonInput{})
 	render(c, http.StatusOK, "PropsReactivityComparison", bf.RenderOptions{
 		Props:   &props,
@@ -421,6 +426,7 @@ func propsReactivityHandler(c *gin.Context) {
 }
 
 func formHandler(c *gin.Context) {
+	c.Header("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
 	props := NewFormProps(FormInput{})
 	render(c, http.StatusOK, "Form", bf.RenderOptions{
 		Props:   &props,
@@ -430,6 +436,7 @@ func formHandler(c *gin.Context) {
 }
 
 func portalHandler(c *gin.Context) {
+	c.Header("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
 	props := NewPortalExampleProps(PortalExampleInput{})
 	render(c, http.StatusOK, "PortalExample", bf.RenderOptions{
 		Props:   &props,
@@ -439,6 +446,7 @@ func portalHandler(c *gin.Context) {
 }
 
 func conditionalReturnHandler(c *gin.Context) {
+	c.Header("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
 	props := NewConditionalReturnProps(ConditionalReturnInput{})
 	render(c, http.StatusOK, "ConditionalReturn", bf.RenderOptions{
 		Props:   &props,
@@ -448,6 +456,7 @@ func conditionalReturnHandler(c *gin.Context) {
 }
 
 func conditionalReturnLinkHandler(c *gin.Context) {
+	c.Header("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
 	props := NewConditionalReturnProps(ConditionalReturnInput{Variant: "link"})
 	render(c, http.StatusOK, "ConditionalReturn", bf.RenderOptions{
 		Props:   &props,
@@ -564,6 +573,7 @@ var fakeResponses = []string{
 }
 
 func aiChatHandler(c *gin.Context) {
+	c.Header("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
 	props := NewAIChatInteractiveProps(AIChatInteractiveInput{})
 	render(c, http.StatusOK, "AIChatInteractive", bf.RenderOptions{
 		Props:   &props,

--- a/integrations/laravel/app/Http/Controllers/BlogController.php
+++ b/integrations/laravel/app/Http/Controllers/BlogController.php
@@ -18,6 +18,14 @@ use Illuminate\Http\Response;
  */
 final class BlogController extends Controller
 {
+    /**
+     * Session-free demo route: cacheable at the Workers Cache layer
+     * regardless of a stale bf_session cookie the visitor's browser may
+     * still be sending from an earlier /todos visit (see
+     * integrations/shared/lib/cache-control.ts).
+     */
+    private const CACHE_CONTROL = 'public, max-age=3600, stale-while-revalidate=86400';
+
     public function index(Request $request): Response
     {
         $backend = ExampleApp::backend();
@@ -46,7 +54,8 @@ final class BlogController extends Controller
         );
         $now = ExampleApp::blogIsland($root, 'NowPlaying', [], ['Math' => ['min' => 0]]);
         $title = $tag !== '' ? "#{$tag} \u{2014} Barefoot Blog" : 'Barefoot Blog \u{2014} Latest posts';
-        return response(ExampleApp::blogPage($root, $title, $base, $postList . $now));
+        return response(ExampleApp::blogPage($root, $title, $base, $postList . $now))
+            ->header('Cache-Control', self::CACHE_CONTROL);
     }
 
     public function post(string $slug): Response
@@ -95,6 +104,7 @@ final class BlogController extends Controller
                 'now_playing' => ['NowPlaying', ['Math' => ['min' => 0]]],
             ],
         );
-        return response(ExampleApp::blogPage($root, "{$p['title']} \u{2014} Barefoot Blog", $base, $content));
+        return response(ExampleApp::blogPage($root, "{$p['title']} \u{2014} Barefoot Blog", $base, $content))
+            ->header('Cache-Control', self::CACHE_CONTROL);
     }
 }

--- a/integrations/laravel/app/Http/Controllers/BlogController.php
+++ b/integrations/laravel/app/Http/Controllers/BlogController.php
@@ -18,13 +18,6 @@ use Illuminate\Http\Response;
  */
 final class BlogController extends Controller
 {
-    /**
-     * Session-free demo route: cacheable at the Workers Cache layer
-     * regardless of a stale bf_session cookie the visitor's browser may
-     * still be sending from an earlier /todos visit (see
-     * integrations/shared/lib/cache-control.ts).
-     */
-    private const CACHE_CONTROL = 'public, max-age=3600, stale-while-revalidate=86400';
 
     public function index(Request $request): Response
     {

--- a/integrations/laravel/app/Http/Controllers/Controller.php
+++ b/integrations/laravel/app/Http/Controllers/Controller.php
@@ -9,4 +9,12 @@ use App\Http\Controllers\Concerns\BarefootHelper;
 abstract class Controller
 {
     use BarefootHelper;
+
+    /**
+     * Cache-Control for a session-free demo route: cacheable at the Workers
+     * Cache layer regardless of a stale bf_session cookie the visitor's
+     * browser may still be sending from an earlier /todos visit (see
+     * integrations/shared/lib/cache-control.ts).
+     */
+    protected const CACHE_CONTROL = 'public, max-age=3600, stale-while-revalidate=86400';
 }

--- a/integrations/laravel/app/Http/Controllers/PagesController.php
+++ b/integrations/laravel/app/Http/Controllers/PagesController.php
@@ -16,13 +16,6 @@ use Illuminate\Http\Response;
  */
 final class PagesController extends Controller
 {
-    /**
-     * Session-free demo route: cacheable at the Workers Cache layer
-     * regardless of a stale bf_session cookie the visitor's browser may
-     * still be sending from an earlier /todos visit (see
-     * integrations/shared/lib/cache-control.ts).
-     */
-    private const CACHE_CONTROL = 'public, max-age=3600, stale-while-revalidate=86400';
 
     public function index(): Response
     {

--- a/integrations/laravel/app/Http/Controllers/PagesController.php
+++ b/integrations/laravel/app/Http/Controllers/PagesController.php
@@ -16,6 +16,14 @@ use Illuminate\Http\Response;
  */
 final class PagesController extends Controller
 {
+    /**
+     * Session-free demo route: cacheable at the Workers Cache layer
+     * regardless of a stale bf_session cookie the visitor's browser may
+     * still be sending from an earlier /todos visit (see
+     * integrations/shared/lib/cache-control.ts).
+     */
+    private const CACHE_CONTROL = 'public, max-age=3600, stale-while-revalidate=86400';
+
     public function index(): Response
     {
         $base = ExampleApp::base();
@@ -39,12 +47,13 @@ HTML;
             body: $body,
             scripts: '',
             back: '',
-        ));
+        ))->header('Cache-Control', self::CACHE_CONTROL);
     }
 
     public function counter(): Response
     {
-        return response($this->renderComponent('Counter', heading: 'Counter Component'));
+        return response($this->renderComponent('Counter', heading: 'Counter Component'))
+            ->header('Cache-Control', self::CACHE_CONTROL);
     }
 
     public function toggle(): Response
@@ -60,12 +69,13 @@ HTML;
             children: ['toggle_item' => 'ToggleItem'],
             props: ['toggleItems' => $items],
             stash: ['toggleItems' => $items],
-        ));
+        ))->header('Cache-Control', self::CACHE_CONTROL);
     }
 
     public function form(): Response
     {
-        return response($this->renderComponent('Form', heading: 'Form Example', props: [], stash: ['accepted' => false]));
+        return response($this->renderComponent('Form', heading: 'Form Example', props: [], stash: ['accepted' => false]))
+            ->header('Cache-Control', self::CACHE_CONTROL);
     }
 
     public function reactiveProps(): Response
@@ -76,7 +86,7 @@ HTML;
             children: ['reactive_child' => 'ReactiveChild'],
             props: [],
             stash: ['count' => 0, 'doubled' => 0],
-        ));
+        ))->header('Cache-Control', self::CACHE_CONTROL);
     }
 
     /**
@@ -98,7 +108,7 @@ HTML;
             ],
             props: [],
             stash: ['count' => 1],
-        ));
+        ))->header('Cache-Control', self::CACHE_CONTROL);
     }
 
     public function conditionalReturn(Request $request): Response
@@ -109,12 +119,13 @@ HTML;
             heading: 'Conditional Return Example' . ($variant !== '' ? ' (Link)' : ''),
             props: ['variant' => $variant],
             stash: ['variant' => $variant, 'count' => 0],
-        ));
+        ))->header('Cache-Control', self::CACHE_CONTROL);
     }
 
     public function portal(): Response
     {
-        return response($this->renderComponent('PortalExample', heading: 'Portal Example', props: [], stash: ['open' => false]));
+        return response($this->renderComponent('PortalExample', heading: 'Portal Example', props: [], stash: ['open' => false]))
+            ->header('Cache-Control', self::CACHE_CONTROL);
     }
 
     public function aiChat(): Response
@@ -126,6 +137,6 @@ HTML;
             heading: 'AI Chat -- SSE Streaming',
             stash: ['messages' => [], 'input' => '', 'streamingText' => '', 'isStreaming' => false],
             extraCss: "<link rel=\"stylesheet\" href=\"{$base}/styles/ai-chat.css\">",
-        ));
+        ))->header('Cache-Control', self::CACHE_CONTROL);
     }
 }

--- a/integrations/mojolicious/app.pl
+++ b/integrations/mojolicious/app.pl
@@ -55,6 +55,15 @@ use constant {
     SESSION_STORE_MAX  => 1000,
 };
 
+# Explicit Cache-Control for routes confirmed session-free (no cookie/session
+# access anywhere in the handler). Setting this here makes the route
+# cacheable by integrations/shared/lib/cache-control.ts's withCacheControl
+# regardless of whether the visitor's browser happens to still be sending a
+# stale bf_session cookie (its Path is the whole $BASE_PATH, not scoped to
+# /todos, so once a visitor has ever hit /todos it rides along on every
+# request to this integration). Must match HTML_CACHE_CONTROL there verbatim.
+use constant CACHEABLE_CACHE_CONTROL => 'public, max-age=3600, stale-while-revalidate=86400';
+
 my %sessions;          # id => { todos => [...], next_id => N }
 my @session_order;     # ids in access order, oldest at index 0
 
@@ -190,6 +199,7 @@ $r->get('/styles/*asset' => sub ($c) {
 });
 
 $r->get('/' => sub ($c) {
+    $c->res->headers->cache_control(CACHEABLE_CACHE_CONTROL);
     $c->stash(
         title     => 'BarefootJS + Mojolicious Example',
         heading   => 'BarefootJS + Mojolicious Example',
@@ -199,11 +209,13 @@ $r->get('/' => sub ($c) {
 });
 
 $r->get('/counter' => sub ($c) {
+    $c->res->headers->cache_control(CACHEABLE_CACHE_CONTROL);
     $c->stash(heading => 'Counter Component');
     $c->render(template => 'Counter', layout => 'default');
 });
 
 $r->get('/toggle' => sub ($c) {
+    $c->res->headers->cache_control(CACHEABLE_CACHE_CONTROL);
     my $items = [
         { label => 'Setting 1', defaultOn => \1 },
         { label => 'Setting 2', defaultOn => \0 },
@@ -224,6 +236,7 @@ $r->get('/toggle' => sub ($c) {
 });
 
 $r->get('/form' => sub ($c) {
+    $c->res->headers->cache_control(CACHEABLE_CACHE_CONTROL);
     $c->render_component('Form',
         props   => {},
         stash   => { accepted => 0 },
@@ -232,6 +245,7 @@ $r->get('/form' => sub ($c) {
 });
 
 $r->get('/reactive-props' => sub ($c) {
+    $c->res->headers->cache_control(CACHEABLE_CACHE_CONTROL);
     $c->render_component('ReactiveProps',
         children => { reactive_child => 'ReactiveChild' },
         props    => {},
@@ -241,6 +255,7 @@ $r->get('/reactive-props' => sub ($c) {
 });
 
 $r->get('/conditional-return' => sub ($c) {
+    $c->res->headers->cache_control(CACHEABLE_CACHE_CONTROL);
     $c->render_component('ConditionalReturn',
         props => { variant => '' },
         stash => { variant => '', count => 0 },
@@ -249,6 +264,7 @@ $r->get('/conditional-return' => sub ($c) {
 });
 
 $r->get('/conditional-return-link' => sub ($c) {
+    $c->res->headers->cache_control(CACHEABLE_CACHE_CONTROL);
     $c->render_component('ConditionalReturn',
         props => { variant => 'link' },
         stash => { variant => 'link', count => 0 },
@@ -291,6 +307,7 @@ $r->get('/todos-ssr' => sub ($c) {
 });
 
 $r->get('/props-reactivity' => sub ($c) {
+    $c->res->headers->cache_control(CACHEABLE_CACHE_CONTROL);
     $c->render_component('PropsReactivityComparison',
         children => {
             props_style_child        => 'PropsStyleChild',
@@ -313,6 +330,7 @@ $r->get('/props-reactivity' => sub ($c) {
 });
 
 $r->get('/portal' => sub ($c) {
+    $c->res->headers->cache_control(CACHEABLE_CACHE_CONTROL);
     $c->render_component('PortalExample',
         props   => {},
         stash   => { open => 0 },
@@ -333,6 +351,7 @@ my @ai_responses = (
 );
 
 $r->get('/ai-chat' => sub ($c) {
+    $c->res->headers->cache_control(CACHEABLE_CACHE_CONTROL);
     $c->render_component('AIChatInteractive',
         title   => 'AI Chat — SSE Streaming (Mojolicious)',
         heading => 'AI Chat — SSE Streaming',
@@ -588,6 +607,7 @@ my $r_blog = $r;
 # index too (data-bf-permanent) so the router moves the same live node between
 # the list and a post.
 $r_blog->get('/blog' => sub ($c) {
+    $c->res->headers->cache_control(CACHEABLE_CACHE_CONTROL);
     my $sort  = $c->param('sort') // 'date';
     my $tag   = $c->param('tag')  // '';
     my $base  = "$BASE_PATH/blog";
@@ -635,6 +655,7 @@ $r_blog->get('/blog/posts/:slug' => sub ($c) {
     my $posts = [ sort { $b->{date} cmp $a->{date} } @{ $BLOG_DATA->{posts} } ];
     my ($i) = grep { $posts->[$_]{slug} eq $slug } 0 .. $#$posts;
     return $c->reply->not_found unless defined $i;
+    $c->res->headers->cache_control(CACHEABLE_CACHE_CONTROL);
     my $p    = $posts->[$i];
     my $prev = $i > 0        ? $posts->[$i - 1] : undef;
     my $next = $i < $#$posts ? $posts->[$i + 1] : undef;

--- a/integrations/nethttp/blog.go
+++ b/integrations/nethttp/blog.go
@@ -208,6 +208,7 @@ func validSortKey(raw string) string {
 // via searchParams() on the client; on the server the same query drives both
 // `NewPostListProps` (active highlight + hrefs) and the SSR row order/visibility.
 func blogIndexHandler(w http.ResponseWriter, req *http.Request) {
+	w.Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
 	sp := bf.NewSearchParams(req.URL.RawQuery)
 	sortKey := validSortKey(sp.Get("sort"))
 	tag := sp.Get("tag")
@@ -249,6 +250,7 @@ func blogPostHandler(w http.ResponseWriter, req *http.Request) {
 		http.NotFound(w, req)
 		return
 	}
+	w.Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
 	in := PostArticleInput{
 		Slug:      a.Post.Slug,
 		Title:     a.Post.Title,

--- a/integrations/nethttp/blog.go
+++ b/integrations/nethttp/blog.go
@@ -208,7 +208,7 @@ func validSortKey(raw string) string {
 // via searchParams() on the client; on the server the same query drives both
 // `NewPostListProps` (active highlight + hrefs) and the SSR row order/visibility.
 func blogIndexHandler(w http.ResponseWriter, req *http.Request) {
-	w.Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
+	w.Header().Set("Cache-Control", cacheableCacheControl)
 	sp := bf.NewSearchParams(req.URL.RawQuery)
 	sortKey := validSortKey(sp.Get("sort"))
 	tag := sp.Get("tag")
@@ -250,7 +250,7 @@ func blogPostHandler(w http.ResponseWriter, req *http.Request) {
 		http.NotFound(w, req)
 		return
 	}
-	w.Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
+	w.Header().Set("Cache-Control", cacheableCacheControl)
 	in := PostArticleInput{
 		Slug:      a.Post.Slug,
 		Title:     a.Post.Title,

--- a/integrations/nethttp/main.go
+++ b/integrations/nethttp/main.go
@@ -157,9 +157,10 @@ func writeJSON(w http.ResponseWriter, status int, v interface{}) {
 // visitor's list is never visible to another. LRU-bounded to keep memory
 // usage predictable.
 const (
-	sessionCookieName = "bf_session"
-	sessionTTLSeconds = 60 * 60 * 24 * 30 // 30d
-	sessionStoreMax   = 1000
+	sessionCookieName     = "bf_session"
+	sessionTTLSeconds     = 60 * 60 * 24 * 30 // 30d
+	sessionStoreMax       = 1000
+	cacheableCacheControl = "public, max-age=3600, stale-while-revalidate=86400"
 )
 
 type sessionState struct {
@@ -332,7 +333,7 @@ func withLogging(next http.Handler) http.Handler {
 }
 
 func indexHandler(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
+	w.Header().Set("Cache-Control", cacheableCacheControl)
 	body := fmt.Sprintf(`
     <h1>BarefootJS + net/http Example</h1>
     <p>This example demonstrates server-side rendering with the Go standard library (net/http) and BarefootJS.</p>
@@ -363,7 +364,7 @@ func indexHandler(w http.ResponseWriter, _ *http.Request) {
 }
 
 func counterHandler(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
+	w.Header().Set("Cache-Control", cacheableCacheControl)
 	props := NewCounterProps(CounterInput{Initial: 0})
 	render(w, http.StatusOK, "Counter", bf.RenderOptions{
 		Props:   &props,
@@ -373,7 +374,7 @@ func counterHandler(w http.ResponseWriter, _ *http.Request) {
 }
 
 func toggleHandler(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
+	w.Header().Set("Cache-Control", cacheableCacheControl)
 	props := NewToggleProps(ToggleInput{
 		ToggleItems: []ToggleItemInput{
 			{Label: "Setting 1", DefaultOn: true},
@@ -437,7 +438,7 @@ func todosSSRHandler(w http.ResponseWriter, req *http.Request) {
 }
 
 func reactivePropsHandler(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
+	w.Header().Set("Cache-Control", cacheableCacheControl)
 	props := NewReactivePropsProps(ReactivePropsInput{})
 	render(w, http.StatusOK, "ReactiveProps", bf.RenderOptions{
 		Props:   &props,
@@ -447,7 +448,7 @@ func reactivePropsHandler(w http.ResponseWriter, _ *http.Request) {
 }
 
 func propsReactivityHandler(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
+	w.Header().Set("Cache-Control", cacheableCacheControl)
 	props := NewPropsReactivityComparisonProps(PropsReactivityComparisonInput{})
 	render(w, http.StatusOK, "PropsReactivityComparison", bf.RenderOptions{
 		Props:   &props,
@@ -457,7 +458,7 @@ func propsReactivityHandler(w http.ResponseWriter, _ *http.Request) {
 }
 
 func formHandler(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
+	w.Header().Set("Cache-Control", cacheableCacheControl)
 	props := NewFormProps(FormInput{})
 	render(w, http.StatusOK, "Form", bf.RenderOptions{
 		Props:   &props,
@@ -467,7 +468,7 @@ func formHandler(w http.ResponseWriter, _ *http.Request) {
 }
 
 func portalHandler(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
+	w.Header().Set("Cache-Control", cacheableCacheControl)
 	props := NewPortalExampleProps(PortalExampleInput{})
 	render(w, http.StatusOK, "PortalExample", bf.RenderOptions{
 		Props:   &props,
@@ -477,7 +478,7 @@ func portalHandler(w http.ResponseWriter, _ *http.Request) {
 }
 
 func conditionalReturnHandler(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
+	w.Header().Set("Cache-Control", cacheableCacheControl)
 	props := NewConditionalReturnProps(ConditionalReturnInput{})
 	render(w, http.StatusOK, "ConditionalReturn", bf.RenderOptions{
 		Props:   &props,
@@ -487,7 +488,7 @@ func conditionalReturnHandler(w http.ResponseWriter, _ *http.Request) {
 }
 
 func conditionalReturnLinkHandler(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
+	w.Header().Set("Cache-Control", cacheableCacheControl)
 	props := NewConditionalReturnProps(ConditionalReturnInput{Variant: "link"})
 	render(w, http.StatusOK, "ConditionalReturn", bf.RenderOptions{
 		Props:   &props,
@@ -604,7 +605,7 @@ var fakeResponses = []string{
 }
 
 func aiChatHandler(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
+	w.Header().Set("Cache-Control", cacheableCacheControl)
 	props := NewAIChatInteractiveProps(AIChatInteractiveInput{})
 	render(w, http.StatusOK, "AIChatInteractive", bf.RenderOptions{
 		Props:   &props,

--- a/integrations/nethttp/main.go
+++ b/integrations/nethttp/main.go
@@ -332,6 +332,7 @@ func withLogging(next http.Handler) http.Handler {
 }
 
 func indexHandler(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
 	body := fmt.Sprintf(`
     <h1>BarefootJS + net/http Example</h1>
     <p>This example demonstrates server-side rendering with the Go standard library (net/http) and BarefootJS.</p>
@@ -362,6 +363,7 @@ func indexHandler(w http.ResponseWriter, _ *http.Request) {
 }
 
 func counterHandler(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
 	props := NewCounterProps(CounterInput{Initial: 0})
 	render(w, http.StatusOK, "Counter", bf.RenderOptions{
 		Props:   &props,
@@ -371,6 +373,7 @@ func counterHandler(w http.ResponseWriter, _ *http.Request) {
 }
 
 func toggleHandler(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
 	props := NewToggleProps(ToggleInput{
 		ToggleItems: []ToggleItemInput{
 			{Label: "Setting 1", DefaultOn: true},
@@ -434,6 +437,7 @@ func todosSSRHandler(w http.ResponseWriter, req *http.Request) {
 }
 
 func reactivePropsHandler(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
 	props := NewReactivePropsProps(ReactivePropsInput{})
 	render(w, http.StatusOK, "ReactiveProps", bf.RenderOptions{
 		Props:   &props,
@@ -443,6 +447,7 @@ func reactivePropsHandler(w http.ResponseWriter, _ *http.Request) {
 }
 
 func propsReactivityHandler(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
 	props := NewPropsReactivityComparisonProps(PropsReactivityComparisonInput{})
 	render(w, http.StatusOK, "PropsReactivityComparison", bf.RenderOptions{
 		Props:   &props,
@@ -452,6 +457,7 @@ func propsReactivityHandler(w http.ResponseWriter, _ *http.Request) {
 }
 
 func formHandler(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
 	props := NewFormProps(FormInput{})
 	render(w, http.StatusOK, "Form", bf.RenderOptions{
 		Props:   &props,
@@ -461,6 +467,7 @@ func formHandler(w http.ResponseWriter, _ *http.Request) {
 }
 
 func portalHandler(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
 	props := NewPortalExampleProps(PortalExampleInput{})
 	render(w, http.StatusOK, "PortalExample", bf.RenderOptions{
 		Props:   &props,
@@ -470,6 +477,7 @@ func portalHandler(w http.ResponseWriter, _ *http.Request) {
 }
 
 func conditionalReturnHandler(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
 	props := NewConditionalReturnProps(ConditionalReturnInput{})
 	render(w, http.StatusOK, "ConditionalReturn", bf.RenderOptions{
 		Props:   &props,
@@ -479,6 +487,7 @@ func conditionalReturnHandler(w http.ResponseWriter, _ *http.Request) {
 }
 
 func conditionalReturnLinkHandler(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
 	props := NewConditionalReturnProps(ConditionalReturnInput{Variant: "link"})
 	render(w, http.StatusOK, "ConditionalReturn", bf.RenderOptions{
 		Props:   &props,
@@ -595,6 +604,7 @@ var fakeResponses = []string{
 }
 
 func aiChatHandler(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400")
 	props := NewAIChatInteractiveProps(AIChatInteractiveInput{})
 	render(w, http.StatusOK, "AIChatInteractive", bf.RenderOptions{
 		Props:   &props,

--- a/integrations/php/index.php
+++ b/integrations/php/index.php
@@ -170,6 +170,7 @@ function stash_from_ssr_defaults(string $component, array $props): array
 // ---------------------------------------------------------------------------
 const SESSION_COOKIE = 'bf_session';
 const SESSION_TTL_SEC = 60 * 60 * 24 * 30;
+const CACHE_CONTROL_HEADER = 'Cache-Control: public, max-age=3600, stale-while-revalidate=86400';
 
 function seed_todos(): array
 {
@@ -673,7 +674,7 @@ function blog_index_route(): void
     );
     $now = blog_island($root, 'NowPlaying', [], ['Math' => ['min' => 0]]);
     $title = $tag !== '' ? "#{$tag} \u{2014} Barefoot Blog" : 'Barefoot Blog \u{2014} Latest posts';
-    header('Cache-Control: public, max-age=3600, stale-while-revalidate=86400');
+    header(CACHE_CONTROL_HEADER);
     html_response(blog_page($root, $title, $base, $postList . $now));
 }
 
@@ -725,7 +726,7 @@ function blog_post_route(string $slug): void
             'now_playing' => ['NowPlaying', ['Math' => ['min' => 0]]],
         ],
     );
-    header('Cache-Control: public, max-age=3600, stale-while-revalidate=86400');
+    header(CACHE_CONTROL_HEADER);
     html_response(blog_page($root, "{$p['title']} \u{2014} Barefoot Blog", $base, $content));
 }
 
@@ -930,12 +931,12 @@ if ($method === 'GET') {
             // regardless of a stale bf_session cookie the visitor's browser
             // may still be sending from an earlier /todos visit (see
             // integrations/shared/lib/cache-control.ts).
-            header('Cache-Control: public, max-age=3600, stale-while-revalidate=86400');
+            header(CACHE_CONTROL_HEADER);
             html_response(home_page());
             exit;
 
         case $route === '/counter':
-            header('Cache-Control: public, max-age=3600, stale-while-revalidate=86400');
+            header(CACHE_CONTROL_HEADER);
             html_response(render_component('Counter', heading: 'Counter Component'));
             exit;
 
@@ -945,7 +946,7 @@ if ($method === 'GET') {
                 ['label' => 'Setting 2', 'defaultOn' => false],
                 ['label' => 'Setting 3', 'defaultOn' => false],
             ];
-            header('Cache-Control: public, max-age=3600, stale-while-revalidate=86400');
+            header(CACHE_CONTROL_HEADER);
             html_response(render_component(
                 'Toggle',
                 heading: 'Toggle Component',
@@ -956,12 +957,12 @@ if ($method === 'GET') {
             exit;
 
         case $route === '/form':
-            header('Cache-Control: public, max-age=3600, stale-while-revalidate=86400');
+            header(CACHE_CONTROL_HEADER);
             html_response(render_component('Form', heading: 'Form Example', props: [], stash: ['accepted' => false]));
             exit;
 
         case $route === '/reactive-props':
-            header('Cache-Control: public, max-age=3600, stale-while-revalidate=86400');
+            header(CACHE_CONTROL_HEADER);
             html_response(render_component(
                 'ReactiveProps',
                 heading: 'Reactive Props Test',
@@ -980,7 +981,7 @@ if ($method === 'GET') {
             // signal_init override needed here: PropsStyleChild /
             // DestructuredStyleChild's compiled templates already derive
             // `displayValue` in-template (`{% set displayValue = value * 10 %}`).
-            header('Cache-Control: public, max-age=3600, stale-while-revalidate=86400');
+            header(CACHE_CONTROL_HEADER);
             html_response(render_component(
                 'PropsReactivityComparison',
                 heading: 'Props Reactivity Comparison',
@@ -995,7 +996,7 @@ if ($method === 'GET') {
 
         case $route === '/conditional-return' || $route === '/conditional-return-link':
             $variant = str_ends_with($route, '-link') ? 'link' : '';
-            header('Cache-Control: public, max-age=3600, stale-while-revalidate=86400');
+            header(CACHE_CONTROL_HEADER);
             html_response(render_component(
                 'ConditionalReturn',
                 heading: 'Conditional Return Example' . ($variant !== '' ? ' (Link)' : ''),
@@ -1005,12 +1006,12 @@ if ($method === 'GET') {
             exit;
 
         case $route === '/portal':
-            header('Cache-Control: public, max-age=3600, stale-while-revalidate=86400');
+            header(CACHE_CONTROL_HEADER);
             html_response(render_component('PortalExample', heading: 'Portal Example', props: [], stash: ['open' => false]));
             exit;
 
         case $route === '/ai-chat':
-            header('Cache-Control: public, max-age=3600, stale-while-revalidate=86400');
+            header(CACHE_CONTROL_HEADER);
             html_response(render_component(
                 'AIChatInteractive',
                 title: 'AI Chat -- SSE Streaming (PHP)',

--- a/integrations/php/index.php
+++ b/integrations/php/index.php
@@ -673,6 +673,7 @@ function blog_index_route(): void
     );
     $now = blog_island($root, 'NowPlaying', [], ['Math' => ['min' => 0]]);
     $title = $tag !== '' ? "#{$tag} \u{2014} Barefoot Blog" : 'Barefoot Blog \u{2014} Latest posts';
+    header('Cache-Control: public, max-age=3600, stale-while-revalidate=86400');
     html_response(blog_page($root, $title, $base, $postList . $now));
 }
 
@@ -724,6 +725,7 @@ function blog_post_route(string $slug): void
             'now_playing' => ['NowPlaying', ['Math' => ['min' => 0]]],
         ],
     );
+    header('Cache-Control: public, max-age=3600, stale-while-revalidate=86400');
     html_response(blog_page($root, "{$p['title']} \u{2014} Barefoot Blog", $base, $content));
 }
 
@@ -924,10 +926,16 @@ if (preg_match('#^/blog/posts/([^/]+)$#', $route, $m) && $method === 'GET') {
 if ($method === 'GET') {
     switch (true) {
         case $route === '/':
+            // Session-free demo route: cacheable at the Workers Cache layer
+            // regardless of a stale bf_session cookie the visitor's browser
+            // may still be sending from an earlier /todos visit (see
+            // integrations/shared/lib/cache-control.ts).
+            header('Cache-Control: public, max-age=3600, stale-while-revalidate=86400');
             html_response(home_page());
             exit;
 
         case $route === '/counter':
+            header('Cache-Control: public, max-age=3600, stale-while-revalidate=86400');
             html_response(render_component('Counter', heading: 'Counter Component'));
             exit;
 
@@ -937,6 +945,7 @@ if ($method === 'GET') {
                 ['label' => 'Setting 2', 'defaultOn' => false],
                 ['label' => 'Setting 3', 'defaultOn' => false],
             ];
+            header('Cache-Control: public, max-age=3600, stale-while-revalidate=86400');
             html_response(render_component(
                 'Toggle',
                 heading: 'Toggle Component',
@@ -947,10 +956,12 @@ if ($method === 'GET') {
             exit;
 
         case $route === '/form':
+            header('Cache-Control: public, max-age=3600, stale-while-revalidate=86400');
             html_response(render_component('Form', heading: 'Form Example', props: [], stash: ['accepted' => false]));
             exit;
 
         case $route === '/reactive-props':
+            header('Cache-Control: public, max-age=3600, stale-while-revalidate=86400');
             html_response(render_component(
                 'ReactiveProps',
                 heading: 'Reactive Props Test',
@@ -969,6 +980,7 @@ if ($method === 'GET') {
             // signal_init override needed here: PropsStyleChild /
             // DestructuredStyleChild's compiled templates already derive
             // `displayValue` in-template (`{% set displayValue = value * 10 %}`).
+            header('Cache-Control: public, max-age=3600, stale-while-revalidate=86400');
             html_response(render_component(
                 'PropsReactivityComparison',
                 heading: 'Props Reactivity Comparison',
@@ -983,6 +995,7 @@ if ($method === 'GET') {
 
         case $route === '/conditional-return' || $route === '/conditional-return-link':
             $variant = str_ends_with($route, '-link') ? 'link' : '';
+            header('Cache-Control: public, max-age=3600, stale-while-revalidate=86400');
             html_response(render_component(
                 'ConditionalReturn',
                 heading: 'Conditional Return Example' . ($variant !== '' ? ' (Link)' : ''),
@@ -992,10 +1005,12 @@ if ($method === 'GET') {
             exit;
 
         case $route === '/portal':
+            header('Cache-Control: public, max-age=3600, stale-while-revalidate=86400');
             html_response(render_component('PortalExample', heading: 'Portal Example', props: [], stash: ['open' => false]));
             exit;
 
         case $route === '/ai-chat':
+            header('Cache-Control: public, max-age=3600, stale-while-revalidate=86400');
             html_response(render_component(
                 'AIChatInteractive',
                 title: 'AI Chat -- SSE Streaming (PHP)',

--- a/integrations/rails/app/controllers/application_controller.rb
+++ b/integrations/rails/app/controllers/application_controller.rb
@@ -7,6 +7,12 @@ class ApplicationController < ActionController::Base
   # note); never look up a layout template.
   layout false
 
+  # Cache-Control for a session-free demo route: cacheable at the Workers
+  # Cache layer regardless of a stale bf_session cookie the visitor's browser
+  # may still be sending from an earlier /todos visit (that cookie's Path is
+  # the whole integration, not /todos — see integrations/shared/lib/cache-control.ts).
+  CACHE_CONTROL = 'public, max-age=3600, stale-while-revalidate=86400'
+
   # Stateless JSON API + hydration showcase — no CSRF tokens (matches Sinatra).
   skip_forgery_protection
 

--- a/integrations/rails/app/controllers/blog_controller.rb
+++ b/integrations/rails/app/controllers/blog_controller.rb
@@ -5,7 +5,14 @@
 # all sharing one request-scoped script collector (`root`). Direct port of the
 # Sinatra example's blog routes.
 class BlogController < ApplicationController
+  # Both actions here are confirmed session-free (no cookies/session reads),
+  # so set Cache-Control explicitly — otherwise a stale bf_session cookie from
+  # a prior /todos visit (Path is the whole integration, not /todos) would
+  # make withCacheControl treat these as private (see cache-control.ts).
+  CACHE_CONTROL = 'public, max-age=3600, stale-while-revalidate=86400'
+
   def index
+    response.headers['Cache-Control'] = CACHE_CONTROL
     root = BarefootJS::Context.new(ExampleApp::BACKEND)
     base = "#{ExampleApp::BASE}/blog"
     sort = params[:sort] || 'date'
@@ -44,6 +51,11 @@ class BlogController < ApplicationController
     i = posts.index { |p| p[:slug] == params[:slug] }
     return render plain: 'Not Found', status: :not_found unless i
 
+    # Only the found (200) path is cacheable — set it here, not before the
+    # not-found guard above, so a bad slug's 404 doesn't get pinned `public`
+    # for an hour (withCacheControl leaves an explicit Cache-Control alone
+    # regardless of status once the backend sets one itself).
+    response.headers['Cache-Control'] = CACHE_CONTROL
     p = posts[i]
     prev_post = i.positive? ? posts[i - 1] : nil
     next_post = i < posts.length - 1 ? posts[i + 1] : nil

--- a/integrations/rails/app/controllers/blog_controller.rb
+++ b/integrations/rails/app/controllers/blog_controller.rb
@@ -7,9 +7,8 @@
 class BlogController < ApplicationController
   # Both actions here are confirmed session-free (no cookies/session reads),
   # so set Cache-Control explicitly — otherwise a stale bf_session cookie from
-  # a prior /todos visit (Path is the whole integration, not /todos) would
-  # make withCacheControl treat these as private (see cache-control.ts).
-  CACHE_CONTROL = 'public, max-age=3600, stale-while-revalidate=86400'
+  # a prior /todos visit would make withCacheControl treat these as private.
+  # CACHE_CONTROL is inherited from ApplicationController.
 
   def index
     response.headers['Cache-Control'] = CACHE_CONTROL

--- a/integrations/rails/app/controllers/pages_controller.rb
+++ b/integrations/rails/app/controllers/pages_controller.rb
@@ -3,7 +3,15 @@
 # The static-ish page group: the example index plus every non-todo, non-blog
 # component demo. Each action is a 1:1 port of the matching Sinatra route.
 class PagesController < ApplicationController
+  # Cache-Control set explicitly on every action here (all confirmed
+  # session-free — no cookies/session reads) so Workers Cache can serve
+  # repeat visits without waking the Container, even if the browser still
+  # carries a stale bf_session cookie from a prior /todos visit (that cookie's
+  # Path is the whole integration, not /todos — see cache-control.ts).
+  CACHE_CONTROL = 'public, max-age=3600, stale-while-revalidate=86400'
+
   def index
+    response.headers['Cache-Control'] = CACHE_CONTROL
     base = ExampleApp::BASE
     body = <<~HTML
       <p>This example renders the same shared JSX components on Ruby on Rails
@@ -23,10 +31,12 @@ class PagesController < ApplicationController
   end
 
   def counter
+    response.headers['Cache-Control'] = CACHE_CONTROL
     render_component('Counter', heading: 'Counter Component')
   end
 
   def toggle
+    response.headers['Cache-Control'] = CACHE_CONTROL
     items = [
       { label: 'Setting 1', defaultOn: true },
       { label: 'Setting 2', defaultOn: false },
@@ -41,10 +51,12 @@ class PagesController < ApplicationController
   end
 
   def form
+    response.headers['Cache-Control'] = CACHE_CONTROL
     render_component('Form', heading: 'Form Example', props: {}, stash: { accepted: false })
   end
 
   def reactive_props
+    response.headers['Cache-Control'] = CACHE_CONTROL
     render_component('ReactiveProps',
                      heading: 'Reactive Props Test',
                      children: { 'reactive_child' => 'ReactiveChild' },
@@ -52,6 +64,7 @@ class PagesController < ApplicationController
   end
 
   def conditional_return
+    response.headers['Cache-Control'] = CACHE_CONTROL
     variant = params[:link] ? 'link' : ''
     render_component('ConditionalReturn',
                      heading: "Conditional Return Example#{variant.empty? ? '' : ' (Link)'}",
@@ -60,6 +73,7 @@ class PagesController < ApplicationController
   end
 
   def props_reactivity
+    response.headers['Cache-Control'] = CACHE_CONTROL
     mk = ->(p) { { displayValue: (p[:value] || 0) * 10 } }
     render_component('PropsReactivityComparison',
                      heading: 'Props Reactivity Comparison',
@@ -69,10 +83,12 @@ class PagesController < ApplicationController
   end
 
   def portal
+    response.headers['Cache-Control'] = CACHE_CONTROL
     render_component('PortalExample', heading: 'Portal Example', props: {}, stash: { open: false })
   end
 
   def ai_chat
+    response.headers['Cache-Control'] = CACHE_CONTROL
     render_component('AIChatInteractive',
                      title: 'AI Chat — SSE Streaming (Rails)',
                      heading: 'AI Chat — SSE Streaming',

--- a/integrations/rails/app/controllers/pages_controller.rb
+++ b/integrations/rails/app/controllers/pages_controller.rb
@@ -6,9 +6,8 @@ class PagesController < ApplicationController
   # Cache-Control set explicitly on every action here (all confirmed
   # session-free — no cookies/session reads) so Workers Cache can serve
   # repeat visits without waking the Container, even if the browser still
-  # carries a stale bf_session cookie from a prior /todos visit (that cookie's
-  # Path is the whole integration, not /todos — see cache-control.ts).
-  CACHE_CONTROL = 'public, max-age=3600, stale-while-revalidate=86400'
+  # carries a stale bf_session cookie from a prior /todos visit. CACHE_CONTROL
+  # is inherited from ApplicationController.
 
   def index
     response.headers['Cache-Control'] = CACHE_CONTROL

--- a/integrations/sinatra/app.rb
+++ b/integrations/sinatra/app.rb
@@ -357,7 +357,15 @@ class SinatraApp < Sinatra::Base
   # Rack::Builder `map`.
   # -----------------------------------------------------------------------
 
+  # Set on every session-free demo route below (confirmed: none of them call
+  # get_session / read request.cookies) so Workers Cache can serve repeat
+  # visits without waking the Container, even if the browser still carries a
+  # stale bf_session cookie from a prior /todos visit (that cookie's Path is
+  # the whole integration, not /todos — see ../shared/lib/cache-control.ts).
+  CACHE_CONTROL = 'public, max-age=3600, stale-while-revalidate=86400'
+
   get '/' do
+    headers 'cache-control' => CACHE_CONTROL
     layout(title: 'BarefootJS + Sinatra Example', heading: 'BarefootJS + Sinatra Example', back: '', scripts: '', body: <<~HTML)
       <p>This example renders the same shared JSX components with Sinatra (ERB)
       under a plain Rack app — Sinatra's routing DSL is the only framework
@@ -374,10 +382,12 @@ class SinatraApp < Sinatra::Base
   end
 
   get '/counter' do
+    headers 'cache-control' => CACHE_CONTROL
     render_component('Counter', heading: 'Counter Component')
   end
 
   get '/toggle' do
+    headers 'cache-control' => CACHE_CONTROL
     items = [
       { label: 'Setting 1', defaultOn: true },
       { label: 'Setting 2', defaultOn: false },
@@ -392,10 +402,12 @@ class SinatraApp < Sinatra::Base
   end
 
   get '/form' do
+    headers 'cache-control' => CACHE_CONTROL
     render_component('Form', heading: 'Form Example', props: {}, stash: { accepted: false })
   end
 
   get '/reactive-props' do
+    headers 'cache-control' => CACHE_CONTROL
     render_component('ReactiveProps',
                       heading: 'Reactive Props Test',
                       children: { 'reactive_child' => 'ReactiveChild' },
@@ -403,6 +415,7 @@ class SinatraApp < Sinatra::Base
   end
 
   get %r{/conditional-return(-link)?} do
+    headers 'cache-control' => CACHE_CONTROL
     variant = params[:captures]&.first == '-link' ? 'link' : ''
     render_component('ConditionalReturn',
                       heading: "Conditional Return Example#{variant.empty? ? '' : ' (Link)'}",
@@ -411,6 +424,7 @@ class SinatraApp < Sinatra::Base
   end
 
   get '/props-reactivity' do
+    headers 'cache-control' => CACHE_CONTROL
     mk = ->(p) { { displayValue: (p[:value] || 0) * 10 } }
     render_component('PropsReactivityComparison',
                       heading: 'Props Reactivity Comparison',
@@ -420,10 +434,12 @@ class SinatraApp < Sinatra::Base
   end
 
   get '/portal' do
+    headers 'cache-control' => CACHE_CONTROL
     render_component('PortalExample', heading: 'Portal Example', props: {}, stash: { open: false })
   end
 
   get '/ai-chat' do
+    headers 'cache-control' => CACHE_CONTROL
     render_component('AIChatInteractive',
                       title: 'AI Chat — SSE Streaming (Sinatra)',
                       heading: 'AI Chat — SSE Streaming',
@@ -521,6 +537,7 @@ class SinatraApp < Sinatra::Base
 
   # --- blog routes ---
   get '/blog' do
+    headers 'cache-control' => CACHE_CONTROL
     root = BarefootJS::Context.new(BACKEND)
     base = "#{BASE}/blog"
     sort = params[:sort] || 'date'
@@ -559,6 +576,11 @@ class SinatraApp < Sinatra::Base
     i = posts.index { |p| p[:slug] == params[:slug] }
     halt 404, 'Not Found' unless i
 
+    # Only the found (200) path is cacheable — set it here, not before the
+    # halt above, so a bad slug's 404 doesn't get pinned `public` for an hour
+    # (withCacheControl leaves an explicit Cache-Control alone regardless of
+    # status once the backend sets one itself).
+    headers 'cache-control' => CACHE_CONTROL
     p = posts[i]
     prev_post = i.positive? ? posts[i - 1] : nil
     next_post = i < posts.length - 1 ? posts[i + 1] : nil

--- a/integrations/xslate/app.psgi
+++ b/integrations/xslate/app.psgi
@@ -46,6 +46,15 @@ use constant {
     SESSION_TTL_SEC   => 60 * 60 * 24 * 30,
     SESSION_STORE_MAX => 1000,
 };
+
+# Explicit Cache-Control for routes confirmed session-free (no cookie/session
+# access anywhere in the handler). Setting this here makes the route
+# cacheable by integrations/shared/lib/cache-control.ts's withCacheControl
+# regardless of whether the visitor's browser happens to still be sending a
+# stale bf_session cookie (its Path is $BASE, not scoped to /todos, so once a
+# visitor has ever hit /todos it rides along on every request to this
+# integration). Must match HTML_CACHE_CONTROL there verbatim.
+use constant CACHEABLE_CACHE_CONTROL => 'public, max-age=3600, stale-while-revalidate=86400';
 my %sessions;
 my @session_order;
 
@@ -218,10 +227,11 @@ my @ai_responses = (
 # Routes — PATH_INFO here is already stripped of $BASE by Plack::Builder mount.
 # ---------------------------------------------------------------------------
 # --- page handlers: one sub per route, each returns a PSGI response ---
-sub home_route ($req) { html_response(home_page()) }
+sub home_route ($req) { html_response(home_page(), 'Cache-Control' => CACHEABLE_CACHE_CONTROL) }
 
 sub counter_route ($req) {
-    html_response(render_component('Counter', heading => 'Counter Component'));
+    html_response(render_component('Counter', heading => 'Counter Component'),
+        'Cache-Control' => CACHEABLE_CACHE_CONTROL);
 }
 
 sub toggle_route ($req) {
@@ -236,19 +246,21 @@ sub toggle_route ($req) {
         signal_init => { toggle_item => sub ($p) { (on => ($p->{defaultOn} ? 1 : 0)) } },
         props       => { toggleItems => $items },
         stash       => { toggleItems => $items },
-    ));
+    ), 'Cache-Control' => CACHEABLE_CACHE_CONTROL);
 }
 
 sub form_route ($req) {
     html_response(render_component('Form',
-        heading => 'Form Example', props => {}, stash => { accepted => 0 }));
+        heading => 'Form Example', props => {}, stash => { accepted => 0 }),
+        'Cache-Control' => CACHEABLE_CACHE_CONTROL);
 }
 
 sub reactive_props_route ($req) {
     html_response(render_component('ReactiveProps',
         heading  => 'Reactive Props Test',
         children => { reactive_child => 'ReactiveChild' },
-        props    => {}, stash => { count => 0, doubled => 0 }));
+        props    => {}, stash => { count => 0, doubled => 0 }),
+        'Cache-Control' => CACHEABLE_CACHE_CONTROL);
 }
 
 sub conditional_return_route ($req, $suffix = '') {
@@ -256,7 +268,8 @@ sub conditional_return_route ($req, $suffix = '') {
     html_response(render_component('ConditionalReturn',
         heading => 'Conditional Return Example' . ($variant ? ' (Link)' : ''),
         props   => { variant => $variant },
-        stash   => { variant => $variant, count => 0 }));
+        stash   => { variant => $variant, count => 0 }),
+        'Cache-Control' => CACHEABLE_CACHE_CONTROL);
 }
 
 sub props_reactivity_route ($req) {
@@ -265,12 +278,14 @@ sub props_reactivity_route ($req) {
         heading     => 'Props Reactivity Comparison',
         children    => { props_style_child => 'PropsStyleChild', destructured_style_child => 'DestructuredStyleChild' },
         signal_init => { props_style_child => $mk, destructured_style_child => $mk },
-        props => {}, stash => { count => 1 }));
+        props => {}, stash => { count => 1 }),
+        'Cache-Control' => CACHEABLE_CACHE_CONTROL);
 }
 
 sub portal_route ($req) {
     html_response(render_component('PortalExample',
-        heading => 'Portal Example', props => {}, stash => { open => 0 }));
+        heading => 'Portal Example', props => {}, stash => { open => 0 }),
+        'Cache-Control' => CACHEABLE_CACHE_CONTROL);
 }
 
 sub ai_chat_route ($req) {
@@ -278,7 +293,8 @@ sub ai_chat_route ($req) {
         title     => 'AI Chat — SSE Streaming (Text::Xslate)',
         heading   => 'AI Chat — SSE Streaming',
         stash     => { messages => [], input => '', streamingText => '', isStreaming => 0 },
-        extra_css => qq{<link rel="stylesheet" href="$BASE/styles/ai-chat.css">}));
+        extra_css => qq{<link rel="stylesheet" href="$BASE/styles/ai-chat.css">}),
+        'Cache-Control' => CACHEABLE_CACHE_CONTROL);
 }
 
 sub todos_route ($req, $suffix = '') {
@@ -512,7 +528,8 @@ sub blog_index_route ($req) {
         { post_list_item => 'PostListItem' });
     my $now = blog_island($root, 'NowPlaying', {}, { Math => { min => 0 } });
     my $title = length $tag ? "#$tag \x{2014} Barefoot Blog" : "Barefoot Blog \x{2014} Latest posts";
-    html_response(blog_page($root, $title, $base, $post_list . $now));
+    html_response(blog_page($root, $title, $base, $post_list . $now),
+        'Cache-Control' => CACHEABLE_CACHE_CONTROL);
 }
 
 sub blog_post_route ($req, $slug) {
@@ -544,7 +561,8 @@ sub blog_post_route ($req, $slug) {
             reading_timer => 'ReadingTimer',
             now_playing   => [ 'NowPlaying', { Math => { min => 0 } } ],
         });
-    html_response(blog_page($root, "$p->{title} \x{2014} Barefoot Blog", $base, $content));
+    html_response(blog_page($root, "$p->{title} \x{2014} Barefoot Blog", $base, $content),
+        'Cache-Control' => CACHEABLE_CACHE_CONTROL);
 }
 
 # Route table: [ METHOD, path pattern, handler ]. First match wins; any regex


### PR DESCRIPTION
## Follow-up to #2791

`integrations/shared/lib/cache-control.ts`'s `withCacheControl` excludes any request carrying a `Cookie` header from caching, to protect the cookie-backed Todo demo (`/todos`, `/api/todos/*`) from the cross-session leak fixed in #2790/#2791.

But `bf_session`'s cookie `Path` is the whole integration's base path (e.g. `Path=/integrations/gin`), not scoped to `/todos`. Confirmed live in production: once a visitor has ever visited `/todos`, every subsequent request to **any** route in that integration — Counter, Toggle, Blog, AI Chat, all completely stateless — carries the cookie and gets excluded from caching too, even though those routes never touch session state. That defeats a good share of the Container-wake-up savings this whole caching project exists for.

### The fix

Each of the 15 backends now explicitly sets `Cache-Control: public, max-age=3600, stale-while-revalidate=86400` (verbatim match to `HTML_CACHE_CONTROL`) on its confirmed session-free routes: `/`, `/counter`, `/toggle`, `/form`, `/reactive-props`, `/props-reactivity`, `/conditional-return(-link)`, `/portal`, `/ai-chat` (page only), `/blog`, `/blog/posts/*`.

`withCacheControl` already treats a response that carries its own `Cache-Control` as authoritative and leaves it alone — so this opts these routes into caching regardless of the visitor's cookie state, without touching the shared helper or weakening its default protection for anything that doesn't explicitly opt in (still an allowlist, same principle as #2791).

`/todos`, `/todos-ssr`, `/api/todos/*`, and `/api/ai-chat` (SSE, already sets its own `no-cache`) are untouched in every backend.

### Verification

Every edited handler was individually confirmed session/cookie-free before being touched (no handler reads a cookie or calls the backend's session helper — verified per-language, route tables cross-checked across all 15 backends to confirm they're identical).

`blog/posts/:slug` handlers set the header only on the 200 success path, after the not-found guard, in every backend. An unconditional set (which is how a first implementation pass placed it in the 4 Go backends before I caught and fixed it) would have let a 404 for a bad slug get cached `public` for an hour — the same class of bug caught earlier in `cache-control.ts`'s own asset branch (see #2791's commit history).

- `gin`/`chi`/`echo`/`nethttp` — `go build` clean
- `axum` — `cargo check` clean
- `flask`/`django`/`fastapi` — `py_compile` clean (no venv in this sandbox, so import-level checks weren't possible)
- `rails`/`sinatra` — `ruby -c` clean (no gems installed, so this is syntax-only)
- `blade`/`php`/`laravel` — `php -l` clean
- `mojolicious` — `perl -c` clean; `xslate`'s `perl -c` hits an unrelated missing-module error in this sandbox (`Plack::Request` not installed), not a syntax issue in the diff

### Test plan

- [x] Static verification above for all 15 backends
- [ ] Manual spot-check on a preview/live deploy: confirm `/integrations/gin/counter` (etc.) gets `Cache-Control: public, ...` and eventually `CF-Cache-Status: HIT` even from a browser that has a `bf_session` cookie from visiting `/todos`
- [ ] Confirm `/blog/posts/<nonexistent-slug>` still returns 404 with no caching in at least one backend

---
_Generated by [Claude Code](https://claude.ai/code/session_016sbzmNrgux5xstrfRLbeKL)_