### PR TITLE
Fix #2797: emit loop-row preamble on the component loop-plan variant

### DIFF
--- a/.changeset/component-loop-preamble-declaration.md
+++ b/.changeset/component-loop-preamble-declaration.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Fix #2797: a loop-row preamble local (e.g. `const handleRowClick = () => {...}` declared inside a `.map()` callback) referenced only as a prop value on a child-component-per-row loop had its declaration dropped from the emitted module while the call site survived — a guaranteed `ReferenceError` at runtime. The `'component'` loop-plan variant now declares its preamble the same way the `'plain'` and `'composite'` variants already do, hoisted once before the hydration-reuse/fresh-row split so both branches read the same value.

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -1311,6 +1311,24 @@
         "text"
       ]
     },
+    "component-row-loop-preamble-handler": {
+      "kinds": [
+        "array-literal",
+        "call",
+        "identifier",
+        "literal",
+        "member",
+        "object-literal"
+      ],
+      "axes": [
+        "literal:number",
+        "literal:string"
+      ],
+      "contexts": [
+        "loop",
+        "text"
+      ]
+    },
     "component-with-jsx-children": {
       "kinds": [
         "call",
@@ -5710,18 +5728,18 @@
     }
   },
   "kindCounts": {
-    "array-literal": 84,
+    "array-literal": 85,
     "array-method": 71,
     "arrow": 71,
     "binary": 94,
-    "call": 235,
+    "call": 236,
     "conditional": 27,
-    "identifier": 334,
+    "identifier": 335,
     "index-access": 14,
-    "literal": 266,
+    "literal": 267,
     "logical": 47,
-    "member": 191,
-    "object-literal": 64,
+    "member": 192,
+    "object-literal": 65,
     "template-literal": 30,
     "unary": 24,
     "unsupported": 42
@@ -5763,8 +5781,8 @@
     "binary:>=": 1,
     "literal:boolean": 56,
     "literal:null": 23,
-    "literal:number": 112,
-    "literal:string": 186,
+    "literal:number": 113,
+    "literal:string": 187,
     "logical:&&": 7,
     "logical:??": 41,
     "logical:||": 14,

--- a/packages/adapter-tests/fixtures/component-row-loop-preamble-handler.ts
+++ b/packages/adapter-tests/fixtures/component-row-loop-preamble-handler.ts
@@ -1,0 +1,65 @@
+import { createFixture } from '../src/types'
+
+/**
+ * #2797 — same defect family as #2750 (a preamble-declared const referenced
+ * only via `.map()` row machinery, dropped from the emitted module) but a
+ * DISTINCT code path: here the row body is a CHILD-COMPONENT call
+ * (`createComponent(...)`/`initChild(...)`), and the dropped identifier is
+ * passed as a PROP VALUE (`onClick={handleRowClick}`), not called directly
+ * like #2750's `ref`.
+ *
+ * `handleRowClick` is a loop-ROW preamble local (`MapCallbackPreamble`), not
+ * a component-scope const — it reads `row`/`idx`, so it can only be declared
+ * inside the `.map()` callback, never hoisted to component scope (that would
+ * be a `ReferenceError` on `row`/`idx` outside the loop). Every dynamic loop
+ * variant except `'component'` already renders its preamble
+ * (`mapPreambleWrapped`); this fixture pins that the `'component'` variant
+ * does too, declaring the preamble once before the `initChild`/
+ * `createComponent` split so both the hydration-reuse and fresh-row branches
+ * read the same value.
+ *
+ * `items` MUST be signal-backed for the same reason as `nested-loop-ref-
+ * const.ts` (#2750): a literal array takes the static fast path, which
+ * never even reaches `mapArray`'s row-construction machinery — that path
+ * would make this fixture pass regardless of whether the fix is present.
+ *
+ * `expectedHtml` is unaffected (the bug is client-JS-emission-only — SSR's
+ * template function already rendered the preamble correctly; only the
+ * client reconciler's `'component'` loop-plan variant dropped it). The
+ * regression pin is `client-js-scope.test.ts`'s automatic TS scope check:
+ * pre-fix this fixture's emitted client JS fails to typecheck (`Cannot find
+ * name 'handleRowClick'`); post-fix it passes with no changes needed to
+ * that test file. Verified directly (reverting the fix reproduces the
+ * pre-fix failure here).
+ */
+export const fixture = createFixture({
+  id: 'component-row-loop-preamble-handler',
+  description: 'a loop-row preamble local passed as a child-component prop has its declaration emitted',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+function Row({ label, onClick }: { label: string; onClick: () => void }) {
+  return <div className="row" onClick={onClick}>{label}</div>
+}
+export function ComponentRowLoop() {
+  const [items] = createSignal([
+    { id: 1, label: 'Alpha' },
+    { id: 2, label: 'Beta' },
+  ])
+  return (
+    <div>
+      {items().map((row, idx) => {
+        const handleRowClick = () => {}
+        return <Row key={row.id} label={row.label} onClick={handleRowClick} />
+      })}
+    </div>
+  )
+}
+`,
+  expectedHtml: `
+    <div bf-s="test" bf="s1">
+      <div bf-s="Row_*" bf="s1" class="row" data-key="1"><!--bf:s0-->Alpha<!--/--></div>
+      <div bf-s="Row_*" bf="s1" class="row" data-key="2"><!--bf:s0-->Beta<!--/--></div>
+    </div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/component-row-loop-preamble-handler.ts
+++ b/packages/adapter-tests/fixtures/component-row-loop-preamble-handler.ts
@@ -31,6 +31,24 @@ import { createFixture } from '../src/types'
  * name 'handleRowClick'`); post-fix it passes with no changes needed to
  * that test file. Verified directly (reverting the fix reproduces the
  * pre-fix failure here).
+ *
+ * This fixture ALSO doubles as the cross-adapter conformance pin for a
+ * second, unrelated fix landed alongside it: `handleRowClick`'s value is a
+ * function literal, which has no per-row template-expression form on any of
+ * the 8 non-Hono (template-DSL) adapters — a naive compiler would have to
+ * refuse this whole shape with `BF021` on all of them. Instead
+ * `neutralPreambleDeclarations` (jsx-to-ir.ts) ELIDES a function-valued
+ * preamble declaration from the SSR side when every read of it is an
+ * event-handler `JsxAttribute` value (`onClick={handleRowClick}` here) —
+ * every DSL adapter's own SSR prop-builder already skips an event-handler
+ * prop outright, so the elided name never needed an SSR representation in
+ * the first place. Because this fixture is part of the shared `jsxFixtures`
+ * corpus, EVERY adapter's own `runJSXConformanceTests` run (real Go/Jinja/
+ * ERB/Blade/Mojolicious/Rust(minijinja)/Twig/Xslate SSR + `expectedHtml`
+ * diff) already exercises this — no separate fixture needed. Verified
+ * directly: reverting the elision reproduces `BF021` on all 8 (confirmed on
+ * jinja and erb via real `jinja2`/Ruby renders); restoring it, this fixture
+ * renders `expectedHtml` correctly on all 9 adapters.
  */
 export const fixture = createFixture({
   id: 'component-row-loop-preamble-handler',

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -221,6 +221,7 @@ import { fixture as staticArrayFromPropsWithComponentPrecomputed } from './stati
 import { fixture as booleanDynamicAttr } from './boolean-dynamic-attr'
 import { fixture as childComponentInit } from './child-component-init'
 import { fixture as childComponentRefProp } from './child-component-ref-prop'
+import { fixture as componentRowLoopPreambleHandler } from './component-row-loop-preamble-handler'
 import { fixture as childComponentRootScopePrefix } from './child-component-root-scope-prefix'
 import { fixture as reactivePropBinding } from './reactive-prop-binding'
 import { fixture as localRecordUnionIndex } from './local-record-union-index'
@@ -714,6 +715,7 @@ export const jsxFixtures: JSXFixture[] = [
   booleanDynamicAttr,
   childComponentInit,
   childComponentRefProp,
+  componentRowLoopPreambleHandler,
   childComponentRootScopePrefix,
   reactivePropBinding,
   localRecordUnionIndex,

--- a/packages/jsx/src/__tests__/preamble-declarations.test.ts
+++ b/packages/jsx/src/__tests__/preamble-declarations.test.ts
@@ -205,3 +205,45 @@ export function Rows(props: { rows: Row[] }) {
     expect(dslErrors(source)).toEqual([])
   })
 })
+
+describe('preamble value declarations — function-literal elision (#2797)', () => {
+  // An event handler hoisted into the preamble (rather than written inline in
+  // the JSX attribute) has no template-expression form on any DSL backend —
+  // but every adapter's own SSR prop-builder already skips an event-handler
+  // prop outright, so a name read ONLY that way needs no SSR representation
+  // at all. Elided, not refused: `declarations` legally ends up `[]`.
+  test('a handler read only as an event-handler prop value elides clean, no refusal', () => {
+    const source = ROWS(`const handleClick = () => {}`, `<li key={r.id} onClick={handleClick}>{r.label}</li>`)
+    expect(loopOf(source).preamble?.declarations).toEqual([])
+    expect(dslErrors(source)).toEqual([])
+  })
+
+  test('an elided handler coexists with a genuinely lowered declaration', () => {
+    const loop = loopOf(
+      ROWS(
+        `const cls = r.done ? 'done' : 'open'\n        const handleClick = () => {}`,
+        `<li key={r.id} class={cls} onClick={handleClick}>{r.label}</li>`,
+      ),
+    )
+    // Only the lowerable declaration survives — the elided one contributes no entry.
+    expect(loop.preamble?.declarations?.map(d => d.name)).toEqual(['cls'])
+  })
+
+  // Soundness: a function-valued local read ANYWHERE other than an
+  // event-handler prop value still refuses — elision only widens what's
+  // SAFE, it never lets an SSR-relevant function read through unassigned.
+  test('a handler also read in a non-event position still refuses', () => {
+    const errors = dslErrors(
+      ROWS(`const handleClick = () => {}`, `<li key={r.id}>{handleClick.name}</li>`),
+    )
+    expect(errors.length).toBeGreaterThan(0)
+    expect(errors[0]).toMatch(/not a sequence of value declarations/)
+  })
+
+  test('a handler passed to a NON-event child prop still refuses', () => {
+    const errors = dslErrors(
+      ROWS(`const handleClick = () => {}`, `<li key={r.id} data-fn={handleClick}>{r.label}</li>`),
+    )
+    expect(errors.length).toBeGreaterThan(0)
+  })
+})

--- a/packages/jsx/src/ir-to-client-js/control-flow.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow.ts
@@ -86,6 +86,18 @@ export function emitLoopUpdates(lines: string[], ctx: ClientJsContext, unsafeLoc
       !(elem.preamble && elem.preamble.builderNames.length > 0 && plan.rowConstruction === 'dom-ops'),
       `loop variant '${plan.kind}' declares dom-ops row construction but received a JSX-bearing preamble — add a Phase-1 refusal (or wire renderPreamble support) for this shape`,
     )
+    // #2797's hole, generalized: a JS-only preamble (no JSX leaf, so the
+    // check above doesn't fire) can still be silently dropped if a variant
+    // just never reads `elem.preamble` at all — which is exactly what
+    // happened to the 'component' variant before it grew
+    // `mapPreambleWrapped`. A variant that doesn't declare that field can't
+    // be checked here (nothing to read), so this only catches a variant
+    // that declares it but leaves it unpopulated for a preamble that has
+    // names to declare.
+    internalInvariant(
+      !(elem.preamble && elem.preamble.declaredNames.length > 0 && 'mapPreambleWrapped' in plan && plan.mapPreambleWrapped === ''),
+      `loop variant '${plan.kind}' has a preamble with declared names (${elem.preamble?.declaredNames.join(', ')}) but its plan's mapPreambleWrapped is empty — wire it up or the emitted call site references a name nothing declares`,
+    )
     stringifyLoop(lines, plan)
     emitLoopEventDelegation(lines, elem, plan.kind, ctx.profile ? ctx.componentName : undefined)
   }

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-component-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-component-loop.ts
@@ -26,9 +26,10 @@ import {
   isTextOnlyConditional,
   buildChildRefBindings,
 } from '../shared.ts'
-import { irChildrenToJsExpr } from '../../html-template.ts'
+import { irChildrenToJsExpr, renderPreamble } from '../../html-template.ts'
 import { buildReactiveEffectsPlan } from './build-reactive-effects.ts'
 import type { ComponentLoopPlan, NestedComponentInit } from './types.ts'
+import { internalInvariant } from '../../../errors.ts'
 
 /** @internal — prefer `buildLoopPlan`. */
 export function buildComponentLoopPlan(elem: TopLevelLoop, profileComponentName?: string): ComponentLoopPlan {
@@ -36,6 +37,22 @@ export function buildComponentLoopPlan(elem: TopLevelLoop, profileComponentName?
   const propsExpr = buildComponentPropsExpr(elem.childComponent!, elem.param)
   const keyExpr = wrapLoopParamAsAccessor(elem.key || '__idx', elem.param, elem.paramBindings)
   const { head: paramHead, unwrap: paramUnwrap } = destructureLoopParam(elem.param, elem.paramBindings)
+
+  // A component-root loop's preamble is JS-only by construction: Phase 1
+  // (jsx-to-ir.ts) already refuses and strips any preamble with a JSX leaf
+  // (`builderNames.length > 0`) on this shape, because a lowered HTML-string
+  // leaf passed as a prop would diverge from SSR's real JSX elements — see
+  // `rowConstruction: 'dom-ops'` below. `renderLeaf` is therefore never
+  // reachable here; if it ever fires, a Phase-1 refusal for the new shape
+  // that let a JSX-bearing preamble through is missing, not this line.
+  const mapPreambleWrapped = elem.preamble
+    ? renderPreamble(elem.preamble, {
+        transformJs: text => wrapLoopParamAsAccessor(text, elem.param, elem.paramBindings),
+        renderLeaf: () => {
+          internalInvariant(false, 'component-root loop received a JSX-bearing preamble — Phase 1 should have refused it')
+        },
+      })
+    : ''
 
   // Only init components at loopDepth 0 — inner-loop components are handled by their own loop
   const outerNestedComps = (elem.nestedComponents ?? []).filter(c => !c.loopDepth)
@@ -64,6 +81,7 @@ export function buildComponentLoopPlan(elem: TopLevelLoop, profileComponentName?
     // prop would diverge from SSR (which passes real JSX elements). The plan
     // dispatcher refuses a JSX-bearing preamble on this variant.
     rowConstruction: 'dom-ops',
+    mapPreambleWrapped,
     containerVar: `_${varSlotId(elem.slotId)}`,
     markerId: elem.markerId,
     arrayExpr: buildChainedArrayExpr(elem),

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/loop.ts
@@ -77,6 +77,8 @@ interface DynamicLoopCommon extends LoopPlanCommon {
   paramHead: string
   /** Statement to unwrap a destructured param at body entry. Empty when not needed. */
   paramUnwrap: string
+  /** Pre-render preamble line (already wrapped with loop param accessor). Empty when none. */
+  mapPreambleWrapped: string
 }
 
 /**
@@ -117,8 +119,6 @@ export interface LoopChildRefBinding {
  */
 interface PlainLoopVariant extends DynamicLoopCommon {
   kind: 'plain'
-  /** Pre-render preamble line (already wrapped with loop param accessor). Empty when none. */
-  mapPreambleWrapped: string
   /** HTML template string for one item. */
   template: string
   /**
@@ -225,8 +225,6 @@ interface ComponentLoopVariant extends DynamicLoopCommon {
  */
 interface CompositeLoopVariant extends DynamicLoopCommon {
   kind: 'composite'
-  /** Wrapped mapPreamble line, hoisted before the SSR/CSR split. Empty when none. */
-  mapPreambleWrapped: string
   /** Inner template HTML for the loop body (single item). */
   template: string
   /** Outer-level child components (depth 0), with `insideConditional` ones already filtered out. */

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/component-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/component-loop.ts
@@ -49,11 +49,18 @@ export function stringifyComponentLoop(lines: string[], plan: ComponentLoopPlan)
     nestedComps,
     childConditionalEffects,
     profileLoopId,
+    mapPreambleWrapped,
   } = plan
 
   const loopBfId = profileLoopId ? `, ${JSON.stringify(profileLoopId)}` : ''
   lines.push(`  mapArray(() => ${arrayExpr}, ${containerVar}, ${keyFn}, (${paramHead}, ${indexParam}, __existing) => {`)
   if (paramUnwrap) lines.push(`    ${paramUnwrap}`)
+  // The preamble's consts are referenced by componentPropsExpr's getters
+  // below, in BOTH the `initChild` (hydration-reuse) and `createComponent`
+  // (fresh row) branches — a row rebuild and a hydration-reused row must
+  // read the same preamble-computed value, so it can't be hoisted into only
+  // one branch.
+  if (mapPreambleWrapped) lines.push(`    ${mapPreambleWrapped}`)
 
   const scopedComp = nameForRegistryRef(componentName)
 

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -4108,7 +4108,7 @@ function leafIsWirelessElement(el: ts.JsxElement | ts.JsxSelfClosingElement): bo
         if (ts.isJsxSpreadAttribute(attr)) { ok = false; return }
         if (ts.isJsxAttribute(attr)) {
           const name = attr.name.getText()
-          if (/^on[A-Z]/.test(name)) { ok = false; return }
+          if (isEventHandlerAttrName(name)) { ok = false; return }
         }
       }
     }
@@ -4667,7 +4667,7 @@ function transformMapCall(
           // the conditional — the same carrier the single-return path uses. A
           // JS-runtime adapter (and the browser under /* @client */) runs it
           // verbatim.
-          preamble = preambleFromValueStatements(pre, ctx)
+          preamble = preambleFromValueStatements(pre, ctx, body.statements)
 
           // Stage 2 of spec/callback-fidelity.md, narrowed by #2447. This used
           // to refuse EVERY branch preamble on a DSL target, on the premise
@@ -4874,7 +4874,7 @@ function transformMapCall(
             valueStmts.push(stmt)
           }
           if (valueStmts.length > 0) {
-            preamble = preambleFromValueStatements(valueStmts, ctx)
+            preamble = preambleFromValueStatements(valueStmts, ctx, body.statements)
 
             // #2447. A DSL adapter cannot execute `preamble.segments` (JS
             // text), so it lowers `declarations` — one per-row local each —
@@ -5844,6 +5844,7 @@ function computePreambleReactiveNames(
 function preambleFromValueStatements(
   statements: readonly ts.Statement[],
   ctx: TransformContext,
+  bodyStatements: readonly ts.Statement[],
 ): MapCallbackPreamble {
   const segments: PreambleSegment[] = []
   const typedParts: string[] = []
@@ -5865,7 +5866,7 @@ function preambleFromValueStatements(
     declaredNames: [...declared],
     // Value-only preambles accumulate no JSX, so no child needs the array join.
     builderNames: [],
-    declarations: neutralPreambleDeclarations(statements, ctx) ?? undefined,
+    declarations: neutralPreambleDeclarations(statements, ctx, bodyStatements) ?? undefined,
     reactiveNames: reactiveNames.size > 0 ? [...reactiveNames] : undefined,
   }
 }
@@ -5882,6 +5883,7 @@ function preambleFromValueStatements(
 function neutralPreambleDeclarations(
   statements: readonly ts.Statement[],
   ctx: TransformContext,
+  bodyStatements: readonly ts.Statement[],
 ): PreambleValueDeclaration[] | null {
   const out: PreambleValueDeclaration[] = []
   for (const stmt of statements) {
@@ -5893,6 +5895,20 @@ function neutralPreambleDeclarations(
       // no adapter has a single per-row local form for that.
       if (!ts.isIdentifier(decl.name)) return null
       if (!decl.initializer) return null
+      // #2797: a function-valued local (an event handler hoisted out of the
+      // JSX attribute position, e.g. `const handleClick = () => {...}`) has
+      // no template-expression form on any backend — no DSL here has a
+      // callable value. But every adapter's own SSR component-prop builder
+      // already skips an event-handler prop (`isEventHandlerAttrName`)
+      // outright, so a name read ONLY that way needs no SSR representation
+      // at all — elide the declaration instead of refusing the whole
+      // preamble. The client-JS preamble (`segments`, not `declarations`)
+      // still carries the real closure; this only concerns what the DSL
+      // SSR template sees.
+      if (isFunctionLiteral(decl.initializer)) {
+        if (everyReadIsEventHandlerPropValue(decl.name.text, bodyStatements)) continue
+        return null
+      }
       const valueParsed = tsNodeToParsedExpr(decl.initializer)
       // The same subset gate every other DSL-lowered expression passes
       // through. An adapter that additionally cannot emit a supported shape
@@ -5907,7 +5923,74 @@ function neutralPreambleDeclarations(
       })
     }
   }
-  return out.length > 0 ? out : null
+  // Not `out.length > 0 ? out : null` — an all-elided preamble legitimately
+  // has zero declarations to emit (see MapCallbackPreamble.declarations'
+  // docstring); `[]` is what tells the Phase-1 gate "fully declared."
+  return out
+}
+
+/** `const x = () => {...}` / `const x = function () {...}` — a callable value, never a template-expression shape. */
+function isFunctionLiteral(node: ts.Expression): boolean {
+  return ts.isArrowFunction(node) || ts.isFunctionExpression(node)
+}
+
+/**
+ * Whether every read of `name` in `bodyStatements`, other than its own
+ * binding site, sits inside an event-handler `JsxAttribute`'s
+ * (`onClick`/`onInput`/...) value — i.e. `name={<ident>}` where the
+ * attribute's own name passes {@link isEventHandlerAttrName}, the exact
+ * predicate every DSL adapter's own SSR prop-builder already uses to skip an
+ * event-handler prop (e.g. `packages/adapter-jinja/src/adapter/
+ * jinja-adapter.ts`'s `renderComponent`, `packages/adapter-go-template/...`'s
+ * `prop.isEventHandler` check).
+ *
+ * Walks the raw preamble+return syntax rather than the already-built row IR
+ * (`children`) deliberately: `neutralPreambleDeclarations` runs on the
+ * PREAMBLE statements specifically, and the IR built from the return
+ * expression doesn't retain a per-occurrence link back to which SOURCE
+ * identifier fed a given `IREvent`/`IRProp` — re-deriving from syntax here
+ * keeps the safety check self-contained rather than threading that link
+ * through the IR builder for one caller.
+ *
+ * Conservative: a property-access name (`x.name`), a nested declaration's own
+ * binding, or any other read shape (a text/attr expression, a NON-event
+ * child prop, a call) fails this and falls through to the ordinary refusal —
+ * this only widens the shapes that are SAFE to elide, never narrows what was
+ * already accepted. Uses `ts.forEachChild`'s own short-circuit (a truthy
+ * return stops the walk) rather than a separate mutable flag.
+ */
+function everyReadIsEventHandlerPropValue(name: string, bodyStatements: readonly ts.Statement[]): boolean {
+  const findDisallowedRead = (node: ts.Node): true | undefined => {
+    if (ts.isIdentifier(node) && node.text === name) {
+      const isBindingName = ts.isVariableDeclaration(node.parent) && node.parent.name === node
+      const isPropertyName = ts.isPropertyAccessExpression(node.parent) && node.parent.name === node
+      if (!isBindingName && !isPropertyName) {
+        const jsxExpr = node.parent
+        const attr = jsxExpr.parent
+        const isEventHandlerAttrValue =
+          ts.isJsxExpression(jsxExpr) &&
+          ts.isJsxAttribute(attr) &&
+          attr.initializer === jsxExpr &&
+          ts.isIdentifier(attr.name) &&
+          isEventHandlerAttrName(attr.name.text)
+        if (!isEventHandlerAttrValue) return true
+      }
+    }
+    return ts.forEachChild(node, findDisallowedRead)
+  }
+  return !bodyStatements.some(findDisallowedRead)
+}
+
+/**
+ * Whether a JSX attribute name is an event handler (`onClick`, `onInput`,
+ * ...) rather than a plain attribute/prop. Shared by every site in this file
+ * that needs the same call: native-element attribute extraction (routes into
+ * `IREvent`, never rendered HTML), the preamble-verbatim-leaf wiring guard,
+ * and {@link everyReadIsEventHandlerPropValue}'s elision safety check — one
+ * decision, one implementation, per CLAUDE.md.
+ */
+function isEventHandlerAttrName(name: string): boolean {
+  return /^on[A-Z]/.test(name)
 }
 
 /** Drop the trailing separator space from the final js segment. */
@@ -6261,7 +6344,7 @@ function processAttributes(
     // they're wired up at hydration time (delegated event registration) and
     // must not leak into rendered HTML. The DOM event name is lowercase
     // (`click`, not `Click`), so strip the `on` prefix and downcase.
-    if (/^on[A-Z]/.test(rawName)) {
+    if (isEventHandlerAttrName(rawName)) {
       if (attr.initializer && ts.isJsxExpression(attr.initializer) && attr.initializer.expression) {
         const eventName = rawName.slice(2).toLowerCase()
         reportJsxBranchLocalInCallback(attr.initializer.expression, ctx)

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -936,6 +936,19 @@ export interface MapCallbackPreamble {
    * expression subset cannot model leaves this `undefined`, and the Phase-1
    * DSL gate refuses the whole loop with `/* @client *\/` guidance.
    *
+   * ONE exception (#2797): a declaration whose initializer is a function
+   * literal is ELIDED (contributes no entry here) rather than refusing the
+   * preamble, when EVERY read of that name outside its own binding sits
+   * inside an event-handler `JsxAttribute` (`/^on[A-Z]/`) value position —
+   * see `neutralPreambleDeclarations`'s `everyReadIsEventHandlerPropValue`
+   * check. Every DSL adapter's own SSR component-prop builder already skips
+   * an event-handler prop outright, so a name read only that way never needs
+   * an SSR representation; the client-JS preamble (`segments`) still carries
+   * the real closure. This can leave `declarations` a legally EMPTY array
+   * (all-declared names elided) rather than `undefined` — the Phase-1 gate
+   * checks falsiness, and `[]` is truthy, so an empty array reads as "fully
+   * declared, nothing to emit," not a refusal.
+   *
    * Declarations appear in source order and may read earlier ones; adapters
    * emit them in order, so an earlier local is in scope for a later
    * initializer, exactly as in the source.

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-conformance section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. This answers, per fixture and per adapter, whether the construct WORKS — not just whether it compiles. A construct works either as written (✓) or with a documented `/* @client */` comment (✓†, a verified, supported escape — most refusals have one). Fixtures absent from the table below work on every adapter — most as written, some via that documented escape; the headline says how many of each. Listed fixtures need attention somewhere: a bare diagnostic code is still-open debt with no escape yet, a code led by ✗ owes no escape at all (by design), and ≠ means the fixture compiles clean but its rendered output diverges from the reference.",
-    "totalFixtures": 356,
+    "totalFixtures": 357,
     "fixtures": {
       "children-passthrough-renamed": {
         "go-template": {

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -14,15 +14,15 @@
   ],
   "kinds": {
     "array-literal": {
-      "total": 84,
+      "total": 85,
       "cells": {
         "hono": {
-          "pass": 84,
-          "total": 84
+          "pass": 85,
+          "total": 85
         },
         "blade": {
-          "pass": 72,
-          "total": 84,
+          "pass": 73,
+          "total": 85,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -79,8 +79,8 @@
           ]
         },
         "erb": {
-          "pass": 73,
-          "total": 84,
+          "pass": 74,
+          "total": 85,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -131,8 +131,8 @@
           ]
         },
         "go-template": {
-          "pass": 70,
-          "total": 84,
+          "pass": 71,
+          "total": 85,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -197,8 +197,8 @@
           ]
         },
         "jinja": {
-          "pass": 72,
-          "total": 84,
+          "pass": 73,
+          "total": 85,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -255,8 +255,8 @@
           ]
         },
         "minijinja": {
-          "pass": 72,
-          "total": 84,
+          "pass": 73,
+          "total": 85,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -313,8 +313,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 73,
-          "total": 84,
+          "pass": 74,
+          "total": 85,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -365,8 +365,8 @@
           ]
         },
         "twig": {
-          "pass": 72,
-          "total": 84,
+          "pass": 73,
+          "total": 85,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -423,8 +423,8 @@
           ]
         },
         "xslate": {
-          "pass": 72,
-          "total": 84,
+          "pass": 73,
+          "total": 85,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1426,11 +1426,11 @@
       }
     },
     "call": {
-      "total": 235,
+      "total": 236,
       "cells": {
         "hono": {
-          "pass": 234,
-          "total": 235,
+          "pass": 235,
+          "total": 236,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1441,8 +1441,8 @@
           ]
         },
         "blade": {
-          "pass": 220,
-          "total": 235,
+          "pass": 221,
+          "total": 236,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1517,8 +1517,8 @@
           ]
         },
         "erb": {
-          "pass": 221,
-          "total": 235,
+          "pass": 222,
+          "total": 236,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1587,8 +1587,8 @@
           ]
         },
         "go-template": {
-          "pass": 217,
-          "total": 235,
+          "pass": 218,
+          "total": 236,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1675,8 +1675,8 @@
           ]
         },
         "jinja": {
-          "pass": 220,
-          "total": 235,
+          "pass": 221,
+          "total": 236,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1751,8 +1751,8 @@
           ]
         },
         "minijinja": {
-          "pass": 220,
-          "total": 235,
+          "pass": 221,
+          "total": 236,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1827,8 +1827,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 221,
-          "total": 235,
+          "pass": 222,
+          "total": 236,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1897,8 +1897,8 @@
           ]
         },
         "twig": {
-          "pass": 220,
-          "total": 235,
+          "pass": 221,
+          "total": 236,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1973,8 +1973,8 @@
           ]
         },
         "xslate": {
-          "pass": 220,
-          "total": 235,
+          "pass": 221,
+          "total": 236,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2194,11 +2194,11 @@
       }
     },
     "identifier": {
-      "total": 334,
+      "total": 335,
       "cells": {
         "hono": {
-          "pass": 331,
-          "total": 334,
+          "pass": 332,
+          "total": 335,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2221,8 +2221,8 @@
           ]
         },
         "blade": {
-          "pass": 315,
-          "total": 334,
+          "pass": 316,
+          "total": 335,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2317,8 +2317,8 @@
           ]
         },
         "erb": {
-          "pass": 316,
-          "total": 334,
+          "pass": 317,
+          "total": 335,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2407,8 +2407,8 @@
           ]
         },
         "go-template": {
-          "pass": 310,
-          "total": 334,
+          "pass": 311,
+          "total": 335,
           "gaps": [
             {
               "fixture": "children-passthrough-renamed",
@@ -2523,8 +2523,8 @@
           ]
         },
         "jinja": {
-          "pass": 315,
-          "total": 334,
+          "pass": 316,
+          "total": 335,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2619,8 +2619,8 @@
           ]
         },
         "minijinja": {
-          "pass": 315,
-          "total": 334,
+          "pass": 316,
+          "total": 335,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2715,8 +2715,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 315,
-          "total": 334,
+          "pass": 316,
+          "total": 335,
           "gaps": [
             {
               "fixture": "children-passthrough-renamed",
@@ -2809,8 +2809,8 @@
           ]
         },
         "twig": {
-          "pass": 315,
-          "total": 334,
+          "pass": 316,
+          "total": 335,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2905,8 +2905,8 @@
           ]
         },
         "xslate": {
-          "pass": 315,
-          "total": 334,
+          "pass": 316,
+          "total": 335,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3066,11 +3066,11 @@
       }
     },
     "literal": {
-      "total": 266,
+      "total": 267,
       "cells": {
         "hono": {
-          "pass": 265,
-          "total": 266,
+          "pass": 266,
+          "total": 267,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -3081,8 +3081,8 @@
           ]
         },
         "blade": {
-          "pass": 254,
-          "total": 266,
+          "pass": 255,
+          "total": 267,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3139,8 +3139,8 @@
           ]
         },
         "erb": {
-          "pass": 254,
-          "total": 266,
+          "pass": 255,
+          "total": 267,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3197,8 +3197,8 @@
           ]
         },
         "go-template": {
-          "pass": 250,
-          "total": 266,
+          "pass": 251,
+          "total": 267,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3271,8 +3271,8 @@
           ]
         },
         "jinja": {
-          "pass": 254,
-          "total": 266,
+          "pass": 255,
+          "total": 267,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3329,8 +3329,8 @@
           ]
         },
         "minijinja": {
-          "pass": 254,
-          "total": 266,
+          "pass": 255,
+          "total": 267,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3387,8 +3387,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 254,
-          "total": 266,
+          "pass": 255,
+          "total": 267,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3445,8 +3445,8 @@
           ]
         },
         "twig": {
-          "pass": 254,
-          "total": 266,
+          "pass": 255,
+          "total": 267,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3503,8 +3503,8 @@
           ]
         },
         "xslate": {
-          "pass": 254,
-          "total": 266,
+          "pass": 255,
+          "total": 267,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3722,11 +3722,11 @@
       }
     },
     "member": {
-      "total": 191,
+      "total": 192,
       "cells": {
         "hono": {
-          "pass": 188,
-          "total": 191,
+          "pass": 189,
+          "total": 192,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3749,8 +3749,8 @@
           ]
         },
         "blade": {
-          "pass": 172,
-          "total": 191,
+          "pass": 173,
+          "total": 192,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3845,8 +3845,8 @@
           ]
         },
         "erb": {
-          "pass": 173,
-          "total": 191,
+          "pass": 174,
+          "total": 192,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3935,8 +3935,8 @@
           ]
         },
         "go-template": {
-          "pass": 168,
-          "total": 191,
+          "pass": 169,
+          "total": 192,
           "gaps": [
             {
               "fixture": "children-passthrough-renamed",
@@ -4047,8 +4047,8 @@
           ]
         },
         "jinja": {
-          "pass": 172,
-          "total": 191,
+          "pass": 173,
+          "total": 192,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4143,8 +4143,8 @@
           ]
         },
         "minijinja": {
-          "pass": 172,
-          "total": 191,
+          "pass": 173,
+          "total": 192,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4239,8 +4239,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 172,
-          "total": 191,
+          "pass": 173,
+          "total": 192,
           "gaps": [
             {
               "fixture": "children-passthrough-renamed",
@@ -4333,8 +4333,8 @@
           ]
         },
         "twig": {
-          "pass": 172,
-          "total": 191,
+          "pass": 173,
+          "total": 192,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4429,8 +4429,8 @@
           ]
         },
         "xslate": {
-          "pass": 172,
-          "total": 191,
+          "pass": 173,
+          "total": 192,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4538,15 +4538,15 @@
       }
     },
     "object-literal": {
-      "total": 64,
+      "total": 65,
       "cells": {
         "hono": {
-          "pass": 64,
-          "total": 64
+          "pass": 65,
+          "total": 65
         },
         "blade": {
-          "pass": 61,
-          "total": 64,
+          "pass": 62,
+          "total": 65,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4565,8 +4565,8 @@
           ]
         },
         "erb": {
-          "pass": 61,
-          "total": 64,
+          "pass": 62,
+          "total": 65,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4585,8 +4585,8 @@
           ]
         },
         "go-template": {
-          "pass": 59,
-          "total": 64,
+          "pass": 60,
+          "total": 65,
           "gaps": [
             {
               "fixture": "nested-loop-ref-const",
@@ -4613,8 +4613,8 @@
           ]
         },
         "jinja": {
-          "pass": 61,
-          "total": 64,
+          "pass": 62,
+          "total": 65,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4633,8 +4633,8 @@
           ]
         },
         "minijinja": {
-          "pass": 61,
-          "total": 64,
+          "pass": 62,
+          "total": 65,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4653,8 +4653,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 61,
-          "total": 64,
+          "pass": 62,
+          "total": 65,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4673,8 +4673,8 @@
           ]
         },
         "twig": {
-          "pass": 61,
-          "total": 64,
+          "pass": 62,
+          "total": 65,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4693,8 +4693,8 @@
           ]
         },
         "xslate": {
-          "pass": 61,
-          "total": 64,
+          "pass": 62,
+          "total": 65,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -7947,15 +7947,15 @@
       }
     },
     "literal:number": {
-      "total": 112,
+      "total": 113,
       "cells": {
         "hono": {
-          "pass": 112,
-          "total": 112
+          "pass": 113,
+          "total": 113
         },
         "blade": {
-          "pass": 107,
-          "total": 112,
+          "pass": 108,
+          "total": 113,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7980,8 +7980,8 @@
           ]
         },
         "erb": {
-          "pass": 107,
-          "total": 112,
+          "pass": 108,
+          "total": 113,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8006,8 +8006,8 @@
           ]
         },
         "go-template": {
-          "pass": 105,
-          "total": 112,
+          "pass": 106,
+          "total": 113,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8040,8 +8040,8 @@
           ]
         },
         "jinja": {
-          "pass": 107,
-          "total": 112,
+          "pass": 108,
+          "total": 113,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8066,8 +8066,8 @@
           ]
         },
         "minijinja": {
-          "pass": 107,
-          "total": 112,
+          "pass": 108,
+          "total": 113,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8092,8 +8092,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 107,
-          "total": 112,
+          "pass": 108,
+          "total": 113,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8118,8 +8118,8 @@
           ]
         },
         "twig": {
-          "pass": 107,
-          "total": 112,
+          "pass": 108,
+          "total": 113,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8144,8 +8144,8 @@
           ]
         },
         "xslate": {
-          "pass": 107,
-          "total": 112,
+          "pass": 108,
+          "total": 113,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8183,15 +8183,15 @@
       }
     },
     "literal:string": {
-      "total": 186,
+      "total": 187,
       "cells": {
         "hono": {
-          "pass": 186,
-          "total": 186
+          "pass": 187,
+          "total": 187
         },
         "blade": {
-          "pass": 178,
-          "total": 186,
+          "pass": 179,
+          "total": 187,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8230,8 +8230,8 @@
           ]
         },
         "erb": {
-          "pass": 178,
-          "total": 186,
+          "pass": 179,
+          "total": 187,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8270,8 +8270,8 @@
           ]
         },
         "go-template": {
-          "pass": 175,
-          "total": 186,
+          "pass": 176,
+          "total": 187,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8322,8 +8322,8 @@
           ]
         },
         "jinja": {
-          "pass": 178,
-          "total": 186,
+          "pass": 179,
+          "total": 187,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8362,8 +8362,8 @@
           ]
         },
         "minijinja": {
-          "pass": 178,
-          "total": 186,
+          "pass": 179,
+          "total": 187,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8402,8 +8402,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 178,
-          "total": 186,
+          "pass": 179,
+          "total": 187,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8442,8 +8442,8 @@
           ]
         },
         "twig": {
-          "pass": 178,
-          "total": 186,
+          "pass": 179,
+          "total": 187,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8482,8 +8482,8 @@
           ]
         },
         "xslate": {
-          "pass": 178,
-          "total": 186,
+          "pass": 179,
+          "total": 187,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",


### PR DESCRIPTION
Fixes #2797, found by the #2481 pairwise sweep. Stacked on #2799 — same defect family (a preamble-declared const dropped from the emitted module while its call site survives), but a distinct code path and root cause.

## Bug 1: the reachability gap (client JS)

A loop-row preamble local — a `const` declared inside a `.map()` callback body, e.g. `const handleRowClick = () => {}` — referenced only as a **child-component prop value** (`onClick={handleRowClick}`) on a component-root loop had its declaration dropped from the emitted module while the call site survived. Guaranteed `ReferenceError` at runtime.

### Root cause

`LoopPlan` is a discriminated union over 4 dynamic-loop shapes. Every shape except `'component'` (a loop body that's a single child-component call) already renders its `.map()`-callback preamble via a `mapPreambleWrapped` field (`PlainLoopVariant`, `CompositeLoopVariant`). `ComponentLoopVariant` simply never had the field — `buildComponentLoopPlan` never read `elem.preamble` at all, so a preamble-declared name was silently unreachable in this one variant while the emitter still spliced in the read site.

Distinct from #2750: that bug was a reachability-graph gap for `ref` callbacks specifically (`build-references.ts`); this one is a loop-plan variant that never wires an existing, working mechanism (`renderPreamble`) at all.

### The fix

- `build-component-loop.ts`: compute `mapPreambleWrapped` via `renderPreamble` (the same single door every other variant uses), with a `renderLeaf` that's provably unreachable — Phase 1 already refuses a JSX-bearing preamble on this `dom-ops`-row-construction variant, so only JS-only preambles ever reach here.
- `component-loop.ts` (stringify): emit the preamble once, before the `initChild`/`createComponent` split, since both the hydration-reuse and fresh-row branches read the same preamble-computed value via `componentPropsExpr`'s getters.
- `plan/loop.ts`: hoisted the now-thrice-duplicated `mapPreambleWrapped` field declaration onto the shared `DynamicLoopCommon` base instead of adding a third copy across sibling interfaces (CLAUDE.md's "one decision, N implementations" defect family — caught by `simplify`).
- `control-flow.ts`: added a second, generalized `internalInvariant` in `emitLoopUpdates` — a JS-only preamble (no JSX leaf, so the existing dom-ops guard doesn't fire) can still be silently dropped if a variant just never reads `elem.preamble`, which is exactly what happened here. The new check catches any FUTURE variant that declares `mapPreambleWrapped` but leaves it unpopulated for a preamble with declared names.

## Bug 2: the same fixture also hit an unrelated DSL-adapter refusal (SSR)

Fixing bug 1 exposed a second, pre-existing gap: the fixture's shape (a `.map()` preamble declaring an event handler, passed to a child component as `onClick`) hit Phase-1's `neutralPreambleDeclarations` gate. Any preamble declaring a function value was unconditionally refused (`BF021`) on all 8 template-DSL adapters, since no DSL has a callable-value template expression — even though every DSL adapter's own SSR component-prop builder already skips an event-handler prop outright, so a name read only that way never needed an SSR representation at all.

### The fix

`neutralPreambleDeclarations` now **elides** such a declaration instead of refusing the whole preamble, when every read of the name (checked via a conservative AST walk, `everyReadIsEventHandlerPropValue`) is an event-handler `JsxAttribute` value. Any other read shape still refuses exactly as before — this only widens what's safe, never narrows what was accepted. Extracted the shared `isEventHandlerAttrName` predicate the file already had two independent inline copies of, rather than adding a third.

Verified directly against real `jinja2` and Ruby (ERB) renders, and CI confirms it on all 8 DSL adapters (Blade, ERB, Go Template, Jinja2, Mojolicious, Rust/minijinja, Twig, Xslate) — the first commit on this branch failed all 8 with `BF021`; this commit's CI run is green on all of them.

## Regression pin

New fixture `component-row-loop-preamble-handler.ts` exploits the same corpus-wide `client-js-scope.test.ts` TS-scope check #2799 uses — no bespoke test file needed. Verified directly: reverting bug 1's fix reproduces `Cannot find name 'handleRowClick'` on this fixture; restoring it passes clean. Because the fixture is part of the shared `jsxFixtures` corpus, every adapter's own real-backend conformance run also exercises bug 2's elision — reverting it reproduces `BF021` on all 8 DSL adapters. `items` is signal-backed for the same reason as #2799's fixture — a literal array would route through the static fast path and pass regardless of either fix.

## Verification

| Check | Result |
|---|---|
| `client-js-scope.test.ts` (whole corpus, incl. new fixture) | pass |
| Reverting either fix reproduces its original bug on the new fixture | confirmed |
| `packages/jsx` full compiler unit suite | pass, 0 fail |
| `packages/adapter-tests` full suite (incl. real Go/Jinja2/ERB conformance) | pass, 0 fail |
| `packages/compat` lockfile freshness (`compat.lock.json`, `support-matrix.lock.json`, regenerated) | pass, 0 fail |
| CI on this PR's head — all 8 DSL adapters + Hono + Core | green |

Design investigated by Fable (root cause + fix location for bug 1, plus the invariant-hardening approach); bug 2 found and fixed by me while verifying bug 1's fix against the full adapter suite. `code-review` and `simplify` both run on the diff before this PR (the `mapPreambleWrapped` duplication finding from `simplify`, and the `isEventHandlerAttrName` duplication, were both applied — see commit history).

Changeset added (`.changeset/component-loop-preamble-declaration.md`) — this is a compiler bug fix shipped in `@barefootjs/jsx`.

---
_Generated by [Claude Code](https://claude.ai/code/session_0198yG2px5ygfvmdoMkhRS13)_