### PR TITLE
go-template: refuse a named jsx-children prop it can't bake, instead of silently dropping it

### DIFF
--- a/.changeset/go-template-named-jsx-children-bf101.md
+++ b/.changeset/go-template-named-jsx-children-bf101.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/go-template": patch
+---
+
+Fix #2746/#2703: a named jsx-children prop (a JSX-valued prop other than the reserved `children`, e.g. `header={<strong>Title</strong>}`) whose value contained a template action that couldn't be baked into a static Go string was silently dropped — no struct field, no diagnostic. The bake chain (`extractTextChildren` → `extractHtmlChildren` → `extractScopedHtmlChildren`) now raises `BF101` when all three attempts fail, since named jsx-children props have no dynamic-delivery route on this adapter yet (only the reserved `children` slot does).

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -118,11 +118,13 @@ runAdapterConformanceTests({
     'todo-app',
     // (#1897) data-table no longer skipped — loop body children + wrapper
     // struct + block-body memo baking render correctly on Go.
-    // Real-render divergence (see `render-divergences.ts` for the full
-    // description): Go's real SSR output drops the `header` prop's
-    // content entirely for this shape, so its rendered template has no
-    // `^s0` marker for the IR's conditional to match against. Paired
-    // with the `renderDivergences` entry, not an independent gap.
+    // #2703: this shape now refuses with BF101 at compile time (see
+    // `conformance-pins.ts`) rather than silently rendering divergent
+    // markup — `expectedDiagnostics` covers the diagnostic contract, and
+    // marker comparison can't apply to a fixture that produces no
+    // complete template (`generate()` still returns partial output rather
+    // than throwing, so this stays on the explicit skip list rather than
+    // relying on the try/catch above).
     'jsx-element-prop-fragment-conditional',
   ]),
   skipDataPoints: new Set<string>([

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -2341,6 +2341,21 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
                   if (scopedHtml !== null) {
                     this.state.usesHtmlTemplate = true
                     emitChildField(prop.name, `template.HTML(${scopedHtml})`)
+                  } else {
+                    // None of the three bake attempts produced a static Go
+                    // string — the value contains a template action that
+                    // survived (#2746) or is otherwise genuinely dynamic
+                    // (#2703). Named jsx-children props have no dynamic
+                    // delivery route yet (only the reserved `children` slot
+                    // does, via `queueDynamicChildrenDefine` + `bf_with_children`
+                    // below) — refuse loudly rather than silently omitting
+                    // the field, per the sound-or-loud trichotomy.
+                    this.state.errors.push({
+                      code: 'BF101',
+                      severity: 'error',
+                      message: `JSX-valued prop '${prop.name}' on <${child.name}> could not be baked into a static Go template value — it is dynamic and named jsx-children props have no dynamic-delivery route on this adapter yet`,
+                      loc: prop.loc,
+                    })
                   }
                 }
               }

--- a/packages/adapter-go-template/src/conformance-pins.ts
+++ b/packages/adapter-go-template/src/conformance-pins.ts
@@ -68,5 +68,16 @@ export const conformancePins: ConformancePins = {
   // (`extractTextChildren`/`extractHtmlChildren`/`extractScopedHtmlChildren`)
   // can't reduce to a literal now refuses with BF101 instead of silently
   // omitting the field.
-  'jsx-element-prop-fragment-conditional': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2703' }],
+  // `unescapable`: a follow-up (#2703 itself) already extends the reserved
+  // `children` slot's dynamic-delivery route to named props, which removes
+  // this refusal entirely rather than working around it with a `/* @client */`
+  // twin — so no escape fixture is authored here. Self-declared per the
+  // escape-coverage floor test's own guidance
+  // (`packages/compat/src/escape-coverage.ts`).
+  'jsx-element-prop-fragment-conditional': [{
+    code: 'BF101',
+    severity: 'error',
+    issue: 'https://github.com/piconic-ai/barefootjs/issues/2703',
+    unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2703' },
+  }],
 }

