### PR TITLE
Fix #2763: fragment-bodied keyed .map() row loses its key

### DIFF
--- a/.changeset/fragment-body-loop-key-2763.md
+++ b/.changeset/fragment-body-loop-key-2763.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Fix #2763: a `.map()` whose callback body returns a fragment (`<><li key={..}/><li/></>`) now resolves its row key instead of silently losing it. `extractLoopKey` and its write-side twin `applyLoopKeyAttr` gained a `fragment` case that reads/stamps the key on the fragment's first ELEMENT child (skipping whitespace-only text), matching the "first element, not first node" rule `IRElement.keyAttr`'s docstring already documents for the render-root relay case. Previously `extractLoopKey` returned `null` for a fragment body, so every SSR adapter omitted the row-key attribute and `mapArray` reconciled positionally — while `ir-to-client-js/html-template.ts`'s client row builders kept baking `data-key` from the raw `key` JSX attribute independently of that decision, a silent SSR/CSR divergence with no diagnostic. Those builders now read `IRElement.keyAttr` (via a new `resolvedKeyAttrName` helper) instead of the raw attribute, so a row the SSR side doesn't recognize as keyed no longer gets a `data-key` baked into it client-side either.

--- a/.changeset/loop-item-marker-double-prefix.md
+++ b/.changeset/loop-item-marker-double-prefix.md
@@ -1,0 +1,6 @@
+---
+"@barefootjs/hono": patch
+"@barefootjs/go-template": patch
+---
+
+Fix a latent SSR-emission bug in the per-item start marker for multi-root Fragment loop bodies (#1212): both adapters called `bfComment('bf-loop-i')` / `` {{bfComment "bf-loop-i"}} `` even though `bfComment` itself already prepends `bf-`, doubling the prefix to `<!--bf-bf-loop-i-->` instead of the correct `<!--bf-loop-i-->` the client runtime and every other adapter's whole-item-conditional anchor (`bf-loop-i:KEY`) already use. No prior fixture exercised `bodyIsMultiRoot` on either adapter, so this went unexercised until #2763's fragment-bodied-keyed-loop fixture was the first to combine a multi-root Fragment row with an SSR render on these adapters, surfacing it as a byte-for-byte `expectedHtml` mismatch.

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -7319,7 +7319,10 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    * `mapArrayAnchored` can hydrate items that render no element.
    */
   private loopItemMarker(loop: { bodyIsMultiRoot?: boolean; bodyIsItemConditional?: boolean; key?: string | null }): string {
-    if (loop.bodyIsMultiRoot) return `{{bfComment "bf-loop-i"}}`
+    // `bfComment` prepends `bf-`, so the argument is `"loop-i"`, not
+    // `"bf-loop-i"` (which would double the prefix to `<!--bf-bf-loop-i-->`
+    // — the same latent bug #2763's fixture caught on the Hono adapter).
+    if (loop.bodyIsMultiRoot) return `{{bfComment "loop-i"}}`
     if (loop.bodyIsItemConditional && loop.key) {
       // `bfComment` prepends `bf-`, so `printf "loop-i:%v"` yields
       // `<!--bf-loop-i:KEY-->`. The key expression resolves against the current

--- a/packages/adapter-hono/src/adapter/hono-adapter.ts
+++ b/packages/adapter-hono/src/adapter/hono-adapter.ts
@@ -1023,10 +1023,12 @@ export class HonoAdapter extends JsxAdapter implements IRNodeEmitter<HonoRenderC
     // in a Fragment so the prefix and the existing children share an arrow
     // expression body.
     if (loop.bodyIsMultiRoot) {
-      // Per-item start marker: BF_LOOP_ITEM ('bf-loop-i'). Hardcoded
-      // literal here to match the adapter's existing convention of
-      // emitting comment-marker strings directly.
-      safeChildren = `<>{bfComment('bf-loop-i')}${children}</>`
+      // Per-item start marker: BF_LOOP_ITEM ('bf-loop-i'). `bfComment(k)`
+      // emits `<!--bf-${k}-->`, so the argument here is `'loop-i'`, not
+      // `'bf-loop-i'` (which would double the prefix to `<!--bf-bf-loop-i-->`
+      // — a genuine SSR-emission bug this fixed, caught by #2763's fixture
+      // being the first `bodyIsMultiRoot` case exercised on this adapter).
+      safeChildren = `<>{bfComment('loop-i')}${children}</>`
     } else if (loop.bodyIsItemConditional && loop.key) {
       // Whole-item conditional (#1665): a per-item `<!--bf-loop-i:KEY-->`
       // anchor that is ALWAYS present (even when the item's conditional

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -2527,6 +2527,19 @@
         "text"
       ]
     },
+    "fragment-body-keyed-loop-row": {
+      "kinds": [
+        "call",
+        "identifier",
+        "member"
+      ],
+      "axes": [],
+      "contexts": [
+        "attribute",
+        "loop",
+        "text"
+      ]
+    },
     "fragment-conditional": {
       "kinds": [
         "call",
@@ -5757,13 +5770,13 @@
     "array-method": 71,
     "arrow": 71,
     "binary": 94,
-    "call": 236,
+    "call": 237,
     "conditional": 27,
-    "identifier": 337,
+    "identifier": 338,
     "index-access": 14,
     "literal": 269,
     "logical": 47,
-    "member": 193,
+    "member": 194,
     "object-literal": 65,
     "template-literal": 30,
     "unary": 24,

--- a/packages/adapter-tests/fixtures/fragment-body-keyed-loop-row.ts
+++ b/packages/adapter-tests/fixtures/fragment-body-keyed-loop-row.ts
@@ -1,0 +1,59 @@
+import { createFixture } from '../src/types'
+
+/**
+ * A `.map()` whose CALLBACK BODY is a fragment with `key={}` on its first
+ * element (`<>` `<li key={item.id}>...</li>` `<li>x</li>` `</>`) — #2763.
+ * Different shape from `fragment-root-keyed-loop-row.ts` (#2732/#2733,
+ * mechanism 2: key on a fragment-rooted CHILD COMPONENT, relayed through
+ * `IRElement.keyAttr` with no local `value`): this fixture pins mechanism 1
+ * — a LOCAL key expression read directly off the loop body, same file, no
+ * component boundary.
+ *
+ * Before the #2763 fix, `extractLoopKey` (`jsx-to-ir.ts`) had no `fragment`
+ * case, so the key resolved to `null` for this shape: no SSR adapter emitted
+ * a row-key attribute and `mapArray` reconciled positionally (no `keyFn`),
+ * while `html-template.ts`'s client row builder baked `data-key` anyway by
+ * reading the raw `key` JSX attribute independently of that decision. This
+ * fixture's SSR-shape half (this file) pins the fix: `data-key` now lands on
+ * the first ELEMENT among the fragment's own top-level children (the `<li>`
+ * carrying `key`), matching the "first element, not first node" rule
+ * (`IRElement.keyAttr`'s docstring) — the second `<li>` in each row carries
+ * no key attribute at all.
+ */
+export const fixture = createFixture({
+  id: 'fragment-body-keyed-loop-row',
+  description: 'Fragment-bodied `.map()` row with a local `key={}` on its first element (#2763)',
+  componentName: 'FragmentBodyKeyedLoopRow',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+type Item = { id: number; label: string }
+export function FragmentBodyKeyedLoopRow(props: { items: Item[] }) {
+  const [items] = createSignal<Item[]>(props.items)
+  return (
+    <ul>
+      {items().map(item => (
+        <>
+          <li key={item.id}>{item.label}</li>
+          <li>x</li>
+        </>
+      ))}
+    </ul>
+  )
+}
+`,
+  props: {
+    items: [
+      { id: 1, label: 'a' },
+      { id: 2, label: 'b' },
+    ],
+  },
+  expectedHtml: `
+    <ul bf-s="test" bf="s1">
+      <li data-key="1"><!--bf:s0-->a<!--/--></li>
+      <li>x</li>
+      <li data-key="2"><!--bf:s0-->b<!--/--></li>
+      <li>x</li>
+    </ul>
+  `,
+})

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -477,6 +477,7 @@ import { fixture as filterWrapperPropsReachable } from './filter-wrapper-props-r
 // `ErbFilterEmitter` ID-matching bug that naming previously routed around.
 import { fixture as filterParamNameDiffers } from './filter-param-name-differs'
 import { fixture as fragmentRootKeyedLoopRow } from './fragment-root-keyed-loop-row'
+import { fixture as fragmentBodyKeyedLoopRow } from './fragment-body-keyed-loop-row'
 // #2237 (PR #2241): a `.map()` callback param shadows a module-scope
 // object const; every Twig-family adapter used to bake the const's
 // literal into each iteration instead of reading the loop's own item.
@@ -948,6 +949,7 @@ export const jsxFixtures: JSXFixture[] = [
   destructuredObjectPropNested,
   loopPreambleConditionalReactive,
   fragmentRootKeyedLoopRow,
+  fragmentBodyKeyedLoopRow,
   loopRowControlledTextarea,
   statelessRestSpreadForward,
 ]

--- a/packages/adapter-tests/generated-data-points.json
+++ b/packages/adapter-tests/generated-data-points.json
@@ -1394,6 +1394,14 @@
       }
     }
   ],
+  "fragment-body-keyed-loop-row": [
+    {
+      "name": "gen:items:empty",
+      "props": {
+        "items": []
+      }
+    }
+  ],
   "fragment-root-conditional-loop-row": [
     {
       "name": "gen:items:empty",

--- a/packages/jsx/src/__tests__/fragment-body-loop-key.test.ts
+++ b/packages/jsx/src/__tests__/fragment-body-loop-key.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Fragment-bodied `.map()` row key extraction (#2763).
+ *
+ * A `.map()` callback whose body is a fragment (`<><li key={..}/><li/></>`)
+ * used to make `extractLoopKey` (`jsx-to-ir.ts`) return `null` — it handled
+ * `element`, `component`, and `conditional`, but not `fragment`. That made
+ * every SSR adapter silently drop the row-key attribute AND left
+ * `mapArray`'s `keyFn` unset (positional reconciliation), while
+ * `html-template.ts`'s client row builder kept baking `data-key` from the
+ * raw `key` JSX attribute — a silent SSR/CSR divergence with no diagnostic.
+ *
+ * The fix adds a `fragment` case to both `extractLoopKey` and its write-side
+ * twin `applyLoopKeyAttr`, reading/stamping the key on the fragment's FIRST
+ * ELEMENT child (skipping whitespace-only text), matching the "first
+ * element, not first node" rule `IRElement.keyAttr`'s docstring already
+ * documents for the render-root relay case. `html-template.ts`'s client
+ * template builders were also changed to read `IRElement.keyAttr` instead
+ * of the raw attribute (see `resolvedKeyAttrName` in that file) — this test
+ * covers only the SSR/IR-resolution half.
+ */
+import { describe, test, expect } from 'bun:test'
+import { analyzeComponent } from '../analyzer'
+import { jsxToIR } from '../jsx-to-ir'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+import type { IRElement, IRLoop, IRNode } from '../types'
+
+function compile(source: string, name = 'Test'): IRNode {
+  const ir = jsxToIR(analyzeComponent(source, `${name}.tsx`))
+  expect(ir).not.toBeNull()
+  return ir!
+}
+
+/** The single `loop` node anywhere in the tree (depth-first), or null. */
+function findLoop(node: IRNode): IRLoop | null {
+  if (node.type === 'loop') return node
+  const children: IRNode[] =
+    'children' in node && Array.isArray((node as { children?: unknown }).children)
+      ? (node as { children: IRNode[] }).children
+      : []
+  for (const c of children) {
+    const found = findLoop(c)
+    if (found) return found
+  }
+  return null
+}
+
+const SOURCE = `
+'use client'
+import { createSignal } from '@barefootjs/client'
+type Item = { id: number; label: string }
+export function KeyFrag(props: { items: Item[] }) {
+  const [items] = createSignal<Item[]>(props.items)
+  return (
+    <ul>
+      {items().map(item => (
+        <>
+          <li key={item.id}>{item.label}</li>
+          <li>x</li>
+        </>
+      ))}
+    </ul>
+  )
+}
+`
+
+describe('fragment-bodied .map() row key extraction (#2763)', () => {
+  test('IRElement.keyAttr lands on the fragment\'s first element, not the second', () => {
+    const ir = compile(SOURCE, 'KeyFrag')
+    const loop = findLoop(ir)
+    expect(loop).not.toBeNull()
+    const fragment = loop!.children[0]
+    expect(fragment.type).toBe('fragment')
+    if (fragment.type !== 'fragment') return
+    const [firstLi, secondLi] = fragment.children.filter(
+      (c): c is IRElement => c.type === 'element',
+    )
+    expect(firstLi.keyAttr).toEqual({ name: 'data-key', value: 'item.id' })
+    expect(secondLi.keyAttr).toBeUndefined()
+  })
+
+  test('mapArray receives a real keyFn instead of reconciling positionally', () => {
+    const result = compileJSX(SOURCE, 'KeyFrag.tsx', { adapter: new TestAdapter() })
+    expect(result.errors.filter((e) => (e as { severity?: string }).severity === 'error')).toHaveLength(0)
+    const cjs = result.files.find((f) => f.type === 'clientJs')
+    expect(cjs).toBeDefined()
+    const calls = cjs!.content
+      .split('\n')
+      .map((ln) => ln.trim())
+      .filter((ln) => ln.startsWith('mapArray(') || ln.startsWith('mapArrayLazy('))
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).toContain('String(item.id)')
+    expect(calls[0]).not.toMatch(/_s\d+, null,/)
+  })
+})

--- a/packages/jsx/src/__tests__/multi-root-loop-body.test.ts
+++ b/packages/jsx/src/__tests__/multi-root-loop-body.test.ts
@@ -48,7 +48,11 @@ export function Edges() {
     const { markedTemplate, clientJs } = compile(source, 'Edges.tsx')
 
     // SSR: per-item start marker is emitted inside the .map() body.
-    expect(markedTemplate.content).toContain(`bfComment('bf-loop-i')`)
+    // `bfComment(k)` itself prepends `bf-`, so the call argument is
+    // `'loop-i'`, yielding `<!--bf-loop-i-->` (#2763 fixed a stray extra
+    // `bf-` prefix here that had gone unexercised until that issue's
+    // fixture was the first `bodyIsMultiRoot` case rendered on this adapter).
+    expect(markedTemplate.content).toContain(`bfComment('loop-i')`)
     // Loop boundary markers also still present.
     expect(markedTemplate.content).toMatch(/bfComment\('loop:[^']+'\)/)
     expect(markedTemplate.content).toMatch(/bfComment\('\/loop:[^']+'\)/)
@@ -79,7 +83,7 @@ export function Items() {
     const { markedTemplate, clientJs } = compile(source, 'Items.tsx')
 
     // No per-item markers in the single-root case (zero-cost).
-    expect(markedTemplate.content).not.toContain(`bfComment('bf-loop-i')`)
+    expect(markedTemplate.content).not.toContain(`bfComment('loop-i')`)
     expect(clientJs).toBeDefined()
     expect(clientJs!.content).not.toContain('__bfExtras')
   })
@@ -104,7 +108,7 @@ export function Items() {
 }
 `
     const { markedTemplate, clientJs } = compile(source, 'NestedFrag.tsx')
-    expect(markedTemplate.content).not.toContain(`bfComment('bf-loop-i')`)
+    expect(markedTemplate.content).not.toContain(`bfComment('loop-i')`)
     expect(clientJs).toBeDefined()
     expect(clientJs!.content).not.toContain('__bfExtras')
   })

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -2,7 +2,7 @@
  * IR → HTML template string generation and validation.
  */
 
-import type { AttrValue, FlatMapCallback, IRAttribute, IRExpression, IRNode, IRProp, MapCallbackPreamble } from '../types.ts'
+import type { AttrValue, FlatMapCallback, IRAttribute, IRElement, IRExpression, IRNode, IRProp, MapCallbackPreamble } from '../types.ts'
 import { isBooleanAttr } from '../html-constants.ts'
 import { toHtmlAttrName, attrValueToString, quotePropName, PROPS_PARAM, DATA_BF_PH, keyAttrName, loopStartMarker, loopEndMarker, loopItemMarker, freeIdsFromRefs, setIntersects, wrapExprWithLoopParams } from './utils.ts'
 import type { LoopParamSpec } from './utils.ts'
@@ -547,6 +547,25 @@ export interface MergeContext {
   honorClientOnly: boolean
 }
 
+/**
+ * The client-template twin of `IRElement.keyAttr`'s SSR-side decision
+ * (`jsx-to-ir.ts`'s `extractLoopKey`/`applyLoopKeyAttr`) — #2763. A raw
+ * `key={}` JSX attribute survives on `.attrs` regardless of whether the
+ * loop/relay actually recognized it as a row key (a fragment-bodied loop
+ * row before #2763's fix, or heterogeneous keys across conditional
+ * branches) — baking `data-key` from the mere presence of that attribute
+ * would disagree with every SSR adapter, which all gate on `keyAttr`
+ * instead. Returns the resolved attribute name only when `node.keyAttr` is
+ * actually set; `null` otherwise, so the caller drops the raw `key`
+ * attribute entirely rather than emitting a `data-key` no SSR adapter
+ * agrees with. `keyAttr.name` and `keyAttrName(loopDepth)` are already the
+ * same value (both derive from `@barefootjs/shared`'s `keyAttrName`, see
+ * `IRElement.keyAttr`'s docstring) — this only decides WHETHER to use it.
+ */
+function resolvedKeyAttrName(node: IRElement, loopDepth: number): string | null {
+  return node.keyAttr ? keyAttrName(loopDepth) : null
+}
+
 /** Return true if this attribute should participate in the merge object. */
 function isMergeableAttr(a: IRAttribute, ctx: MergeContext): boolean {
   if (ctx.honorClientOnly && a.clientOnly) return false
@@ -876,10 +895,11 @@ export function irToHtmlTemplate(node: IRNode, restSpreadNames?: ReadonlySet<str
             // others are already represented inside the merge object.
             return idx === firstMergeableIdx ? mergeCall! : ''
           }
-          const attrName = a.name === '...'
-            ? '...'
-            : (a.name === 'key' ? keyAttrName(loopDepth) : toHtmlAttrName(a.name))
-          return renderTemplateAttrPart(a, attrName, wrapExpr, restSpreadNames)
+          if (a.name === 'key') {
+            const attrName = resolvedKeyAttrName(node, loopDepth)
+            return attrName ? renderTemplateAttrPart(a, attrName, wrapExpr, restSpreadNames) : ''
+          }
+          return renderTemplateAttrPart(a, toHtmlAttrName(a.name), wrapExpr, restSpreadNames)
         })
         .filter(Boolean)
 
@@ -1189,7 +1209,9 @@ export function buildLoopSkeletonTemplate(node: IRNode, safe: LoopSkeletonSafeSl
         if (a.name === '...') return null
         if (a.name === 'dangerouslySetInnerHTML') return null
         if (a.name === 'key') {
-          attrParts.push(`${keyAttrName(0)}=""`)
+          if (resolvedKeyAttrName(node, 0)) {
+            attrParts.push(`${keyAttrName(0)}=""`)
+          }
           continue
         }
         const v = a.value
@@ -1485,9 +1507,11 @@ export function irToPlaceholderTemplate(node: IRNode, restSpreadNames?: Readonly
           // composite-row twin of it, so a row it builds must carry the
           // same attributes a hydration-reused row does (#2756).
           if (a.clientOnly) return ''
-          const attrName = a.name === '...'
-            ? '...'
-            : (a.name === 'key' ? keyAttrName(loopDepth) : toHtmlAttrName(a.name))
+          if (a.name === 'key') {
+            const attrName = resolvedKeyAttrName(node, loopDepth)
+            return attrName ? renderTemplateAttrPart(a, attrName, wrapExpr, restSpreadNames) : ''
+          }
+          const attrName = a.name === '...' ? '...' : toHtmlAttrName(a.name)
           return renderTemplateAttrPart(a, attrName, wrapExpr, restSpreadNames)
         })
         .filter(Boolean)
@@ -2550,9 +2574,26 @@ function generateCsrTemplateWithOpts(node: IRNode, opts: TemplateOptions): strin
             if (mergeCtx.isFilteredSpread(v)) return ''
             return `\${spreadAttrs(${transformExpr(v.expr, v.templateExpr)})}`
           }
-          const attrName = a.name === 'key'
-            ? keyAttrName(loopDepth)
-            : toHtmlAttrName(a.name)
+          if (a.name === 'key') {
+            const keyName = resolvedKeyAttrName(node, loopDepth)
+            if (!keyName) return ''
+            switch (v.kind) {
+              case 'boolean-attr':
+                return keyName
+              case 'literal':
+                return `${keyName}="${escapeHtml(v.value)}"`
+              case 'expression':
+                return templateAttrExpr(keyName, transformExpr(v.expr, v.templateExpr), v.presenceOrUndefined)
+              case 'template': {
+                const valueStr = attrValueToString(v, { useTemplate: true })
+                return valueStr ? templateAttrExpr(keyName, transformExpr(valueStr)) : ''
+              }
+              case 'boolean-shorthand':
+              case 'jsx-children':
+                return ''
+            }
+          }
+          const attrName = toHtmlAttrName(a.name)
           switch (v.kind) {
             case 'boolean-attr':
               return attrName

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -4219,12 +4219,12 @@ function tagLoopItemRootComponents(nodes: readonly IRNode[]): void {
  *
  * Deliberately does NOT remove the literal `key` entry from `.attrs`: the
  * CSR/client-JS codegen path (`ir-to-client-js/html-template.ts`'s
- * `a.name === 'key' ? keyAttrName(loopDepth) : ...`) already reads it
- * directly and is not part of #2753's 16-site duplication — it derives the
- * same name from the same `keyAttrName()` single source of truth, just at a
- * different phase (client-template bake time, not SSR emit time). Adapters
- * skip the raw `key` attr in their generic `renderAttributes` loop instead
- * (Hono's own JSX runtime already drops it silently either way).
+ * `resolvedKeyAttrName` helper, #2763) reads it back off `.attrs` too, but
+ * only emits `data-key` when THIS field — `node.keyAttr` — is actually set;
+ * a raw `key` attribute the SSR side didn't recognize as a row key (e.g. a
+ * fragment-bodied row before #2763's fix) no longer gets baked client-side
+ * either. Adapters skip the raw `key` attr in their generic `renderAttributes`
+ * loop instead (Hono's own JSX runtime already drops it silently either way).
  *
  * `component` bodies are left untouched: a `<Comp key={x}/>` row root's key
  * is a PROP (`renderComponentProps`'s own `data-key` prop-forwarding), not

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -3793,6 +3793,19 @@ function extractLoopKey(node: IRNode): string | null {
     if (b === null) return null
     return normalizeKeyExpr(a) === normalizeKeyExpr(b) ? a : null
   }
+  if (node.type === 'fragment') {
+    // #2763: a `.map()` body returning a fragment (`<><li key={..}/><li/></>`)
+    // reads the key off its FIRST element, not first node — same "first
+    // element, not first node" rule as `IRElement.keyAttr`'s docstring and
+    // `markCarrierIn`'s relay case, skipping whitespace-only text the way
+    // `branchHasNoElement` does. Recursing through `extractLoopKey` (rather
+    // than requiring `type === 'element'` directly) lets a nested
+    // conditional/fragment first child resolve too.
+    const first = node.children.find(
+      (c) => !(c.type === 'text' && typeof c.value === 'string' && !c.value.trim())
+    )
+    return first ? extractLoopKey(first) : null
+  }
   return null
 }
 
@@ -4226,6 +4239,16 @@ function applyLoopKeyAttr(node: IRNode, name: string, value: string): void {
   if (node.type === 'conditional') {
     applyLoopKeyAttr(node.whenTrue, name, value)
     applyLoopKeyAttr(node.whenFalse, name, value)
+    return
+  }
+  if (node.type === 'fragment') {
+    // Write-side twin of `extractLoopKey`'s fragment case: stamp the SAME
+    // first-real-child this key was read from, not every child, matching
+    // the "first element, not first node" rule.
+    const first = node.children.find(
+      (c) => !(c.type === 'text' && typeof c.value === 'string' && !c.value.trim())
+    )
+    if (first) applyLoopKeyAttr(first, name, value)
   }
 }
 

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-conformance section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. This answers, per fixture and per adapter, whether the construct WORKS — not just whether it compiles. A construct works either as written (✓) or with a documented `/* @client */` comment (✓†, a verified, supported escape — most refusals have one). Fixtures absent from the table below work on every adapter — most as written, some via that documented escape; the headline says how many of each. Listed fixtures need attention somewhere: a bare diagnostic code is still-open debt with no escape yet, a code led by ✗ owes no escape at all (by design), and ≠ means the fixture compiles clean but its rendered output diverges from the reference.",
-    "totalFixtures": 359,
+    "totalFixtures": 360,
     "fixtures": {
       "children-passthrough-renamed": {
         "go-template": {

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -1426,11 +1426,11 @@
       }
     },
     "call": {
-      "total": 236,
+      "total": 237,
       "cells": {
         "hono": {
-          "pass": 235,
-          "total": 236,
+          "pass": 236,
+          "total": 237,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1441,8 +1441,8 @@
           ]
         },
         "blade": {
-          "pass": 221,
-          "total": 236,
+          "pass": 222,
+          "total": 237,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1517,8 +1517,8 @@
           ]
         },
         "erb": {
-          "pass": 222,
-          "total": 236,
+          "pass": 223,
+          "total": 237,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1587,8 +1587,8 @@
           ]
         },
         "go-template": {
-          "pass": 218,
-          "total": 236,
+          "pass": 219,
+          "total": 237,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1675,8 +1675,8 @@
           ]
         },
         "jinja": {
-          "pass": 221,
-          "total": 236,
+          "pass": 222,
+          "total": 237,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1751,8 +1751,8 @@
           ]
         },
         "minijinja": {
-          "pass": 221,
-          "total": 236,
+          "pass": 222,
+          "total": 237,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1827,8 +1827,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 222,
-          "total": 236,
+          "pass": 223,
+          "total": 237,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1897,8 +1897,8 @@
           ]
         },
         "twig": {
-          "pass": 221,
-          "total": 236,
+          "pass": 222,
+          "total": 237,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1973,8 +1973,8 @@
           ]
         },
         "xslate": {
-          "pass": 221,
-          "total": 236,
+          "pass": 222,
+          "total": 237,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2194,11 +2194,11 @@
       }
     },
     "identifier": {
-      "total": 337,
+      "total": 338,
       "cells": {
         "hono": {
-          "pass": 334,
-          "total": 337,
+          "pass": 335,
+          "total": 338,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2221,8 +2221,8 @@
           ]
         },
         "blade": {
-          "pass": 318,
-          "total": 337,
+          "pass": 319,
+          "total": 338,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2317,8 +2317,8 @@
           ]
         },
         "erb": {
-          "pass": 319,
-          "total": 337,
+          "pass": 320,
+          "total": 338,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2407,8 +2407,8 @@
           ]
         },
         "go-template": {
-          "pass": 313,
-          "total": 337,
+          "pass": 314,
+          "total": 338,
           "gaps": [
             {
               "fixture": "children-passthrough-renamed",
@@ -2525,8 +2525,8 @@
           ]
         },
         "jinja": {
-          "pass": 318,
-          "total": 337,
+          "pass": 319,
+          "total": 338,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2621,8 +2621,8 @@
           ]
         },
         "minijinja": {
-          "pass": 318,
-          "total": 337,
+          "pass": 319,
+          "total": 338,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2717,8 +2717,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 318,
-          "total": 337,
+          "pass": 319,
+          "total": 338,
           "gaps": [
             {
               "fixture": "children-passthrough-renamed",
@@ -2811,8 +2811,8 @@
           ]
         },
         "twig": {
-          "pass": 318,
-          "total": 337,
+          "pass": 319,
+          "total": 338,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2907,8 +2907,8 @@
           ]
         },
         "xslate": {
-          "pass": 318,
-          "total": 337,
+          "pass": 319,
+          "total": 338,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3726,11 +3726,11 @@
       }
     },
     "member": {
-      "total": 193,
+      "total": 194,
       "cells": {
         "hono": {
-          "pass": 190,
-          "total": 193,
+          "pass": 191,
+          "total": 194,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3753,8 +3753,8 @@
           ]
         },
         "blade": {
-          "pass": 174,
-          "total": 193,
+          "pass": 175,
+          "total": 194,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3849,8 +3849,8 @@
           ]
         },
         "erb": {
-          "pass": 175,
-          "total": 193,
+          "pass": 176,
+          "total": 194,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3939,8 +3939,8 @@
           ]
         },
         "go-template": {
-          "pass": 170,
-          "total": 193,
+          "pass": 171,
+          "total": 194,
           "gaps": [
             {
               "fixture": "children-passthrough-renamed",
@@ -4053,8 +4053,8 @@
           ]
         },
         "jinja": {
-          "pass": 174,
-          "total": 193,
+          "pass": 175,
+          "total": 194,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4149,8 +4149,8 @@
           ]
         },
         "minijinja": {
-          "pass": 174,
-          "total": 193,
+          "pass": 175,
+          "total": 194,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4245,8 +4245,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 174,
-          "total": 193,
+          "pass": 175,
+          "total": 194,
           "gaps": [
             {
               "fixture": "children-passthrough-renamed",
@@ -4339,8 +4339,8 @@
           ]
         },
         "twig": {
-          "pass": 174,
-          "total": 193,
+          "pass": 175,
+          "total": 194,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4435,8 +4435,8 @@
           ]
         },
         "xslate": {
-          "pass": 174,
-          "total": 193,
+          "pass": 175,
+          "total": 194,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",


### PR DESCRIPTION
## Summary

Closes #2763. `extractLoopKey` (`jsx-to-ir.ts`) handled `element`, `component`, and `conditional` loop bodies but not `fragment`, so a `.map()` whose callback returns a fragment (`<><li>...</li><li>x</li>`) resolved its key to `null`. Every SSR adapter then silently omitted the row-key attribute and `mapArray` fell back to positional reconciliation, while `ir-to-client-js/html-template.ts`'s client row builders kept baking `data-key` by reading the raw `key` JSX attribute directly, independently of that decision — a silent SSR/CSR divergence with no diagnostic.

## The fix

`extractLoopKey` and its write-side twin `applyLoopKeyAttr` gained a `fragment` case that reads/stamps the key on the fragment's first ELEMENT child (skipping whitespace-only text), matching the "first element, not first node" rule `IRElement.keyAttr`'s docstring already documents for the render-root relay case (#2753). Four `html-template.ts` call sites (`irToHtmlTemplate`, `buildLoopSkeletonTemplate`, `irToPlaceholderTemplate`, `generateCsrTemplateWithOpts`) that read the raw `key` attribute independently now go through a new `resolvedKeyAttrName` helper that consults `IRElement.keyAttr` instead — in the spirit of #2762's consolidation — so a row the SSR side doesn't recognize as keyed no longer gets a `data-key` baked into it client-side either. (A fifth raw-`key`-reading site exists in `irToComponentTemplateWithOpts`, but it's dead code for any loop-containing tree — `canGenerateStaticTemplate`'s `case 'loop': return false` gates both of its callers away first — so it needed no change.)

## A latent bug this surfaced

Chasing the new fixture to a byte-exact `expectedHtml` caught an unrelated, pre-existing bug: both the Hono and go-template adapters emitted their multi-root Fragment per-item start marker (#1212) as `bfComment('bf-loop-i')` / `{{bfComment "bf-loop-i"}}`, even though `bfComment` already prepends `bf-` itself — doubling the prefix, unlike every other call site and the client runtime already agree on. No prior fixture combined a multi-root Fragment row with an SSR render on either adapter, so this went unexercised until now. Fixed on both adapters; `multi-root-loop-body.test.ts`'s pinned assertions (which had hardcoded the buggy string as expected) updated to match.

## Coverage

New fixture `fragment-body-keyed-loop-row` (`adapter-tests`) pins the SSR/CSR contract for this shape (its `expectedHtml` auto-regenerated from the fixed Hono reference). New unit test `fragment-body-loop-key.test.ts` (`jsx`) pins both the IR-level `keyAttr` resolution and the resulting `mapArray` keyFn directly.

## Verification

- `packages/jsx` full suite: 3166 pass / 0 fail
- `packages/adapter-tests` full suite: 2297 pass / 0 fail
- `packages/adapter-go-template` full suite: 1861 pass / 0 fail (real `go run` steps skipped in this sandbox — no `go` binary; CI covers them)
- `packages/compat` full suite: 514 pass / 0 fail (after regenerating `ui/support-matrix.lock.json` and `ui/compat.lock.json`)
- `generate-expected-html.ts` / `coverage-map.ts` re-run, only the new fixture's entries changed
- Changesets added: `@barefootjs/jsx` (patch), `@barefootjs/hono` + `@barefootjs/go-template` (patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198yG2px5ygfvmdoMkhRS13

---
_Generated by [Claude Code](https://claude.ai/code/session_0198yG2px5ygfvmdoMkhRS13)_