### PR TITLE
Fix #2806: direct rest-bag read in JSX leaks unbound `rest` into CSR template

### DIFF
--- a/.changeset/rest-bag-template-rewrite-2806.md
+++ b/.changeset/rest-bag-template-rewrite-2806.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Fix #2806: a component reading its own rest-bag spread directly in JSX (`{rest.header}`, not spread onto an element's attrs via `{...rest}`) emitted a CSR template referencing the bare, unbound `rest` identifier — a guaranteed `ReferenceError`. The rest binding is `_p` at runtime (the init body already rewrites `rest.x` → `_p.x` via `rewritePropsObjectRef`, #2723, and `applyRestAttrs` excludes the consumed keys by name from that same object rather than constructing a narrower one), but the four CSR/static template builders in `html-template.ts` were calling `rewritePropsObjectRef` with `null` for the rest name — the same four sites #2737 just migrated onto this shared door for `propsObjectName`. They now thread `ctx.restPropsName` through as well, so a direct rest-bag read resolves the same way in the template as it always did in init.

--- a/packages/adapter-tests/src/__tests__/client-js-scope.test.ts
+++ b/packages/adapter-tests/src/__tests__/client-js-scope.test.ts
@@ -55,16 +55,12 @@ const KNOWN_UNDECLARED: Record<string, KnownHole> = {
   // map-index-handler, reactive-props, props-reactivity-comparison)
   // graduated with the memo/`templateExpr`/getter-elided-signal emission
   // fixes; see the issue for the closing PR.
-  'jsx-element-prop-rest-bag-dynamic': {
-    // #2806: a component reading its own rest-bag spread directly in JSX
-    // (`{rest.header}`) emits a CSR template referencing `rest`, which is
-    // never bound in that scope — the same `applyRestAttrs`-not-modeled
-    // class as the CSR_SKIP_FIXTURES entries above it, manifesting here as
-    // a genuine undeclared-identifier compile hole rather than a harness
-    // limitation.
-    names: ['rest'],
-    issue: 'https://github.com/piconic-ai/barefootjs/issues/2806',
-  },
+  // #2806 (a component reading its own rest-bag spread directly in JSX,
+  // `{rest.header}`) is FIXED — the four template builders in
+  // `html-template.ts` now thread `restPropsName` into the same
+  // `rewritePropsObjectRef` door the init body already used (#2723), so
+  // `rest.x` resolves to `_p.x` in the template the same way it always did
+  // in init.
 }
 
 /** One virtual .ts file per emitted client-JS artifact. */

--- a/packages/adapter-tests/src/csr-skip-set.ts
+++ b/packages/adapter-tests/src/csr-skip-set.ts
@@ -90,13 +90,4 @@ export const CSR_SKIP_FIXTURES: ReadonlySet<string> = new Set([
   // child needs no `$c` lookup at all (it IS `__scope`) — see
   // `ClientJsContext.commentScopeRootSlotId` and
   // `comment-wrapper-grandchild-slot-collision.test.ts`.
-  // #2806: same `applyRestAttrs`-not-modeled class as `jsx-spread-props-object`
-  // / `rest-spread-child-attrs` / `stateless-rest-spread-forward` above, but
-  // reading the rest bag directly in JSX (`{rest.header}`) rather than
-  // spreading it onto an element's attrs — the emitted CSR template
-  // references `rest` without ever binding it, a guaranteed
-  // `ReferenceError` (also pinned in `client-js-scope.test.ts`'s
-  // `KNOWN_UNDECLARED`). SSR is correct on every adapter; go-template's own
-  // orthogonal refusal for this shape is #2805.
-  'jsx-element-prop-rest-bag-dynamic',
 ])