--- a/packages/adapter-go-template/src/conformance-pins.ts
+++ b/packages/adapter-go-template/src/conformance-pins.ts
@@ -59,4 +59,14 @@ export const conformancePins: ConformancePins = {
   // `rich-prop-client-read` above.
   'jsx-element-prop-ternary': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2667' }],
   'jsx-element-prop-array': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2667' }],
+  // #2703: graduated from a silent render-divergence (`render-divergences.ts`)
+  // to a loud refusal. A named jsx-children prop (any JSX-valued prop other
+  // than the reserved `children`) has no dynamic-delivery route on this
+  // adapter yet — only the reserved `children` slot gets one, via
+  // `queueDynamicChildrenDefine` + `bf_with_children`/`bf_tmpl`. Until that
+  // route is extended to named props, a value the static bake chain
+  // (`extractTextChildren`/`extractHtmlChildren`/`extractScopedHtmlChildren`)
+  // can't reduce to a literal now refuses with BF101 instead of silently
+  // omitting the field.
+  'jsx-element-prop-fragment-conditional': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2703' }],
 }

--- a/packages/adapter-go-template/src/render-divergences.ts
+++ b/packages/adapter-go-template/src/render-divergences.ts
@@ -13,13 +13,21 @@
  * the same way it already seeded a signal-backed dynamic one: the adapter's
  * own `emission` was never the bug, only this harness's route-handler
  * stand-in was missing the prop-derived case.)
