### PR TITLE
go-template: extend named-prop dynamic delivery to fix #2703

### DIFF
--- a/.changeset/go-template-named-prop-dynamic-delivery.md
+++ b/.changeset/go-template-named-prop-dynamic-delivery.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/go-template": patch
+---
+
+Fix #2703: a named jsx-children prop (a JSX-valued prop other than the reserved `children`, e.g. `header={<strong>Title</strong>}`) whose value couldn't be baked into a static Go string now renders correctly instead of refusing with `BF101` — the dynamic-delivery route the reserved `children` slot already had (`bf_with_props` + `bf_tmpl` companion defines) is extended to named props.

--- a/.changeset/go-template-rest-bag-and-aliased-prop-guards.md
+++ b/.changeset/go-template-rest-bag-and-aliased-prop-guards.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/go-template": patch
+---
+
+Fix two review-caught gaps in the named-prop dynamic-delivery route added for #2703: `bf_with_props` now targets the child's LOCAL destructured field name instead of the bare JSX attribute name (a child that aliases the prop, e.g. `function Card({ header: h })`, would otherwise silently drop the dynamic value), and a prop routed into the child's rest bag (no declared param at all) now refuses loudly with `BF101` instead of silently no-op'ing through `bf_with_props`'s unmatched-field passthrough (tracked as a capability gap in #2805).

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -122,6 +122,11 @@ runAdapterConformanceTests({
     // renders correctly since named jsx-children props got the same
     // `bf_with_props`/`bf_tmpl` dynamic-delivery route reserved `children`
     // already had.
+    // #2805: this shape refuses with BF101 at compile time (see
+    // `conformance-pins.ts`) — `expectedDiagnostics` covers the diagnostic
+    // contract, and marker comparison can't apply to a fixture that
+    // produces no complete template.
+    'jsx-element-prop-rest-bag-dynamic',
   ]),
   skipDataPoints: new Set<string>([
     // #2743: html/template's URL-context autoescape percent-encodes the

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -118,14 +118,10 @@ runAdapterConformanceTests({
     'todo-app',
     // (#1897) data-table no longer skipped — loop body children + wrapper
     // struct + block-body memo baking render correctly on Go.
-    // #2703: this shape now refuses with BF101 at compile time (see
-    // `conformance-pins.ts`) rather than silently rendering divergent
-    // markup — `expectedDiagnostics` covers the diagnostic contract, and
-    // marker comparison can't apply to a fixture that produces no
-    // complete template (`generate()` still returns partial output rather
-    // than throwing, so this stays on the explicit skip list rather than
-    // relying on the try/catch above).
-    'jsx-element-prop-fragment-conditional',
+    // `jsx-element-prop-fragment-conditional` (#2703) no longer skipped —
+    // renders correctly since named jsx-children props got the same
+    // `bf_with_props`/`bf_tmpl` dynamic-delivery route reserved `children`
+    // already had.
   ]),
   skipDataPoints: new Set<string>([
     // #2743: html/template's URL-context autoescape percent-encodes the

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -7375,12 +7375,31 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    */
   private queueDynamicPropDefine(comp: IRComponent): string | null {
     const args: string[] = []
+    const childShape = this.childComponentShapes.get(comp.name)
     for (const prop of comp.props) {
       if (prop.value.kind !== 'jsx-children' || prop.name === 'children') continue
       const children = prop.value.children
       if (this.extractTextChildren(children) !== null) continue
       if (this.extractHtmlChildren(children) !== null) continue
       if (this.extractScopedHtmlChildren(children) !== null) continue
+      // A prop routed into the child's rest bag (no declared param —
+      // `loopRowChildPropOverrides`'s identical guard, above) has no named
+      // Go field for `bf_with_props`/`WithProps` to target at all; `WithProps`
+      // silently no-ops on an unmatched field name. Refuse loudly instead of
+      // delivering the value against a field name that can never land —
+      // this shape had no dynamic-delivery route before this method existed
+      // either (the blanket BF101 this method's caller replaced was
+      // unconditional for any unbakeable named prop), so this keeps it loud
+      // rather than trading that refusal for a silent dropped render.
+      if (childShape?.restBagField && !childShape.paramNames.has(prop.name)) {
+        this.state.errors.push({
+          code: 'BF101',
+          severity: 'error',
+          message: `JSX-valued prop '${prop.name}' on <${comp.name}> is dynamic and routes into the child's rest-bag prop ('${childShape.restBagField}') rather than a declared field — there is no named Go struct field for 'bf_with_props' to target`,
+          loc: prop.loc,
+        })
+        continue
+      }
       const name = `${this.state.componentName}__prop_${prop.name}_${comp.slotId}`
       if (!this.state.pendingChildrenDefines.some(d => d.name === name)) {
         this.state.pendingChildrenDefines.push({

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -7388,7 +7388,17 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
           content: this.renderChildren(children),
         })
       }
-      args.push(`${JSON.stringify(capitalizeFieldName(prop.name))} (bf_tmpl ${JSON.stringify(name)} .)`)
+      // `bf_with_props`/`WithProps` patches the child's Props struct, keyed
+      // by the child's own LOCAL destructured field name — not necessarily
+      // the caller's JSX attribute name (`function Card({ header: h })`
+      // reads `h`, whose field is `H`, not `Header`). `WithProps` silently
+      // no-ops on an unmatched field name, so skipping this lookup would
+      // turn an aliased prop's dynamic delivery into a silent dropped
+      // render. `childPropFieldNames` resolves this exact hazard for the
+      // sibling `bf_with_props` call site (`loopRowChildPropOverrides`,
+      // below) — mirrored here.
+      const fieldName = this.childPropFieldNames.get(comp.name)?.get(prop.name) ?? capitalizeFieldName(prop.name)
+      args.push(`${JSON.stringify(fieldName)} (bf_tmpl ${JSON.stringify(name)} .)`)
     }
     return args.length > 0 ? args.join(' ') : null
   }

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -2341,22 +2341,21 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
                   if (scopedHtml !== null) {
                     this.state.usesHtmlTemplate = true
                     emitChildField(prop.name, `template.HTML(${scopedHtml})`)
-                  } else {
-                    // None of the three bake attempts produced a static Go
-                    // string — the value contains a template action that
-                    // survived (#2746) or is otherwise genuinely dynamic
-                    // (#2703). Named jsx-children props have no dynamic
-                    // delivery route yet (only the reserved `children` slot
-                    // does, via `queueDynamicChildrenDefine` + `bf_with_children`
-                    // below) — refuse loudly rather than silently omitting
-                    // the field, per the sound-or-loud trichotomy.
-                    this.state.errors.push({
-                      code: 'BF101',
-                      severity: 'error',
-                      message: `JSX-valued prop '${prop.name}' on <${child.name}> could not be baked into a static Go template value — it is dynamic and named jsx-children props have no dynamic-delivery route on this adapter yet`,
-                      loc: prop.loc,
-                    })
                   }
+                  // Else: none of the three bake attempts produced a static
+                  // Go string — the value contains a template action that
+                  // survived (#2746) or is otherwise genuinely dynamic
+                  // (#2703). No field is emitted here; `queueDynamicPropDefine`
+                  // (called from `renderComponent`'s static-call-site branch)
+                  // detects the SAME unbakeable shape and delivers it at
+                  // template-execution time via `bf_with_props` + `bf_tmpl`,
+                  // mirroring how the reserved `children` field's null case
+                  // just above is filled in by `bf_with_children`. A
+                  // component nested in a loop row never reaches this
+                  // function (`collectStaticChildInstancesRecursive` only
+                  // collects `!inLoop` components), so there is no dynamic
+                  // named-prop delivery for that shape yet — out of scope
+                  // here, tracked separately if it turns up.
                 }
               }
             }
@@ -7358,6 +7357,43 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   }
 
   /**
+   * #2703/B2: extend `queueDynamicChildrenDefine`'s companion-define delivery
+   * from the reserved `children` slot to NAMED jsx-children props (any
+   * JSX-valued prop other than `children`, e.g. `header={<strong>Title</strong>}`).
+   * A named prop whose value can't be baked into a static Go string by
+   * `emitStaticChildInstances`'s bake chain (`extractTextChildren` /
+   * `extractHtmlChildren` / `extractScopedHtmlChildren`, all null) is queued
+   * here instead, the same way; the caller composes the result into
+   * `bf_with_props` + `bf_tmpl` at the STATIC (non-loop) call site — the one
+   * shape `emitStaticChildInstances` bakes for at all (a component nested in
+   * a loop row never reaches `collectStaticChildInstances`).
+   *
+   * Returns the flat `"FieldName" (bf_tmpl "name" .) ...` argument list ready
+   * to splice into `bf_with_props`, or null when no named prop needs it —
+   * batches every prop that needs dynamic delivery into ONE `bf_with_props`
+   * call rather than nesting one per prop.
+   */
+  private queueDynamicPropDefine(comp: IRComponent): string | null {
+    const args: string[] = []
+    for (const prop of comp.props) {
+      if (prop.value.kind !== 'jsx-children' || prop.name === 'children') continue
+      const children = prop.value.children
+      if (this.extractTextChildren(children) !== null) continue
+      if (this.extractHtmlChildren(children) !== null) continue
+      if (this.extractScopedHtmlChildren(children) !== null) continue
+      const name = `${this.state.componentName}__prop_${prop.name}_${comp.slotId}`
+      if (!this.state.pendingChildrenDefines.some(d => d.name === name)) {
+        this.state.pendingChildrenDefines.push({
+          name,
+          content: this.renderChildren(children),
+        })
+      }
+      args.push(`${JSON.stringify(capitalizeFieldName(prop.name))} (bf_tmpl ${JSON.stringify(name)} .)`)
+    }
+    return args.length > 0 ? args.join(' ') : null
+  }
+
+  /**
    * Queue a companion define for a loop body component's JSX children. Like
    * `queueDynamicChildrenDefine` but temporarily exits the `inLoop` context so
    * nested component calls render with the normal `.NameSlotN` field-access
@@ -7462,9 +7498,19 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       // Static children with slotId: unique field name based on slotId.
       const suffix = slotIdToFieldSuffix(comp.slotId)
       const childrenDefine = this.queueDynamicChildrenDefine(comp)
+      // #2703/B2: a NAMED jsx-children prop (any JSX-valued prop other than
+      // `children`) that couldn't be baked into the constructor gets the
+      // same treatment `children` already has — delivered at the call site
+      // via a companion define. Props helper stays INNER, same ordering
+      // rule as the loop-nested branch above: `bf_with_children` applies
+      // last, on the props-patched value.
+      const propArgs = this.queueDynamicPropDefine(comp)
+      const base = propArgs
+        ? `(bf_with_props .${comp.name}${suffix} ${propArgs})`
+        : `.${comp.name}${suffix}`
       templateCall = childrenDefine
-        ? `{{template "${comp.name}" (bf_with_children .${comp.name}${suffix} (bf_tmpl "${childrenDefine}" .))}}`
-        : `{{template "${comp.name}" .${comp.name}${suffix}}}`
+        ? `{{template "${comp.name}" (bf_with_children ${base} (bf_tmpl "${childrenDefine}" .))}}`
+        : `{{template "${comp.name}" ${base}}}`
     } else {
       // Static children without slotId: fall back to .ComponentName.
       templateCall = `{{template "${comp.name}" .${comp.name}}}`

--- a/packages/adapter-go-template/src/conformance-pins.ts
+++ b/packages/adapter-go-template/src/conformance-pins.ts
@@ -59,14 +59,8 @@ export const conformancePins: ConformancePins = {
   // `rich-prop-client-read` above.
   'jsx-element-prop-ternary': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2667' }],
   'jsx-element-prop-array': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2667' }],
-  // #2703: graduated from a silent render-divergence (`render-divergences.ts`)
-  // to a loud refusal. A named jsx-children prop (any JSX-valued prop other
-  // than the reserved `children`) has no dynamic-delivery route on this
-  // adapter yet — only the reserved `children` slot gets one, via
-  // `queueDynamicChildrenDefine` + `bf_with_children`/`bf_tmpl`. Until that
-  // route is extended to named props, a value the static bake chain
-  // (`extractTextChildren`/`extractHtmlChildren`/`extractScopedHtmlChildren`)
-  // can't reduce to a literal now refuses with BF101 instead of silently
-  // omitting the field.
-  'jsx-element-prop-fragment-conditional': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2703' }],
+  // `jsx-element-prop-fragment-conditional` (#2703) is NOT pinned here — it
+  // renders correctly since `queueDynamicPropDefine` (go-template-adapter.ts)
+  // extended the reserved `children` slot's `bf_with_children`/`bf_tmpl`
+  // dynamic-delivery route to named jsx-children props.
 }

--- a/packages/adapter-go-template/src/conformance-pins.ts
+++ b/packages/adapter-go-template/src/conformance-pins.ts
@@ -63,4 +63,17 @@ export const conformancePins: ConformancePins = {
   // renders correctly since `queueDynamicPropDefine` (go-template-adapter.ts)
   // extended the reserved `children` slot's `bf_with_children`/`bf_tmpl`
   // dynamic-delivery route to named jsx-children props.
+  // #2805: a named jsx-children prop routed into the child's rest bag (no
+  // declared param — only reachable via the child's `...rest` spread) has
+  // no named Go struct field for `bf_with_props`/`WithProps` to target at
+  // all. `queueDynamicPropDefine` refuses loudly with BF101 rather than
+  // silently no-op through `WithProps`'s unmatched-field passthrough.
+  // `unescapable`: the capability gap (a rest-bag delivery route) is #2805
+  // itself, not authored yet, so no `/* @client */` escape twin exists.
+  'jsx-element-prop-rest-bag-dynamic': [{
+    code: 'BF101',
+    severity: 'error',
+    issue: 'https://github.com/piconic-ai/barefootjs/issues/2805',
+    unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2805' },
+  }],
 }

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -2731,6 +2731,31 @@
         "text"
       ]
     },
+    "jsx-element-prop-renamed-destructure": {
+      "kinds": [
+        "identifier",
+        "literal"
+      ],
+      "axes": [
+        "literal:boolean"
+      ],
+      "contexts": [
+        "text"
+      ]
+    },
+    "jsx-element-prop-rest-bag-dynamic": {
+      "kinds": [
+        "identifier",
+        "literal",
+        "member"
+      ],
+      "axes": [
+        "literal:boolean"
+      ],
+      "contexts": [
+        "text"
+      ]
+    },
     "jsx-element-prop-ternary": {
       "kinds": [
         "identifier",
@@ -5734,11 +5759,11 @@
     "binary": 94,
     "call": 236,
     "conditional": 27,
-    "identifier": 335,
+    "identifier": 337,
     "index-access": 14,
-    "literal": 267,
+    "literal": 269,
     "logical": 47,
-    "member": 192,
+    "member": 193,
     "object-literal": 65,
     "template-literal": 30,
     "unary": 24,
@@ -5779,7 +5804,7 @@
     "binary:===": 49,
     "binary:>": 11,
     "binary:>=": 1,
-    "literal:boolean": 56,
+    "literal:boolean": 58,
     "literal:null": 23,
     "literal:number": 113,
     "literal:string": 187,

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -434,6 +434,7 @@ import { fixture as textareaRowBreakout } from './textarea-row-breakout'
 // `irToHtmlTemplate` (found by review on #2792, PR fix in the same file).
 import { fixture as textareaRowBreakoutComposite } from './textarea-row-breakout-composite'
 import { fixture as jsxElementPropFragmentConditional } from './jsx-element-prop-fragment-conditional'
+import { fixture as jsxElementPropRenamedDestructure } from './jsx-element-prop-renamed-destructure'
 import { fixture as grandchildComposition } from './grandchild-composition'
 import { fixture as compositeRowChildComponent } from './composite-row-child-component'
 import { fixture as compositeRowChildDerivedProp } from './composite-row-child-derived-prop'
@@ -876,6 +877,7 @@ export const jsxFixtures: JSXFixture[] = [
   textareaRowBreakout,
   textareaRowBreakoutComposite,
   jsxElementPropFragmentConditional,
+  jsxElementPropRenamedDestructure,
   grandchildComposition,
   compositeRowChildComponent,
   compositeRowChildDerivedProp,

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -435,6 +435,7 @@ import { fixture as textareaRowBreakout } from './textarea-row-breakout'
 import { fixture as textareaRowBreakoutComposite } from './textarea-row-breakout-composite'
 import { fixture as jsxElementPropFragmentConditional } from './jsx-element-prop-fragment-conditional'
 import { fixture as jsxElementPropRenamedDestructure } from './jsx-element-prop-renamed-destructure'
+import { fixture as jsxElementPropRestBagDynamic } from './jsx-element-prop-rest-bag-dynamic'
 import { fixture as grandchildComposition } from './grandchild-composition'
 import { fixture as compositeRowChildComponent } from './composite-row-child-component'
 import { fixture as compositeRowChildDerivedProp } from './composite-row-child-derived-prop'
@@ -878,6 +879,7 @@ export const jsxFixtures: JSXFixture[] = [
   textareaRowBreakoutComposite,
   jsxElementPropFragmentConditional,
   jsxElementPropRenamedDestructure,
+  jsxElementPropRestBagDynamic,
   grandchildComposition,
   compositeRowChildComponent,
   compositeRowChildDerivedProp,

--- a/packages/adapter-tests/fixtures/jsx-element-prop-renamed-destructure.ts
+++ b/packages/adapter-tests/fixtures/jsx-element-prop-renamed-destructure.ts
@@ -1,0 +1,59 @@
+import { createFixture } from '../src/types'
+
+/**
+ * A named jsx-children prop (`header`) whose value is genuinely dynamic
+ * (a fragment-wrapped conditional, same shape as
+ * `jsx-element-prop-fragment-conditional`) delivered to a child that
+ * destructures that prop under a DIFFERENT local name (`{ header: h }`).
+ *
+ * Regression pin for a bug Pullfrog's review caught on go-template PR #2804
+ * (`queueDynamicPropDefine`, go-template-adapter.ts): the go-template
+ * adapter's dynamic-delivery route for an unbakeable named prop
+ * (`bf_with_props` + `bf_tmpl`) keyed its `bf_with_props` argument by the
+ * bare capitalized JSX attribute name (`Header`) instead of the child's
+ * LOCAL destructured field name (`H`) — the same aliasing hazard
+ * `childPropFieldNames` already exists to resolve for the sibling
+ * `bf_with_props` call site (`loopRowChildPropOverrides`,
+ * go-template-adapter.ts). `bf.WithProps` silently no-ops on an unmatched
+ * field name, so the unfixed code would have SSR'd `<header></header>` —
+ * a silently dropped dynamic value — on exactly this shape.
+ *
+ * Hono is correct by construction for this shape (a plain destructure
+ * rename has no bearing on JSX-runtime SSR), so `expectedHtml` is
+ * generated from it unmodified.
+ */
+export const fixture = createFixture({
+  id: 'jsx-element-prop-renamed-destructure',
+  description: 'A named jsx-children prop with a genuinely dynamic value, destructured under a renamed local binding',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+import { Card } from './Card'
+export function JsxElementPropRenamedDestructure() {
+  const [cond, setCond] = createSignal(true)
+  return (
+    <Card header={<>{cond() ? <a>x</a> : <b>y</b>}</>}>
+      <p>body text</p>
+    </Card>
+  )
+}
+`,
+  components: {
+    './Card': `
+export function Card({ header: h, children }: { header?: any; children?: any }) {
+  return (
+    <section>
+      <header>{h}</header>
+      <div>{children}</div>
+    </section>
+  )
+}
+`,
+  },
+  expectedHtml: `
+    <section bf-s="test_s1">
+      <header bf="s1"><!--bf:s0--><a bf-c="^s0">x</a><!--/--></header>
+      <div><p>body text</p></div>
+    </section>
+  `,
+})