--- a/packages/jsx/src/__tests__/issue-2806-rest-bag-template-rewrite.test.ts
+++ b/packages/jsx/src/__tests__/issue-2806-rest-bag-template-rewrite.test.ts
@@ -43,6 +43,11 @@ describe('#2806 — rest-bag identifier resolves in the CSR template', () => {
   })
 
   test('a rest-bag read inside a `.map()` row still resolves', () => {
+    // NOTE: `rest.items ?? []` is classified `isStaticArray` here (no signal,
+    // no `isArrayExprDirectPropRef` match — see `jsx-to-ir.ts`'s `isStaticArray`
+    // derivation), so this row is emitted through `buildStaticLoopPlan`'s
+    // SSR-time-only `forEach`, NOT through the reactive `mapArray`/`mapArrayLazy`
+    // loop emitters. It does not exercise those two paths — the tests below do.
     const content = clientJs(`
       "use client";
       export function Row({ children, ...rest }: { children?: any; items?: Array<{ id: number }>; [key: string]: any }) {
@@ -55,6 +60,58 @@ describe('#2806 — rest-bag identifier resolves in the CSR template', () => {
         )
       }
     `)
+    expect(content).toContain('_p.suffix')
+    expect(content).not.toMatch(/[^.\w]rest\.suffix/)
+  })
+
+  test('a rest-bag read inside a lazy-eligible `.map()` row resolves (`mapArrayLazy`)', () => {
+    // Signal-backed source + a keyed, single-root, child-component-free row
+    // is lazy-eligible (`lazyRowEligibility`), so this hits the `createRow`/
+    // `applyOuter` bodies emitted by `stringify/lazy-row.ts` — a SEPARATE
+    // emitter from the whole-init-body rewrite the other tests here exercise
+    // only incidentally through the eager `mapArray` row body.
+    const content = clientJs(`
+      "use client";
+      import { createSignal } from '@barefootjs/client'
+      export function Row({ children, ...rest }: { children?: any; [key: string]: any }) {
+        const [items, setItems] = createSignal<{ id: number }[]>([])
+        return (
+          <ul>
+            {items().map((item: { id: number }) => (
+              <li key={item.id}>{item.id}{rest.suffix}</li>
+            ))}
+          </ul>
+        )
+      }
+    `)
+    expect(content).toContain('mapArrayLazy')
+    expect(content).toContain('_p.suffix')
+    expect(content).not.toMatch(/[^.\w]rest\.suffix/)
+  })
+
+  test('a rest-bag read inside an eager `.map()` row with a child component resolves (`mapArray`)', () => {
+    // A child component in the row forces eager `mapArray` eligibility
+    // (`lazyRowEligibility`'s `hasChildComponent` gate) — the loop-row-body
+    // emission path #2812 actually fixed (the `hydrate(... template: ...)`
+    // line and the CSR/static template builders in `html-template.ts`).
+    const content = clientJs(`
+      "use client";
+      import { createSignal } from '@barefootjs/client'
+      function Item(props: { id: number }) {
+        return <span>{props.id}</span>
+      }
+      export function Row({ children, ...rest }: { children?: any; [key: string]: any }) {
+        const [items, setItems] = createSignal<{ id: number }[]>([])
+        return (
+          <ul>
+            {items().map((item: { id: number }) => (
+              <li key={item.id}><Item id={item.id} />{rest.suffix}</li>
+            ))}
+          </ul>
+        )
+      }
+    `)
+    expect(content).toContain('mapArray(')
     expect(content).toContain('_p.suffix')
     expect(content).not.toMatch(/[^.\w]rest\.suffix/)
   })