+ *
+ * (#2703's `jsx-element-prop-fragment-conditional` divergence graduated by
+ * reclassification, not a lowering fix: the underlying gap — a named
+ * jsx-children prop whose value can't be baked into a static Go string
+ * silently got no field at all, no diagnostic — is now a loud `BF101`
+ * refusal (see `conformance-pins.ts`) instead of a silent wrong render.
+ * "Compiles clean but renders divergent" no longer describes this fixture on
+ * Go, so it moved off this table. Dynamic delivery for named jsx-children
+ * props (the actual capability gap) is tracked separately at
+ * https://github.com/piconic-ai/barefootjs/issues/2703.)
  */
 
 import type { RenderDivergences } from '@barefootjs/jsx'
 
 export const renderDivergences: RenderDivergences = {
-  'jsx-element-prop-fragment-conditional':
-    'Go-specific half of the fragment-wrapped-conditional prop shape, tracked as https://github.com/piconic-ai/barefootjs/issues/2703 (distinct from #2702, the cross-adapter hydrate-time bug). #2702 is a hydrate-time-only bug (SSR is correct on every adapter, confirmed for Go by direct `adapter.generate()` inspection of the raw template TEXT, which does contain `{{if .Cond}}<a bf-c="^s0">x</a>{{else}}...{{end}}`-shaped markup). But the REAL Go render of this exact fixture (`go-template-adapter.test.ts`, real `go run`) produces an EMPTY `<header>` — `<header bf="s1"><!--bf:s0--><!--/--></header>` instead of the reference `<a>x</a>` — i.e. the `header` prop\'s jsx-children payload never reaches the child (`Card`) component\'s slot construction (`.CardSlot1`) at all for this NAMED-prop shape, even though the same conditional-in-fragment payload renders correctly when passed via `children` instead (`jsx-element-prop-children-escape`). Root cause not yet isolated to a specific emitter function — only the reproducible symptom is pinned here. Every other adapter (Hono, ERB, Jinja, Mojolicious, MiniJinja, Twig, Xslate, Blade) renders this fixture correctly; verified by running each adapter\'s own JSX Conformance Tests for this fixture id.',
   'children-passthrough-renamed':
     'A `children` prop destructured under a different name (`const { children: kids } = props`) does not reach the SSR template on Go, tracked as https://github.com/piconic-ai/barefootjs/issues/2788. The same fixture also fails on Mojolicious, where the mechanism IS isolated: the `.html.ep` interpolates the LOCAL alias (`$kids`) while the stash defines only the caller-facing `children`, so the Perl render dies inside `Mojo::Template::process`. Go\'s own failure mode has NOT been read — `go` is not reachable from the local test process (the conformance case prints "go command not found" and skips), so this entry is declared from the CI failure on #2787 alone, not from a local reproduction. Whoever graduates this should read Go\'s actual output first rather than assume it shares Mojo\'s mechanism. Same alias family as `aliased-destructured-prop` (`{ n: count }`), whose Go half graduated in #2525 — worth checking whether the reserved `children` slot bypasses that fix or never had it. `children-passthrough-renamed` asserts the CORRECT (Hono-generated) output, so deleting this entry is the graduation.',
   'signal-object-spread-init':

--- a/packages/compat/src/__tests__/compat-engine.test.ts
+++ b/packages/compat/src/__tests__/compat-engine.test.ts
@@ -46,12 +46,14 @@ describe('compileForCompat', () => {
     // `issues` is the UNION of every issue URL any BF101 pin carries on
     // this adapter (buildCompatCell attributes by code, not by fixture —
     // see its docstring) — #2320 (this shape, nested filter callback,
-    // successor to #2038) and #2321 (static-array-from-props computed loop
-    // source) surface here even though this test only exercises the nested-
-    // filter-callback shape. Three pins are no longer among them, each
-    // because the shape got a real lowering rather than a narrower refusal:
-    // #2319 (dangerous-inner-html-dynamic → a faithful raw-output lowering),
-    // #2208 (static-array-children → the loop-source gate bakes a fully-static
+    // successor to #2038), #2321 (static-array-from-props computed loop
+    // source), and #2703 (a named jsx-children prop with no dynamic-delivery
+    // route, `jsx-element-prop-fragment-conditional`) surface here even
+    // though this test only exercises the nested-filter-callback shape.
+    // Three pins are no longer among them, each because the shape got a
+    // real lowering rather than a narrower refusal: #2319
+    // (dangerous-inner-html-dynamic → a faithful raw-output lowering), #2208
+    // (static-array-children → the loop-source gate bakes a fully-static
     // array-of-objects const), and #2448 (loop-row child prop override feeding
     // a derived field → the child rebuilds itself per row through
     // `bf_reprops`). See `go-template`'s `conformance-pins.ts`.
@@ -62,6 +64,7 @@ describe('compileForCompat', () => {
         issues: [
           'https://github.com/piconic-ai/barefootjs/issues/2320',
           'https://github.com/piconic-ai/barefootjs/issues/2321',
+          'https://github.com/piconic-ai/barefootjs/issues/2703',
         ],
       },
     ])

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -2590,8 +2590,16 @@
       },
       "jsx-element-prop-fragment-conditional": {
         "go-template": {
-          "kind": "render",
-          "reason": "Go-specific half of the fragment-wrapped-conditional prop shape, tracked as https://github.com/piconic-ai/barefootjs/issues/2703 (distinct from #2702, the cross-adapter hydrate-time bug). #2702 is a hydrate-time-only bug (SSR is correct on every adapter, confirmed for Go by direct `adapter.generate()` inspection of the raw template TEXT, which does contain `{{if .Cond}}<a bf-c=\"^s0\">x</a>{{else}}...{{end}}`-shaped markup). But the REAL Go render of this exact fixture (`go-template-adapter.test.ts`, real `go run`) produces an EMPTY `<header>` — `<header bf=\"s1\"><!--bf:s0--><!--/--></header>` instead of the reference `<a>x</a>` — i.e. the `header` prop's jsx-children payload never reaches the child (`Card`) component's slot construction (`.CardSlot1`) at all for this NAMED-prop shape, even though the same conditional-in-fragment payload renders correctly when passed via `children` instead (`jsx-element-prop-children-escape`). Root cause not yet isolated to a specific emitter function — only the reproducible symptom is pinned here. Every other adapter (Hono, ERB, Jinja, Mojolicious, MiniJinja, Twig, Xslate, Blade) renders this fixture correctly; verified by running each adapter's own JSX Conformance Tests for this fixture id."
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2703"
+          ],
+          "escape": {
+            "state": "debt"
+          }
         }
       },
       "jsx-element-prop-ternary": {

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -2460,7 +2460,9 @@
             },
             {
               "fixture": "jsx-element-prop-fragment-conditional",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2703"
+              ]
             },
             {
               "fixture": "jsx-element-prop-ternary",
@@ -3222,7 +3224,9 @@
             },
             {
               "fixture": "jsx-element-prop-fragment-conditional",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2703"
+              ]
             },
             {
               "fixture": "jsx-element-prop-ternary",
@@ -3988,7 +3992,9 @@
             },
             {
               "fixture": "jsx-element-prop-fragment-conditional",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2703"
+              ]
             },
             {
               "fixture": "jsx-element-prop-ternary",
@@ -7784,7 +7790,9 @@
           "gaps": [
             {
               "fixture": "jsx-element-prop-fragment-conditional",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2703"
+              ]
             },
             {
               "fixture": "jsx-element-prop-ternary",


### PR DESCRIPTION
Part of the Family B root-cure track from #2779 (see that issue's "Family B — bounded, two layers, not a rewrite" section). This is layer (i), soundness; layer (ii), parity (extending dynamic delivery to named props), is a follow-up.

## The bug

`#2746` and `#2703` are the same silent fall-through, not two independent bugs: `extractTextChildren` → `extractHtmlChildren` → `extractScopedHtmlChildren` (`go-template-adapter.ts`) all fail for a named jsx-children prop — any JSX-valued prop other than the reserved `children`, e.g. `header={<strong>Title</strong>}` — and the caller (`emitStaticChildInstances`) emitted no struct field and no diagnostic. The generated Go struct simply lacks the field; the child component renders without the content the caller passed it.

`#2746`'s own specific trigger (a leaked `{{if .BfDataKey}}` action from `ctx.isRoot` bleeding into a JSX-valued prop subtree) is already guarded against by the existing `bakingStaticChildren` flag — but the general soundness gap it flagged (ANY other cause of unbakeable dynamism falls through the same way, with no diagnostic) remained open. `#2703` is the reproducible symptom: a fragment-wrapped conditional in a named prop renders an empty slot on real Go SSR with zero compile diagnostics, while every other adapter (Hono, ERB, Jinja, Mojolicious, MiniJinja, Twig, Xslate, Blade) renders it correctly.

## The fix

The bake chain now pushes `BF101` when all three extraction attempts return null, naming the prop and the component. This is the "loud" half of the sound-or-loud trichotomy — it does not add dynamic delivery for named jsx-children props (the actual capability gap; `queueDynamicChildrenDefine` + `bf_with_children`/`bf_tmpl` already solves this for the reserved `children` slot but isn't extended to named props yet). That's tracked as a follow-up (parity layer).

`jsx-element-prop-fragment-conditional` graduates from `render-divergences.ts` ("compiles clean, renders wrong") to `conformance-pins.ts` ("refuses loudly with BF101") — the fixture's failure *mechanism* changed, not its pass/fail status, so it stays on `skipMarkerConformance` (marker comparison can't apply to a fixture `generate()` doesn't fully complete).

## What I investigated and reverted

A second, structurally identical-looking gap in `convertInitialValue`'s object-literal fallback (`#2700` — a derived signal/memo whose value is an object literal silently seeds `nil`) was in scope for this same treatment per the original plan. Adding a `BF101` there fired on fully-static object literals used as JSX spread sources (`jsx-spread-reactive`, `jsx-spread-multiple`, `jsx-spread-static-and-spread` — caught by running the adapter's own test suite locally), where the baked constructor value is legitimately unused (spreads resolve through a separate runtime evaluator path) and a diagnostic there is a false positive. `#2700` needs a call-site-aware design — only refuse when the baked value is actually read structurally by the template — which is a bigger change than this PR's scope. Left filed and unaddressed for a follow-up.

## Verification

| Check | Result |
|---|---|
| Targeted local run (`jsx-element-prop-fragment-conditional`, reserved-children unit tests) | 4 pass, 0 fail |
| `git diff` on `value-lowering.ts` (the reverted #2700 attempt) | clean, no changes shipped |
| Full `packages/adapter-go-template` suite | not completed locally (slow real-`go run` conformance in this environment); relying on CI (`CI — Go Template Adapter`) for the full signal |

Changeset added (`@barefootjs/go-template`, patch).

---
_Generated by [Claude Code](https://claude.ai/code/session_0198yG2px5ygfvmdoMkhRS13)_