--- a/packages/adapter-tests/fixtures/jsx-element-prop-rest-bag-dynamic.ts
+++ b/packages/adapter-tests/fixtures/jsx-element-prop-rest-bag-dynamic.ts
@@ -1,0 +1,61 @@
+import { createFixture } from '../src/types'
+
+/**
+ * A named jsx-children prop (`header`) with a genuinely dynamic
+ * (fragment-wrapped-conditional) value, on a child that does NOT declare
+ * `header` as a param at all — it's captured only via the child's rest-bag
+ * spread (`{ children, ...rest }`), the same routing `emitChildField`
+ * already special-cases for the STATIC bake path.
+ *
+ * Regression pin for a gap Pullfrog's review caught on go-template PR #2804
+ * (`queueDynamicPropDefine`, go-template-adapter.ts): a prop routed into
+ * the child's rest bag has no named Go struct field at all for
+ * `bf_with_props`/`WithProps` to target — `loopRowChildPropOverrides`
+ * already guards against this exact shape (`childShape?.restBagField &&
+ * !childShape.paramNames.has(prop.name)`) for its own `bf_with_props` call
+ * site, but `queueDynamicPropDefine` initially didn't, which would have
+ * silently no-op'd the dynamic value via `WithProps`'s unmatched-field
+ * passthrough — turning the BLANKET `BF101` refusal this PR's first commit
+ * replaced (unconditional for any unbakeable named prop) into a silent
+ * wrong render for exactly this shape. `queueDynamicPropDefine` mirrors
+ * the same guard and refuses loudly with `BF101` instead.
+ *
+ * This fixture is pinned on go-template only (`conformance-pins.ts`);
+ * every other adapter renders it correctly, same as its sibling
+ * `jsx-element-prop-fragment-conditional`.
+ */
+export const fixture = createFixture({
+  id: 'jsx-element-prop-rest-bag-dynamic',
+  description: 'A named jsx-children prop with a genuinely dynamic value, captured only by the child\'s rest-bag spread',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+import { Card } from './Card'
+export function JsxElementPropRestBagDynamic() {
+  const [cond, setCond] = createSignal(true)
+  return (
+    <Card header={<>{cond() ? <a>x</a> : <b>y</b>}</>}>
+      <p>body text</p>
+    </Card>
+  )
+}
+`,
+  components: {
+    './Card': `
+export function Card({ children, ...rest }: { children?: any; [key: string]: any }) {
+  return (
+    <section>
+      <header>{rest.header}</header>
+      <div>{children}</div>
+    </section>
+  )
+}
+`,
+  },
+  expectedHtml: `
+    <section bf-s="test_s1">
+      <header bf="s1"><!--bf:s0--><a bf-c="^s0">x</a><!--/--></header>
+      <div><p>body text</p></div>
+    </section>
+  `,
+})

--- a/packages/adapter-tests/src/__tests__/client-js-scope.test.ts
+++ b/packages/adapter-tests/src/__tests__/client-js-scope.test.ts
@@ -55,6 +55,16 @@ const KNOWN_UNDECLARED: Record<string, KnownHole> = {
   // map-index-handler, reactive-props, props-reactivity-comparison)
   // graduated with the memo/`templateExpr`/getter-elided-signal emission
   // fixes; see the issue for the closing PR.
+  'jsx-element-prop-rest-bag-dynamic': {
+    // #2806: a component reading its own rest-bag spread directly in JSX
+    // (`{rest.header}`) emits a CSR template referencing `rest`, which is
+    // never bound in that scope — the same `applyRestAttrs`-not-modeled
+    // class as the CSR_SKIP_FIXTURES entries above it, manifesting here as
+    // a genuine undeclared-identifier compile hole rather than a harness
+    // limitation.
+    names: ['rest'],
+    issue: 'https://github.com/piconic-ai/barefootjs/issues/2806',
+  },
 }
 
 /** One virtual .ts file per emitted client-JS artifact. */

--- a/packages/adapter-tests/src/csr-skip-set.ts
+++ b/packages/adapter-tests/src/csr-skip-set.ts
@@ -90,4 +90,13 @@ export const CSR_SKIP_FIXTURES: ReadonlySet<string> = new Set([
   // child needs no `$c` lookup at all (it IS `__scope`) — see
   // `ClientJsContext.commentScopeRootSlotId` and
   // `comment-wrapper-grandchild-slot-collision.test.ts`.
+  // #2806: same `applyRestAttrs`-not-modeled class as `jsx-spread-props-object`
+  // / `rest-spread-child-attrs` / `stateless-rest-spread-forward` above, but
+  // reading the rest bag directly in JSX (`{rest.header}`) rather than
+  // spreading it onto an element's attrs — the emitted CSR template
+  // references `rest` without ever binding it, a guaranteed
+  // `ReferenceError` (also pinned in `client-js-scope.test.ts`'s
+  // `KNOWN_UNDECLARED`). SSR is correct on every adapter; go-template's own
+  // orthogonal refusal for this shape is #2805.
+  'jsx-element-prop-rest-bag-dynamic',
 ])

--- a/packages/adapter-tests/src/jsx-runner.ts
+++ b/packages/adapter-tests/src/jsx-runner.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, test, expect } from 'bun:test'
-import type { CompilerError, TemplateAdapter } from '@barefootjs/jsx'
+import type { ComponentIR, CompilerError, TemplateAdapter } from '@barefootjs/jsx'
 import { compileJSX } from '@barefootjs/jsx'
 import { jsxFixtures } from '../fixtures'
 import type { ExpectedDiagnostic } from './types'
@@ -81,6 +81,23 @@ export { normalizeHTML, stripConditionalMarkersForCrossAdapter }
  * surface adapter-emitted diagnostics without going through the
  * adapter's `render()` (which typically throws on errors).
  */
+/**
+ * Register a child/sibling component's cross-component shape on the adapter
+ * when it supports the optional `registerChildComponentShape` hook (Go
+ * template — #checkbox). A no-op on adapters without it. Mirrors
+ * `test-render.ts`'s identically-named helper: `compileJSX` alone never
+ * calls this hook, so a diagnostic that depends on it (a prop routed into
+ * a child's rest bag rather than a declared field, #2805) would silently
+ * never fire under `collectFixtureDiagnostics`'s compile-only path without
+ * this — the exact gap that let `jsx-element-prop-rest-bag-dynamic`'s
+ * pinned BF101 go unreproduced in this runner despite reproducing correctly
+ * under the real-render harness.
+ */
+function registerChildShape(adapter: TemplateAdapter, ir: ComponentIR): void {
+  const hook = (adapter as { registerChildComponentShape?: (ir: ComponentIR) => void }).registerChildComponentShape
+  if (typeof hook === 'function') hook.call(adapter, ir)
+}
+
 function collectFixtureDiagnostics(args: {
   source: string
   components?: Record<string, string>
@@ -106,6 +123,14 @@ function collectFixtureDiagnostics(args: {
         siblingTemplatesRegistered,
       })
       all.push(...r.errors)
+      // Register every child's shape before the parent compiles below —
+      // same ordering `test-render.ts` uses, and for the same reason (a
+      // child that itself renders a sibling needs every shape registered
+      // first, though this diagnostics-only path never reaches that
+      // two-hop case in practice).
+      for (const irFile of r.files.filter(f => f.type === 'ir')) {
+        registerChildShape(args.adapter, JSON.parse(irFile.content) as ComponentIR)
+      }
     }
   }
   const result = compileJSX(args.source.trimStart(), 'component.tsx', {

--- a/packages/compat/src/__tests__/compat-engine.test.ts
+++ b/packages/compat/src/__tests__/compat-engine.test.ts
@@ -46,12 +46,14 @@ describe('compileForCompat', () => {
     // `issues` is the UNION of every issue URL any BF101 pin carries on
     // this adapter (buildCompatCell attributes by code, not by fixture —
     // see its docstring) — #2320 (this shape, nested filter callback,
-    // successor to #2038) and #2321 (static-array-from-props computed loop
-    // source) surface here even though this test only exercises the nested-
-    // filter-callback shape. Three pins are no longer among them, each
-    // because the shape got a real lowering rather than a narrower refusal:
-    // #2319 (dangerous-inner-html-dynamic → a faithful raw-output lowering),
-    // #2208 (static-array-children → the loop-source gate bakes a fully-static
+    // successor to #2038), #2321 (static-array-from-props computed loop
+    // source), and #2805 (a named jsx-children prop routed into a child's
+    // rest bag, `jsx-element-prop-rest-bag-dynamic`) surface here even
+    // though this test only exercises the nested-filter-callback shape.
+    // Three pins are no longer among them, each because the shape got a
+    // real lowering rather than a narrower refusal: #2319
+    // (dangerous-inner-html-dynamic → a faithful raw-output lowering), #2208
+    // (static-array-children → the loop-source gate bakes a fully-static
     // array-of-objects const), and #2448 (loop-row child prop override feeding
     // a derived field → the child rebuilds itself per row through
     // `bf_reprops`). See `go-template`'s `conformance-pins.ts`.
@@ -62,6 +64,7 @@ describe('compileForCompat', () => {
         issues: [
           'https://github.com/piconic-ai/barefootjs/issues/2320',
           'https://github.com/piconic-ai/barefootjs/issues/2321',
+          'https://github.com/piconic-ai/barefootjs/issues/2805',
         ],
       },
     ])

--- a/packages/compat/src/engine.ts
+++ b/packages/compat/src/engine.ts
@@ -1,10 +1,25 @@
 // @barefootjs/compat — pure compile+reduce logic. No console output here;
 // the command layer (src/cli.ts) owns all user-facing text.
 
-import type { CompilerError, ConformancePins, EscapeKind, TemplateAdapter } from '@barefootjs/jsx'
+import type { ComponentIR, CompilerError, ConformancePins, EscapeKind, TemplateAdapter } from '@barefootjs/jsx'
 import { compileJSX } from '@barefootjs/jsx'
 
 export type CompatMode = 'build' | 'conformance'
+
+/**
+ * Register a child/sibling component's cross-component shape on the adapter
+ * when it supports the optional `registerChildComponentShape` hook (Go
+ * template — #checkbox). A no-op on adapters without it. Mirrors
+ * `packages/adapter-tests/src/jsx-runner.ts`'s identically-named helper and
+ * `test-render.ts`'s original: `compileJSX` alone never calls this hook, so
+ * a diagnostic that depends on it (a prop routed into a child's rest bag
+ * rather than a declared field, #2805) would silently never fire under
+ * `compileForCompat`'s conformance-mode compile-only path without this.
+ */
+function registerChildShape(adapter: TemplateAdapter, ir: ComponentIR): void {
+  const hook = (adapter as { registerChildComponentShape?: (ir: ComponentIR) => void }).registerChildComponentShape
+  if (typeof hook === 'function') hook.call(adapter, ir)
+}
 
 export interface CompatDiagnostic {
   code: string
@@ -76,6 +91,9 @@ export function compileForCompat(
             siblingTemplatesRegistered,
           })
           all.push(...childResult.errors)
+          for (const irFile of childResult.files.filter(f => f.type === 'ir')) {
+            registerChildShape(adapter, JSON.parse(irFile.content) as ComponentIR)
+          }
         }
       }
       const result = compileJSX(source.trimStart(), filePath, {

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-conformance section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. This answers, per fixture and per adapter, whether the construct WORKS — not just whether it compiles. A construct works either as written (✓) or with a documented `/* @client */` comment (✓†, a verified, supported escape — most refusals have one). Fixtures absent from the table below work on every adapter — most as written, some via that documented escape; the headline says how many of each. Listed fixtures need attention somewhere: a bare diagnostic code is still-open debt with no escape yet, a code led by ✗ owes no escape at all (by design), and ≠ means the fixture compiles clean but its rendered output diverges from the reference.",
-    "totalFixtures": 357,
+    "totalFixtures": 358,
     "fixtures": {
       "children-passthrough-renamed": {
         "go-template": {

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-conformance section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. This answers, per fixture and per adapter, whether the construct WORKS — not just whether it compiles. A construct works either as written (✓) or with a documented `/* @client */` comment (✓†, a verified, supported escape — most refusals have one). Fixtures absent from the table below work on every adapter — most as written, some via that documented escape; the headline says how many of each. Listed fixtures need attention somewhere: a bare diagnostic code is still-open debt with no escape yet, a code led by ✗ owes no escape at all (by design), and ≠ means the fixture compiles clean but its rendered output diverges from the reference.",
-    "totalFixtures": 358,
+    "totalFixtures": 359,
     "fixtures": {
       "children-passthrough-renamed": {
         "go-template": {
@@ -2586,6 +2586,20 @@
           "issues": [
             "https://github.com/piconic-ai/barefootjs/issues/2667"
           ]
+        }
+      },
+      "jsx-element-prop-rest-bag-dynamic": {
+        "go-template": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2805"
+          ],
+          "escape": {
+            "state": "debt"
+          }
         }
       },
       "jsx-element-prop-ternary": {
@@ -3599,6 +3613,10 @@
       "jsx-element-prop-array": {
         "description": "Array literal wrapping JSX at a non-children prop position refuses with BF021",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/jsx-element-prop-array.ts"
+      },
+      "jsx-element-prop-rest-bag-dynamic": {
+        "description": "A named jsx-children prop with a genuinely dynamic value, captured only by the child's rest-bag…",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/jsx-element-prop-rest-bag-dynamic.ts"
       },
       "jsx-element-prop-ternary": {
         "description": "Ternary wrapping JSX at a non-children prop position refuses with BF021",

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -2194,11 +2194,11 @@
       }
     },
     "identifier": {
-      "total": 335,
+      "total": 337,
       "cells": {
         "hono": {
-          "pass": 332,
-          "total": 335,
+          "pass": 334,
+          "total": 337,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2221,8 +2221,8 @@
           ]
         },
         "blade": {
-          "pass": 316,
-          "total": 335,
+          "pass": 318,
+          "total": 337,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2317,8 +2317,8 @@
           ]
         },
         "erb": {
-          "pass": 317,
-          "total": 335,
+          "pass": 319,
+          "total": 337,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2407,8 +2407,8 @@
           ]
         },
         "go-template": {
-          "pass": 312,
-          "total": 335,
+          "pass": 313,
+          "total": 337,
           "gaps": [
             {
               "fixture": "children-passthrough-renamed",
@@ -2456,6 +2456,12 @@
               "fixture": "jsx-element-prop-array",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2667"
+              ]
+            },
+            {
+              "fixture": "jsx-element-prop-rest-bag-dynamic",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2805"
               ]
             },
             {
@@ -2519,8 +2525,8 @@
           ]
         },
         "jinja": {
-          "pass": 316,
-          "total": 335,
+          "pass": 318,
+          "total": 337,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2615,8 +2621,8 @@
           ]
         },
         "minijinja": {
-          "pass": 316,
-          "total": 335,
+          "pass": 318,
+          "total": 337,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2711,8 +2717,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 316,
-          "total": 335,
+          "pass": 318,
+          "total": 337,
           "gaps": [
             {
               "fixture": "children-passthrough-renamed",
@@ -2805,8 +2811,8 @@
           ]
         },
         "twig": {
-          "pass": 316,
-          "total": 335,
+          "pass": 318,
+          "total": 337,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2901,8 +2907,8 @@
           ]
         },
         "xslate": {
-          "pass": 316,
-          "total": 335,
+          "pass": 318,
+          "total": 337,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3062,11 +3068,11 @@
       }
     },
     "literal": {
-      "total": 267,
+      "total": 269,
       "cells": {
         "hono": {
-          "pass": 266,
-          "total": 267,
+          "pass": 268,
+          "total": 269,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -3077,8 +3083,8 @@
           ]
         },
         "blade": {
-          "pass": 255,
-          "total": 267,
+          "pass": 257,
+          "total": 269,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3135,8 +3141,8 @@
           ]
         },
         "erb": {
-          "pass": 255,
-          "total": 267,
+          "pass": 257,
+          "total": 269,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3193,8 +3199,8 @@
           ]
         },
         "go-template": {
-          "pass": 252,
-          "total": 267,
+          "pass": 253,
+          "total": 269,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3215,6 +3221,12 @@
             {
               "fixture": "flatmap-typeof-projection",
               "issues": []
+            },
+            {
+              "fixture": "jsx-element-prop-rest-bag-dynamic",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2805"
+              ]
             },
             {
               "fixture": "jsx-element-prop-ternary",
@@ -3263,8 +3275,8 @@
           ]
         },
         "jinja": {
-          "pass": 255,
-          "total": 267,
+          "pass": 257,
+          "total": 269,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3321,8 +3333,8 @@
           ]
         },
         "minijinja": {
-          "pass": 255,
-          "total": 267,
+          "pass": 257,
+          "total": 269,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3379,8 +3391,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 255,
-          "total": 267,
+          "pass": 257,
+          "total": 269,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3437,8 +3449,8 @@
           ]
         },
         "twig": {
-          "pass": 255,
-          "total": 267,
+          "pass": 257,
+          "total": 269,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3495,8 +3507,8 @@
           ]
         },
         "xslate": {
-          "pass": 255,
-          "total": 267,
+          "pass": 257,
+          "total": 269,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3714,11 +3726,11 @@
       }
     },
     "member": {
-      "total": 192,
+      "total": 193,
       "cells": {
         "hono": {
-          "pass": 189,
-          "total": 192,
+          "pass": 190,
+          "total": 193,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3741,8 +3753,8 @@
           ]
         },
         "blade": {
-          "pass": 173,
-          "total": 192,
+          "pass": 174,
+          "total": 193,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3837,8 +3849,8 @@
           ]
         },
         "erb": {
-          "pass": 174,
-          "total": 192,
+          "pass": 175,
+          "total": 193,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3928,7 +3940,7 @@
         },
         "go-template": {
           "pass": 170,
-          "total": 192,
+          "total": 193,
           "gaps": [
             {
               "fixture": "children-passthrough-renamed",
@@ -3976,6 +3988,12 @@
               "fixture": "jsx-element-prop-array",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2667"
+              ]
+            },
+            {
+              "fixture": "jsx-element-prop-rest-bag-dynamic",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2805"
               ]
             },
             {
@@ -4035,8 +4053,8 @@
           ]
         },
         "jinja": {
-          "pass": 173,
-          "total": 192,
+          "pass": 174,
+          "total": 193,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4131,8 +4149,8 @@
           ]
         },
         "minijinja": {
-          "pass": 173,
-          "total": 192,
+          "pass": 174,
+          "total": 193,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4227,8 +4245,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 173,
-          "total": 192,
+          "pass": 174,
+          "total": 193,
           "gaps": [
             {
               "fixture": "children-passthrough-renamed",
@@ -4321,8 +4339,8 @@
           ]
         },
         "twig": {
-          "pass": 173,
-          "total": 192,
+          "pass": 174,
+          "total": 193,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4417,8 +4435,8 @@
           ]
         },
         "xslate": {
-          "pass": 173,
-          "total": 192,
+          "pass": 174,
+          "total": 193,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -7720,11 +7738,11 @@
       }
     },
     "literal:boolean": {
-      "total": 56,
+      "total": 58,
       "cells": {
         "hono": {
-          "pass": 55,
-          "total": 56,
+          "pass": 57,
+          "total": 58,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -7735,8 +7753,8 @@
           ]
         },
         "blade": {
-          "pass": 54,
-          "total": 56,
+          "pass": 56,
+          "total": 58,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -7751,8 +7769,8 @@
           ]
         },
         "erb": {
-          "pass": 54,
-          "total": 56,
+          "pass": 56,
+          "total": 58,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -7767,9 +7785,15 @@
           ]
         },
         "go-template": {
-          "pass": 53,
-          "total": 56,
+          "pass": 54,
+          "total": 58,
           "gaps": [
+            {
+              "fixture": "jsx-element-prop-rest-bag-dynamic",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2805"
+              ]
+            },
             {
               "fixture": "jsx-element-prop-ternary",
               "issues": [
@@ -7787,8 +7811,8 @@
           ]
         },
         "jinja": {
-          "pass": 54,
-          "total": 56,
+          "pass": 56,
+          "total": 58,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -7803,8 +7827,8 @@
           ]
         },
         "minijinja": {
-          "pass": 54,
-          "total": 56,
+          "pass": 56,
+          "total": 58,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -7819,8 +7843,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 54,
-          "total": 56,
+          "pass": 56,
+          "total": 58,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -7835,8 +7859,8 @@
           ]
         },
         "twig": {
-          "pass": 54,
-          "total": 56,
+          "pass": 56,
+          "total": 58,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -7851,8 +7875,8 @@
           ]
         },
         "xslate": {
-          "pass": 54,
-          "total": 56,
+          "pass": 56,
+          "total": 58,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",


### PR DESCRIPTION
Stacked on #2803 (Family B layer (i), soundness). This is layer (ii), parity — see #2779's "Family B" section.

## The fix

The reserved `children` slot already had a working dynamic-delivery route for content the static bake chain can't reduce to a literal: `queueDynamicChildrenDefine` renders it into a companion define, and `renderComponent`'s static-call-site branch composes `bf_with_children` + `bf_tmpl` to apply it at template-execution time. A named jsx-children prop (any JSX-valued prop other than `children`, e.g. `header={<strong>Title</strong>}`) had no equivalent — #2803 made that silence loud (`BF101`); this PR makes it work.

`queueDynamicPropDefine` mirrors `queueDynamicChildrenDefine` per named prop, batching every prop on a component that needs dynamic delivery into one `bf_with_props` call — props helper stays INNER, the same ordering the existing loop-nested branch already uses (`bf_with_children` applies last, on the props-patched value). `WithProps` (`runtime/bf.go`, #2445) already sets a named struct field generically via reflection and already handles a `template.HTML`-typed value through its String-kind branch, so **no runtime change was needed**.

`emitStaticChildInstances`'s named-prop bake-failure case now just omits the field instead of raising `BF101` — the same field is filled in at the call site instead, mirroring how the reserved `children` field's null case already works.

**Scope**: static (non-loop) components only. A component nested in a loop row never reaches `collectStaticChildInstances` at all, so dynamic named-prop delivery for that shape is untouched here — out of scope, would need its own investigation if it turns up.

## Graduation

`jsx-element-prop-fragment-conditional` (#2703) is un-pinned from `conformance-pins.ts` and un-skipped from `skipMarkerConformance` — it now renders to Hono parity on real Go.

## Verification

| Check | Result |
|---|---|
| Targeted local run (`jsx-element-prop-fragment-conditional` + every reserved-children unit test in this file, real `go run`) | 22 pass, 0 fail |
| Full `packages/adapter-go-template` suite | not completed locally (slow real-`go run` conformance in this environment); relying on CI for the full signal |

Changeset added (`@barefootjs/go-template`, patch).

---
_Generated by [Claude Code](https://claude.ai/code/session_0198yG2px5ygfvmdoMkhRS13)_