--- a/packages/jsx/src/__tests__/issue-2806-rest-bag-template-rewrite.test.ts
+++ b/packages/jsx/src/__tests__/issue-2806-rest-bag-template-rewrite.test.ts
@@ -1,0 +1,79 @@
+/**
+ * #2806 — a component reading its own rest-bag spread directly in JSX
+ * (`{rest.header}`, not spread onto an element's attrs) emitted a CSR
+ * template that referenced the bare, unbound `rest` identifier.
+ *
+ * The rest binding IS `_p` at runtime (`applyRestAttrs` excludes the
+ * consumed keys by name rather than constructing a narrower object, and
+ * the init body already rewrites `rest.x` → `_p.x` via
+ * `rewritePropsObjectRef`, #2723). The four CSR/static template builders
+ * in `html-template.ts` each call that same function for `propsObjectName`
+ * but were passing `null` for the rest name, so a direct rest-bag read
+ * never got the same treatment there.
+ */
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+function clientJs(source: string): string {
+  const result = compileJSX(source, 'Repro.tsx', { adapter })
+  expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+  return result.files.find(f => f.type === 'clientJs')!.content
+}
+
+describe('#2806 — rest-bag identifier resolves in the CSR template', () => {
+  test('a direct rest-bag read in a text expression emits `_p.x`, not bare `rest`', () => {
+    const content = clientJs(`
+      "use client";
+      import { createSignal } from '@barefootjs/client'
+      export function Card({ children, ...rest }: { children?: any; [key: string]: any }) {
+        const [cond, setCond] = createSignal(true)
+        return (
+          <section>
+            <header>{cond() ? rest.header : null}</header>
+            <div>{children}</div>
+          </section>
+        )
+      }
+    `)
+    expect(content).toContain('_p.header')
+    expect(content).not.toMatch(/[^.\w]rest\.header/)
+  })
+
+  test('a rest-bag read inside a `.map()` row still resolves', () => {
+    const content = clientJs(`
+      "use client";
+      export function Row({ children, ...rest }: { children?: any; items?: Array<{ id: number }>; [key: string]: any }) {
+        return (
+          <ul>
+            {(rest.items ?? []).map((item: { id: number }) => (
+              <li key={item.id}>{rest.suffix}</li>
+            ))}
+          </ul>
+        )
+      }
+    `)
+    expect(content).toContain('_p.suffix')
+    expect(content).not.toMatch(/[^.\w]rest\.suffix/)
+  })
+
+  test('a `.map()` row PARAMETER literally named `rest` is not rewritten (shadow guard)', () => {
+    const content = clientJs(`
+      "use client";
+      export function List({ children, ...outer }: { children?: any; [key: string]: any }) {
+        const rows = [{ id: 1, name: 'a' }]
+        return (
+          <ul>
+            {rows.map(rest => (
+              <li key={rest.id}>{rest.name}</li>
+            ))}
+          </ul>
+        )
+      }
+    `)
+    expect(content).not.toContain('_p.name')
+    expect(content).toContain('rest.name')
+  })
+})

--- a/packages/jsx/src/ir-to-client-js/emit-registration.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-registration.ts
@@ -223,7 +223,7 @@ export function emitRegistrationAndHydration(
     // (#2651) — see `generateCsrTemplate`'s identical derivation below
     // for why this is reused as-is rather than re-derived.
     const markupSlotIds = new Set(ctx.dynamicElements.map(e => e.slotId))
-    const templateHtml = irToComponentTemplate(_ir.root, inlinableConstants, restSpreadNames, ctx.propsObjectName, markupSlotIds)
+    const templateHtml = irToComponentTemplate(_ir.root, inlinableConstants, restSpreadNames, ctx.propsObjectName, markupSlotIds, ctx.restPropsName)
     if (templateHtml) {
       defParts.push(buildTemplateDefPart(ctx, templateHtml))
     }

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -1788,6 +1788,21 @@ export interface TemplateOptions {
   restSpreadNames?: ReadonlySet<string>
   propsObjectName?: string | null
   /**
+   * The rest-bag binding's source name (`ctx.restPropsName` — `'rest'` in
+   * `{ children, ...rest }`), threaded alongside `propsObjectName` into
+   * `rewritePropsObjectRef` so a component that reads the rest binding
+   * directly in its own body (`{rest.header}`, not just spread onto an
+   * element via `applyRestAttrs`) resolves to `_p` here too (#2806).
+   * Not folded into `restSpreadNames`: that set is spread-filter
+   * membership keyed by raw expression text (`isFilteredSpread`,
+   * `collect-elements.ts`'s exclude-key resolution) and must keep seeing
+   * the untouched name; this field is the separate "identifier to rewrite"
+   * input `rewritePropsObjectRef` already accepts for the init body
+   * (`generate-init.ts`) — the four template builders below were the only
+   * callers still passing `null` for it.
+   */
+  restPropsName?: string | null
+  /**
    * Names that exist only in the init-body scope (or were demoted to unsafe
    * during chained-ref resolution). The CSR template runs at module scope
    * via `render()` / `renderChild()`, so any expression that reaches one
@@ -1878,13 +1893,14 @@ export function irToComponentTemplate(
   inlinableConstants?: Map<string, string>,
   restSpreadNames?: ReadonlySet<string>,
   propsObjectName?: string | null,
-  markupSlotIds?: ReadonlySet<string>
+  markupSlotIds?: ReadonlySet<string>,
+  restPropsName?: string | null
 ): string {
-  return irToComponentTemplateWithOpts(node, { inlinableConstants, restSpreadNames, propsObjectName, loopDepth: -1, markupSlotIds })
+  return irToComponentTemplateWithOpts(node, { inlinableConstants, restSpreadNames, propsObjectName, loopDepth: -1, markupSlotIds, restPropsName })
 }
 
 function irToComponentTemplateWithOpts(node: IRNode, opts: TemplateOptions): string {
-  const { inlinableConstants, restSpreadNames, propsObjectName, loopDepth = 0 } = opts
+  const { inlinableConstants, restSpreadNames, propsObjectName, restPropsName, loopDepth = 0 } = opts
   // `recurse` preserves `inHoistedChildren` for structural pass-through
   // (fragment / conditional); `childrenRecurse` clears it so element
   // descendants don't re-emit the placeholder. (#1320)
@@ -1917,9 +1933,18 @@ function irToComponentTemplateWithOpts(node: IRNode, opts: TemplateOptions): str
     // function's own constant-inlining step just above when the inlined
     // value is itself `props` (a local alias of the whole props object) —
     // silently kept the pre-rewrite name instead of `_p`.
+    //
+    // The gate stays keyed on `propsObjectName` for the destructured-prop
+    // case (unconditionally rewriting here would also change static-path
+    // output for components with neither a props object nor a rest binding
+    // — a separate alignment, not this fix) but widens to fire when only
+    // a rest binding exists (`{ children, ...rest }` with no whole-props
+    // param), so `rest.header` resolves to `_p.header` here the same way
+    // it already does in the init body (`generate-init.ts`, #2723) instead
+    // of reaching the template as a bare, undeclared `rest` (#2806).
     const restored = restore(result)
-    return propsObjectName && propsObjectName !== PROPS_PARAM
-      ? rewritePropsObjectRef(restored, propsObjectName, null, { enclosingScope: opts.scope })
+    return (propsObjectName && propsObjectName !== PROPS_PARAM) || restPropsName
+      ? rewritePropsObjectRef(restored, propsObjectName ?? null, restPropsName ?? null, { enclosingScope: opts.scope })
       : restored
   }
 
@@ -2315,7 +2340,7 @@ export function generateCsrTemplate(
   // by construction (`collectElements`'s `expression` visitor only pushes
   // here). Reused as-is, not re-derived.
   const markupSlotIds = new Set(ctx.dynamicElements.map(e => e.slotId))
-  return generateCsrTemplateWithOpts(node, { inlinableConstants, restSpreadNames, propsObjectName, csrEnv, unsafeLocalNames: effectiveUnsafeLocalNames, deferredChildSlots, loopDepth: -1, markupSlotIds })
+  return generateCsrTemplateWithOpts(node, { inlinableConstants, restSpreadNames, propsObjectName, csrEnv, unsafeLocalNames: effectiveUnsafeLocalNames, deferredChildSlots, loopDepth: -1, markupSlotIds, restPropsName: ctx.restPropsName })
 }
 
 /**
@@ -2510,7 +2535,7 @@ export function computeDeferredChildSlots(
 }
 
 function generateCsrTemplateWithOpts(node: IRNode, opts: TemplateOptions): string {
-  const { restSpreadNames, propsObjectName, csrEnv, unsafeLocalNames, loopDepth = 0 } = opts
+  const { restSpreadNames, propsObjectName, restPropsName, csrEnv, unsafeLocalNames, loopDepth = 0 } = opts
   const env: CsrEnv = csrEnv ?? { substitutions: new Map(), propsObjectName: propsObjectName ?? null }
   const transformExpr = (expr: string, templateExpr?: string): string => {
     // Single AST substitution pass: replaces signal getter calls
@@ -2539,11 +2564,16 @@ function generateCsrTemplateWithOpts(node: IRNode, opts: TemplateOptions): strin
     if (unsafeLocalNames && unsafeLocalNames.size > 0 && setIntersects(freeIdentifiers, unsafeLocalNames)) {
       return UNSAFE_TEMPLATE_EXPR
     }
-    // Final emit-form: rewrite `propsName.X → _p.X`. Deferred until
-    // after the unsafe-name check because the check used raw form
+    // Final emit-form: rewrite `propsName.X → _p.X` (and a direct
+    // rest-bag read, `restName.X → _p.X` — the rest binding IS `_p` at
+    // runtime, same as the init body's `rewritePropsObjectRef` call and
+    // `applyRestAttrs`'s exclude-key filtering both already assume; a
+    // computed "props minus consumed keys" object here would be a second,
+    // divergent implementation of that same decision, #2806). Deferred
+    // until after the unsafe-name check because the check used raw form
     // (consistent with `populateCsrInlinable`'s `isInlinableInTemplate`
     // gate — #1138).
-    return rewritePropsObjectRef(rewritten, propsObjectName ?? null, null, { enclosingScope: opts.scope })
+    return rewritePropsObjectRef(rewritten, propsObjectName ?? null, restPropsName ?? null, { enclosingScope: opts.scope })
   }
 
   // `recurse` preserves `inHoistedChildren` for structural pass-through
@@ -2864,7 +2894,7 @@ function generateCsrTemplateWithOpts(node: IRNode, opts: TemplateOptions): strin
         // its own props context via recurseInLoopBody.
         const body = renderPreamble(node.flatMapCallback, {
           textVariant: 'template',
-          transformJs: (t) => rewritePropsObjectRef(t, propsObjectName ?? null, null, { enclosingScope: childScope }),
+          transformJs: (t) => rewritePropsObjectRef(t, propsObjectName ?? null, restPropsName ?? null, { enclosingScope: childScope }),
           // Leaf `key` stripped — see the irToHtmlTemplate site above.
           renderLeaf: (ir) => recurseInLoopBody(stripLeafKeyAttr(ir)),
         })
@@ -2872,7 +2902,7 @@ function generateCsrTemplateWithOpts(node: IRNode, opts: TemplateOptions): strin
       } else if (node.preamble) {
         // Stage 3 / D4 — template-variant js text with the props rewrite
         // applied per segment; JSX leaves render via the loop-body recursion.
-        const preamble = renderPreamble(node.preamble, { textVariant: 'template', transformJs: (t) => rewritePropsObjectRef(t, propsObjectName ?? null, null, { enclosingScope: childScope }), renderLeaf: (ir) => recurseInLoopBody(ir) })
+        const preamble = renderPreamble(node.preamble, { textVariant: 'template', transformJs: (t) => rewritePropsObjectRef(t, propsObjectName ?? null, restPropsName ?? null, { enclosingScope: childScope }), renderLeaf: (ir) => recurseInLoopBody(ir) })
         mapExpr = `\${${iterArrayExpr}.${iterMethod}(${callbackParam} => { ${preamble} return \`${childTemplate}\` }).join('')}`
       } else {
         mapExpr = `\${${iterArrayExpr}.${iterMethod}(${callbackParam} => \`${childTemplate}\`).join('')}`

--- a/packages/jsx/src/ir-to-client-js/index.ts
+++ b/packages/jsx/src/ir-to-client-js/index.ts
@@ -275,7 +275,7 @@ function generateTemplateOnlyMount(ir: ComponentIR, ctx: ClientJsContext): strin
     // matches `emitRegistrationAndHydration`'s derivation byte-for-byte
     // rather than special-casing "no markup slots here" (#2651).
     const markupSlotIds = new Set(ctx.dynamicElements.map(e => e.slotId))
-    templateHtml = irToComponentTemplate(ir.root, inlinableConstants, restSpreadNames, ctx.propsObjectName, markupSlotIds)
+    templateHtml = irToComponentTemplate(ir.root, inlinableConstants, restSpreadNames, ctx.propsObjectName, markupSlotIds, ctx.restPropsName)
   }
 
   // CSR fallback: when static template generation fails (e.g., components with


### PR DESCRIPTION
## Summary

Closes #2806. Stacked on #2811 (#2737) — same class of gap, same fix mechanism, next PR in the sequence.

A component reading its own rest-bag spread directly in JSX (`{rest.header}`, not spread onto an element's attrs via `{...rest}`) emitted a CSR template referencing the bare, unbound `rest` identifier — a guaranteed `ReferenceError` the moment that code path runs on a real page. The client-JS scope gate (`client-js-scope.test.ts`) caught this mechanically (TS diagnostic 2304).

- **Root cause**: the rest binding is `_p` at runtime — the init body already rewrites `rest.x` → `_p.x` via `rewritePropsObjectRef` (#2723), and `applyRestAttrs` excludes the consumed keys by name from that same object rather than constructing a narrower one. But the four CSR/static template builders in `html-template.ts` — the exact same sites #2737 just migrated onto `rewritePropsObjectRef` for `propsObjectName` — were still passing `null` for the rest name.
- **Fix**: thread `ctx.restPropsName` through as a new `TemplateOptions.restPropsName` field to all four sites. The static-template gate widens from "has a props object" to "has a props object OR a rest binding" — kept minimal (not made unconditional) so it doesn't change output for components with neither.
- **Not `BindingScope`**: this isn't a shadow-guard question (no "is this name bound here" check needed) — the shadow-guard case (a `.map()` row parameter literally named `rest`) already works via the `enclosingScope` option #2737 added to the same function. This fix is purely "thread an argument the function already accepts."
- **Fixture**: `jsx-element-prop-rest-bag-dynamic` (added in #2804) is the graduation fixture per the issue — no new fixture needed (not a subset extension; `coverage-map.json` already covers this shape). SSR is unaffected; regenerating `expectedHtml` produced zero diff.

Investigation and design for this fix were done by a separate Fable-model agent per this stack's process, verifying the root cause against the actual current codebase (compiled the issue's repro, confirmed the TS2304 diagnostic, traced both the working init-body path and the broken template path to their exact line numbers) before any code was written.

## Test plan

- [x] New compiler unit test: `packages/jsx/src/__tests__/issue-2806-rest-bag-template-rewrite.test.ts` (direct rest-bag text read, rest-bag read inside a `.map()` row, and the shadow-guard case where a loop parameter is literally named `rest`).
- [x] `client-js-scope.test.ts`: 358 pass, 0 fail (pin removed, gate no longer flags `rest` as undeclared).
- [x] `csr-conformance.test.ts`: green (one `toggle-shared` timeout under parallel load, reproduced as a pass in isolation — unrelated pre-existing flake, not caused by this change).
- [x] Full `packages/jsx/src/__tests__` suite: 3175 pass, 0 fail.
- [x] Full `packages/adapter-tests/src/__tests__` suite: 2303 pass, 0 fail.
- [x] `generate-expected-html.ts` regenerated — zero diff (SSR unaffected).
- [x] Changeset added (`@barefootjs/jsx` patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198yG2px5ygfvmdoMkhRS13

---
_Generated by [Claude Code](https://claude.ai/code/session_0198yG2px5ygfvmdoMkhRS13)_