### PR TITLE
Fix #2700: loud BF101 refusal for an unbakeable object-literal signal the SSR template reads

### DIFF
--- a/.changeset/go-signal-object-literal-loud-refusal-2700.md
+++ b/.changeset/go-signal-object-literal-loud-refusal-2700.md
@@ -1,0 +1,11 @@
+---
+"@barefootjs/go-template": patch
+---
+
+Fix #2700: a `derived`-classified signal seeded from an object literal that references a live prop/signal (`createSignal({ ...base, done: true })`) silently kept the field's Go zero value in the SSR template whenever the constructor-time baker (`convertInitialValue`) couldn't reproduce it — that baker is static-only (identifier/member/call operands defer, `parsed-literal-to-go.ts`'s own docstring), so `merged().id` / `merged().done` reads on real Go always saw the zero value with no diagnostic at all.
+
+The adapter now refuses this shape loudly with `BF101` instead: `rootFieldRef` (the single door every SSR template read of a root-scope field passes through) records which fields the template actually reads, and `generateNewPropsFunction`'s signal loop consults that record — after `generate()` has rendered the template — to fire only when the deferred bake is ACTUALLY read (a signal that only feeds a JSX spread bag, which bakes through its own `.Spread_<slot>` route, is unaffected) and only for a `derived` step with a non-empty free set (a fully-static object literal is a separate, untracked silent-divergence shape left for its own issue, not silently widened into this fix). A verified-working `/* @client */` escape twin (`signal-object-spread-init-client`) exists, so the refusal is `/* @client */`-escapable per policy.
+
+No memo-side counterpart: the analyzer deliberately never attaches a structured `parsed` tree to an object-returning memo body, so there's no structural handle to reach this check for a memo without re-parsing source text, which the repo's own conventions rule out — #2700's own reproduction and fixture are signal-only.
+
+Reclassifies #2700 from `bug` to `enhancement` (the divergence is now a loud, escapable refusal rather than a silent wrong render) and graduates the `signal-object-spread-init` render-divergence pin.

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -1633,6 +1633,32 @@ export function Widget({ base }: { base: Item }) {
       expect(bf101[0].message).not.toContain("Signal 'merged' is seeded")
     })
 
+    // A signal read ONLY from inside a `.filter()` predicate (never a plain
+    // `{merged()}` text read) must still register in `templateReadRootFields`
+    // and trip #2700's refusal — `renderFilterExprNode`'s zero-arg-call arm
+    // used to build the `$.Merged` field reference by hand instead of
+    // through `rootFieldRef`, so this exact shape was a false negative
+    // (pullfrog review, PR #2818).
+    test('a signal reachable only through a .filter() predicate still refuses with BF101 (#2700, #2818 pullfrog review)', () => {
+      const adapter = new GoTemplateAdapter()
+      compileAndGenerate(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+type Item = { id: string; done: boolean }
+export function Widget({ base, items }: { base: Item; items: Item[] }) {
+  const [merged] = createSignal({ ...base, done: true })
+  return (
+    <ul>
+      {items().filter(i => i.id === merged().id).map(i => <li key={i.id}>{i.id}</li>)}
+    </ul>
+  )
+}
+`, adapter)
+      const bf101 = adapter.errors.filter(e => e.code === 'BF101')
+      expect(bf101.length).toBe(1)
+      expect(bf101[0].message).toContain("Signal 'merged'")
+    })
+
     // A destructured prop sharing the module const's name must still win
     // (shadowing) — the const resolver is checked AFTER the prop lookup.
     test('a destructured prop shadows a same-named module const', () => {

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -1531,6 +1531,108 @@ export function Demo() {
       expect(types).toContain('Open: true')
     })
 
+    // #2700: a `derived` signal (non-empty free set, e.g. `{ ...base, done }`)
+    // whose object literal the constructor-time baker can't reproduce
+    // (identifier/member/call operands defer) used to silently keep the Go
+    // zero value for every field the SSR template reads. Loud-ified instead
+    // of taught a live-expression lowering — Go has none — since the
+    // template's `.Merged.ID` / `.Merged.Done` reads would otherwise see a
+    // wrong value with no diagnostic at all.
+    test('signal object-literal spreading a live prop refuses with BF101 when the template reads it (#2700)', () => {
+      const adapter = new GoTemplateAdapter()
+      const result = compileAndGenerate(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+type Item = { id: string; done: boolean }
+export function Widget({ base }: { base: Item }) {
+  const [merged] = createSignal({ ...base, done: true })
+  return (
+    <div>
+      <span>{merged().id}</span>
+      <span>{merged().done ? 'yes' : 'no'}</span>
+    </div>
+  )
+}
+`, adapter)
+      const bf101 = adapter.errors.filter(e => e.code === 'BF101')
+      expect(bf101.length).toBe(1)
+      expect(bf101[0].message).toContain("Signal 'merged'")
+      expect(bf101[0].message).toContain('base')
+      expect(bf101[0].suggestion?.escape).toEqual([{ kind: 'client-directive' }])
+      expect(result.template).toBeTruthy()
+    })
+
+    // Same refusal for an EXPLICITLY typed object signal (`createSignal<Item>`)
+    // — the typed `interface` branch (`value-lowering.ts`) also defers to a
+    // struct zero value (`Item{}`) for the identical reason.
+    test('typed object signal spreading a live prop also refuses with BF101 (#2700)', () => {
+      const adapter = new GoTemplateAdapter()
+      compileAndGenerate(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+type Item = { id: string; done: boolean }
+export function Widget({ base }: { base: Item }) {
+  const [merged] = createSignal<Item>({ id: base.id, done: true })
+  return <span>{merged().id}</span>
+}
+`, adapter)
+      expect(adapter.errors.some(e => e.code === 'BF101')).toBe(true)
+    })
+
+    // No memo-side counterpart: the analyzer deliberately never sets
+    // `MemoInfo.parsed` to an `object-literal` for an object-returning memo
+    // body (`analyzer.ts`, "isn't lowered from the parsed tree yet") — a
+    // pre-existing, unrelated exclusion — so this refusal has no structural
+    // handle to reach a memo without re-parsing `computation` as text,
+    // which the repo's own convention rules out. #2700's own reproduction
+    // and fixture are signal-only.
+
+    // The `/* @client */` escape: wrapping every SSR read defers evaluation
+    // to the client, so the template never reaches `rootFieldRef` for this
+    // signal — no refusal, even though the constructor still bakes `nil`.
+    test('/* @client */ on every read suppresses the #2700 refusal', () => {
+      const adapter = new GoTemplateAdapter()
+      const result = compileAndGenerate(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+type Item = { id: string; done: boolean }
+export function Widget({ base }: { base: Item }) {
+  const [merged] = createSignal({ ...base, done: true })
+  return (
+    <div>
+      <span>{/* @client */ merged().id}</span>
+      <span>{/* @client */ merged().done ? 'yes' : 'no'}</span>
+    </div>
+  )
+}
+`, adapter)
+      expect(adapter.errors.filter(e => e.code === 'BF101')).toEqual([])
+      expect(result.types).toContain('Merged: nil,')
+    })
+
+    // A signal that ONLY feeds a JSX spread (`{...merged()}`) never reaches
+    // `rootFieldRef` — spread bags bake through their own `.Spread_<slot>`
+    // route (`emitSpreadBagInits`) — so it must not trip the #2700 check even
+    // though the constructor still can't bake the literal. (This shape DOES
+    // still refuse, but with the PRE-EXISTING, unrelated "JSX spread has no
+    // Go template lowering" BF101 for `{...merged()}` on an intrinsic
+    // element — not a second, redundant #2700-shaped one.)
+    test('a signal only spread into attrs does not double-refuse under #2700', () => {
+      const adapter = new GoTemplateAdapter()
+      compileAndGenerate(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+type Item = { id: string; done: boolean }
+export function Widget({ base }: { base: Item }) {
+  const [merged] = createSignal({ ...base, done: true })
+  return <div {...merged()} />
+}
+`, adapter)
+      const bf101 = adapter.errors.filter(e => e.code === 'BF101')
+      expect(bf101.length).toBe(1)
+      expect(bf101[0].message).not.toContain("Signal 'merged' is seeded")
+    })
+
     // A destructured prop sharing the module const's name must still win
     // (shadowing) — the const resolver is checked AFTER the prop lookup.
     test('a destructured prop shadows a same-named module const', () => {

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -536,7 +536,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     for (const d of this.state.pendingChildrenDefines) {
       template += `{{define "${d.name}"}}${d.content}{{end}}\n`
     }
-    const types = this.generateTypes(ir)
+    const types = this.generateTypes(ir, true)
 
     if (this.state.errors.length > 0) {
       ir.errors.push(...this.state.errors)
@@ -1074,9 +1074,25 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     return desired
   }
 
-  generateTypes(ir: ComponentIR): string | null {
+  /**
+   * `preserveTemplateReadRootFields` is set ONLY by `generate()`'s own
+   * internal call below — `templateReadRootFields` is an observation log
+   * `renderNode` populated moments ago while rendering THIS SAME
+   * component's template body, and this call needs to read that log back,
+   * not a freshly emptied one. Every other caller (the standalone public
+   * entry point `test-render.ts` calls directly on an already-`generate()`d
+   * adapter for a sibling/child IR, and this file's own unit tests) omits
+   * it and gets the set reset fresh — otherwise a stale log left over from
+   * whichever OTHER component `generate()` rendered last would silently
+   * narrow #2700's BF101 refusal to a false negative (pullfrog review, PR
+   * #2818).
+   */
+  generateTypes(ir: ComponentIR, preserveTemplateReadRootFields = false): string | null {
     this.state.usesHtmlTemplate = false
     this.state.usesFmt = false
+    if (!preserveTemplateReadRootFields) {
+      this.state.templateReadRootFields = new Set()
+    }
     // Prime identically to `generate()` so the standalone `generateTypes` entry
     // can't drift the structs (e.g. a `{...props}` bag field in one entry only).
     this.primeCompileState(ir)
@@ -6020,8 +6036,17 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         // A local variable mapped to a signal.
         const signal = localVarMap.get(expr.name)
         if (signal) {
+          // Root-scope read (#2700's BF101 gate needs it in
+          // `templateReadRootFields`) — `$.` is hardcoded rather than
+          // routed through `rootFieldRef`'s `this.inLoop`-conditional
+          // prefix because a filter predicate must always escape back to
+          // root regardless of loop nesting; call it only for its
+          // registration side effect and keep the prefix here (pullfrog
+          // review, PR #2818).
+          this.rootFieldRef(signal)
           return `$.${capitalizeFieldName(signal)}`
         }
+        this.rootFieldRef(expr.name)
         return `.${capitalizeFieldName(expr.name)}`
       }
 
@@ -6066,8 +6091,11 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         if (expr.callee.kind === 'member' && expr.callee.object.kind === 'identifier' && expr.callee.object.name === param) {
           return `${paramPrefix}.${capitalizeFieldName(expr.callee.property)}`
         }
-        // Signal calls: `filter()` -> `$.Filter`
+        // Signal calls: `filter()` -> `$.Filter`. Same registration-only
+        // `rootFieldRef` call as the `identifier` case above, for the same
+        // reason (#2700's BF101 gate; pullfrog review, PR #2818).
         if (expr.callee.kind === 'identifier' && expr.args.length === 0) {
+          this.rootFieldRef(expr.callee.name)
           return `$.${capitalizeFieldName(expr.callee.name)}`
         }
         // A nested callback method call (`other.some(r => …)`) reaching this

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -490,6 +490,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     this.state.componentName = ir.metadata.componentName
     this.state.errors = []
     this.state.referencedDerivedConsts = new Set()
+    this.state.templateReadRootFields = new Set()
     this.state.templateVarCounter = 0
     this.state.pendingChildrenDefines = []
     this.scope = BindingScope.EMPTY
@@ -2095,8 +2096,13 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         // Bake against the synthesised struct type if one was inferred for this
         // untyped object-array signal, else the signal's own type.
         const bakeType = this.state.synthStructTypes.get(signal.getter) ?? signal.type
+        const resolvedParsed = this.resolvedSignalParsed(signal)
         const initialValue = convertInitialValue(this.emitCtx, signal.initialValue, bakeType, ir.metadata.propsParams, signal.parsed)
         lines.push(`\t\t${fieldName}: ${initialValue},`)
+        if (resolvedParsed?.kind === 'object-literal' && jsLiteralToGo(this.emitCtx, bakeType, resolvedParsed) === null) {
+          const step = this.state.ssrSeedPlan.steps.find(s => s.kind === 'derived' && s.origin === 'signal' && s.name === signal.getter)
+          if (step?.kind === 'derived') this.refuseUnbakeableDerivedObjectLiteral(signal.getter, signal.loc, step.frees)
+        }
       }
     }
 
@@ -2128,6 +2134,17 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       const goType = this.inferMemoType(memo, ir.metadata.signals, memoPropsParamMap)
       const memoValue = computeMemoInitialValue(this.emitCtx, memo, ir.metadata.signals, ir.metadata.propsParams, propFallbackVars, goType)
       lines.push(`\t\t${fieldName}: ${memoValue},`)
+      // No #2700 refusal check here (unlike the signal loop above): the
+      // analyzer deliberately never sets `MemoInfo.parsed` to an
+      // `object-literal` for an object-returning memo body (`() => ({…})`,
+      // `analyzer.ts`'s own docstring — "isn't lowered from the parsed tree
+      // yet") — a pre-existing, unrelated exclusion this fix doesn't touch.
+      // Detecting the shape without `parsed` would mean re-parsing
+      // `memo.computation` as text, which the repo's own convention (see
+      // CLAUDE.md, "Never parse imports... with regex or string matching")
+      // rules out. #2700's own reproduction and fixture are signal-only;
+      // a memo-side refusal is left for whoever lands the "Roadmap A" memo
+      // object-literal `parsed` support this comment references.
     }
 
     // Computed derived-const fields (`Root: func() string { … }()`), matching
@@ -4009,6 +4026,55 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   }
 
   /**
+   * #2700: a `derived`-classified signal (`SsrSeedPlan`'s classification —
+   * an object literal whose free identifiers ALL resolve in scope, e.g.
+   * `createSignal({ ...base, done: true })`) whose value the
+   * constructor-time baker (`convertInitialValue`) can't reproduce silently
+   * keeps the field's Go zero value — that baker is static-only
+   * (identifier/member/call operands defer, `parsed-literal-to-go.ts`'s own
+   * docstring). Signal-only: the analyzer deliberately never sets
+   * `MemoInfo.parsed` to an `object-literal` for an object-returning memo
+   * body (`analyzer.ts`'s own docstring — "isn't lowered from the parsed
+   * tree yet"), so there is no structural way to reach this check for a
+   * memo without re-parsing `computation` as text, which the repo's own
+   * convention rules out.
+   *
+   * Deferring silently is harmless UNLESS the SSR template actually reads
+   * the field: a signal that only feeds a spread-attrs bag never reaches
+   * here as a false positive because spread bags bake through their own
+   * `.Spread_<slot>` route (`emitSpreadBagInits`), never `rootFieldRef` —
+   * so `templateReadRootFields` (populated while `generate()` rendered the
+   * template, which always precedes `generateTypes`'s call into this
+   * method) is the exact structural proxy for "the zero value would
+   * actually surface," not merely "the bake failed."
+   *
+   * Scoped to a NON-EMPTY free set on purpose, not every deferred bake: a
+   * fully-static object literal (`createSignal({ id: 'row-1' })`) hits the
+   * same `nil` fallback today but is a separate, untracked silent-divergence
+   * shape with no fixture of its own — loud-ifying it here would silently
+   * widen this fix beyond #2700's actual reproduction (a literal that
+   * references a live prop/signal), so it's left for its own issue instead.
+   */
+  private refuseUnbakeableDerivedObjectLiteral(
+    name: string,
+    loc: SourceLocation,
+    frees: readonly string[],
+  ): void {
+    if (frees.length === 0) return
+    if (!this.state.templateReadRootFields.has(name)) return
+    this.state.errors.push({
+      code: 'BF101',
+      severity: 'error',
+      message: `Signal '${name}' is seeded from an object literal that references live value(s) (${frees.join(', ')}) — the Go template adapter bakes object-typed signal values into Go source at New${this.state.componentName}Props time, and that baker is static-only (identifier/member/call operands defer), so the SSR template's read of it would see the Go zero value instead of the derived object.`,
+      loc,
+      suggestion: {
+        message: `Wrap each SSR read of '${name}()' in /* @client */ so it renders on the client instead, or pass the already-derived object in as a prop.`,
+        escape: [{ kind: 'client-directive' }],
+      },
+    })
+  }
+
+  /**
    * Parse a signal-time initial value of the form `props.X ?? <literal>` —
    * or, for destructured components, `x ?? <literal>` — into the source prop
    * name and the Go-formatted fallback. Returns null when the expression
@@ -4666,6 +4732,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    * rebinds. Outside any loop the root *is* the dot, so we emit `.Field`.
    */
   private rootFieldRef(name: string): string {
+    this.state.templateReadRootFields.add(name)
     const prefix = this.inLoop ? '$.' : '.'
     return `${prefix}${capitalizeFieldName(name)}`
   }

--- a/packages/adapter-go-template/src/adapter/lib/compile-state.ts
+++ b/packages/adapter-go-template/src/adapter/lib/compile-state.ts
@@ -38,6 +38,24 @@ export class CompileState {
    *  that's resolvable and non-colliding. */
   referencedDerivedConsts: Set<string> = new Set()
 
+  /**
+   * Root-scope field names (signal getters, memo names, props, derived
+   * consts) the SSR template actually READ while rendering — recorded by
+   * `rootFieldRef`, the single door every such read passes through
+   * (`identifier`/`call`/`member`'s zero-arg-getter and bare-name lowering,
+   * plus the typed-expression emitter). `generateTypes` (#2700) consults
+   * this AFTER `generate()` has rendered the template to decide whether a
+   * signal whose object-literal initializer the constructor-time baker
+   * can't reproduce (`convertInitialValue` returning null) needs a loud
+   * BF101 refusal: a deferred bake that is NEVER read by the template (e.g.
+   * only feeds a spread-attrs bag, which routes through its own
+   * `.Spread_<slot>` field, never this set) silently keeping its Go zero
+   * value is harmless, so refusing it would be a false positive — see
+   * `refuseUnbakeableDerivedObjectLiteral`'s docstring for why the check is
+   * call-site-aware instead of firing at the bake site itself.
+   */
+  templateReadRootFields: Set<string> = new Set()
+
   templateVarCounter: number = 0
 
   /**

--- a/packages/adapter-go-template/src/conformance-pins.ts
+++ b/packages/adapter-go-template/src/conformance-pins.ts
@@ -76,4 +76,16 @@ export const conformancePins: ConformancePins = {
     issue: 'https://github.com/piconic-ai/barefootjs/issues/2805',
     unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2805' },
   }],
+  // #2700: a `derived` signal/memo (non-empty free set) seeded from an
+  // object literal the constructor-time baker can't reproduce (identifier/
+  // member/call operands defer, `parsed-literal-to-go.ts`) now refuses
+  // loudly instead of silently keeping the Go zero value — this fixture's
+  // `merged().id` / `merged().done` reads are exactly that shape. A working
+  // `/* @client */` escape twin exists (`signal-object-spread-init-client`),
+  // verified to render correctly, so no `unescapable`.
+  'signal-object-spread-init': [{
+    code: 'BF101',
+    severity: 'error',
+    issue: 'https://github.com/piconic-ai/barefootjs/issues/2700',
+  }],
 }

--- a/packages/adapter-go-template/src/render-divergences.ts
+++ b/packages/adapter-go-template/src/render-divergences.ts
@@ -23,6 +23,16 @@
  * Go, so it moved off this table. Dynamic delivery for named jsx-children
  * props (the actual capability gap) is tracked separately at
  * https://github.com/piconic-ai/barefootjs/issues/2703.)
+ *
+ * (#2700's `signal-object-spread-init` divergence graduated the same way —
+ * by reclassification, not a lowering fix: a `derived` signal/memo's
+ * object-literal initializer referencing a live prop/signal has no
+ * live-template-expression lowering on Go, only a static constructor-time
+ * baker — now a loud `BF101` refusal (`conformance-pins.ts`) with a
+ * verified `/* @client *\/` escape twin (`signal-object-spread-init-client`),
+ * instead of a silent wrong render. Teaching the baker to emit
+ * prop-referencing Go expressions — the actual capability gap — stays
+ * tracked at https://github.com/piconic-ai/barefootjs/issues/2700.)
  */
 
 import type { RenderDivergences } from '@barefootjs/jsx'
@@ -30,8 +40,6 @@ import type { RenderDivergences } from '@barefootjs/jsx'
 export const renderDivergences: RenderDivergences = {
   'children-passthrough-renamed':
     'A `children` prop destructured under a different name (`const { children: kids } = props`) does not reach the SSR template on Go, tracked as https://github.com/piconic-ai/barefootjs/issues/2788. The same fixture also fails on Mojolicious, where the mechanism IS isolated: the `.html.ep` interpolates the LOCAL alias (`$kids`) while the stash defines only the caller-facing `children`, so the Perl render dies inside `Mojo::Template::process`. Go\'s own failure mode has NOT been read — `go` is not reachable from the local test process (the conformance case prints "go command not found" and skips), so this entry is declared from the CI failure on #2787 alone, not from a local reproduction. Whoever graduates this should read Go\'s actual output first rather than assume it shares Mojo\'s mechanism. Same alias family as `aliased-destructured-prop` (`{ n: count }`), whose Go half graduated in #2525 — worth checking whether the reserved `children` slot bypasses that fix or never had it. `children-passthrough-renamed` asserts the CORRECT (Hono-generated) output, so deleting this entry is the graduation.',
-  'signal-object-spread-init':
-    'PRE-EXISTING, unrelated to the #2696 Step 2 spread work this fixture pins: a `derived`-classified signal/memo whose value is an OBJECT literal has no live-template-expression lowering on Go — unlike the other six template-stash backends (e.g. minijinja emits `{% set merged = dict(base, done=true) %}`), Go always bakes an object-typed signal/memo field into Go SOURCE at `NewXxxProps` constructor time (`convertInitialValue`/`parsedLiteralToGo`), and that baker is STATIC-only (identifier/call/member operands defer, `parsed-literal-to-go.ts`\'s own docstring) — it cannot reference a live prop at all. Reproduced identically with the spread REMOVED (`createSignal({ id: base.id, done: true })`), confirming the gap predates and is independent of spread: the signal seeds `nil` and every field read (`.Merged.ID`/`.Merged.Done`) reads the Go zero value regardless of `initialTodos`. Graduate by teaching the baker to emit prop-referencing Go expressions (https://github.com/piconic-ai/barefootjs/issues/2700).',
   'aliased-loop-source':
     'A `.map()` loop whose source is a local const alias of a signal getter (`const items__alias = items`) fails template execution on real Go (`can\'t evaluate field Items__alias in type main.AliasedLoopSourceProps`) — the zero-arg-call-to-field lowering routes `items__alias()` to a `.Items__alias` struct field that was never seeded, since seeding only knows about `items`, the real signal name; the alias hop is never resolved. This is the SSR-side twin of #2778 (fixed for the CSR client-JS template in the same PR that added this fixture) — that fix only touches client-JS emission, not Go\'s field-routing/seeding. Tracked at https://github.com/piconic-ai/barefootjs/issues/2813; graduate by resolving the alias hop at field-routing time using the same `resolveAliasOrigin`/`resolveGetterAliases` mechanism #2778 introduced, rather than a third alias-hop walker.',
 }

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -4706,6 +4706,23 @@
         "text"
       ]
     },
+    "signal-object-spread-init-client": {
+      "kinds": [
+        "call",
+        "identifier",
+        "literal",
+        "member",
+        "object-literal"
+      ],
+      "axes": [
+        "literal:boolean",
+        "literal:string"
+      ],
+      "contexts": [
+        "condition",
+        "text"
+      ]
+    },
     "signal-prop-same-name": {
       "kinds": [
         "call",
@@ -5805,14 +5822,14 @@
     "array-method": 71,
     "arrow": 71,
     "binary": 94,
-    "call": 239,
+    "call": 240,
     "conditional": 27,
-    "identifier": 340,
+    "identifier": 341,
     "index-access": 14,
-    "literal": 271,
+    "literal": 272,
     "logical": 47,
-    "member": 195,
-    "object-literal": 66,
+    "member": 196,
+    "object-literal": 67,
     "template-literal": 30,
     "unary": 24,
     "unsupported": 42
@@ -5852,10 +5869,10 @@
     "binary:===": 49,
     "binary:>": 11,
     "binary:>=": 1,
-    "literal:boolean": 58,
+    "literal:boolean": 59,
     "literal:null": 23,
     "literal:number": 115,
-    "literal:string": 189,
+    "literal:string": 190,
     "logical:&&": 7,
     "logical:??": 41,
     "logical:||": 14,

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -497,6 +497,7 @@ import { fixture as mapObjectLiteralBody } from './map-object-literal-body'
 // directly, in value position (not nested in a `.map()` body) — see the
 // fixture file header.
 import { fixture as signalObjectSpreadInit } from './signal-object-spread-init'
+import { fixture as signalObjectSpreadInitClient } from './signal-object-spread-init-client'
 import { fixture as loopParamShadowsRecordTemplateSpan } from './loop-param-shadows-record-template-span'
 // #2482 audit follow-ups, adapter-side (pinned known limitations):
 // Go condition-position destructured bindings, Go nested-loop `inLoop`
@@ -918,6 +919,7 @@ export const jsxFixtures: JSXFixture[] = [
   callbackParamShadowsProp,
   mapObjectLiteralBody,
   signalObjectSpreadInit,
+  signalObjectSpreadInitClient,
   loopParamShadowsRecordTemplateSpan,
   loopDestructuredParamCondition,
   nestedLoopTailContent,

--- a/packages/adapter-tests/fixtures/signal-object-spread-init-client.ts
+++ b/packages/adapter-tests/fixtures/signal-object-spread-init-client.ts
@@ -1,0 +1,38 @@
+import { createFixture } from '../src/types'
+
+/**
+ * `/* @client *​/` twin of `signal-object-spread-init` (#2700). Wrapping both
+ * SSR reads of the derived signal defers them to client-only evaluation, so
+ * the Go template adapter never needs to bake the object literal into Go
+ * source at all — verified to compile clean and render correctly on real Go
+ * (no `.Merged` field read anywhere in the emitted template), unlike the
+ * un-escaped fixture this twins, which the adapter now refuses loudly with
+ * BF101 (`conformance-pins.ts`) instead of silently seeding a Go zero value.
+ */
+export const fixture = createFixture({
+  id: 'signal-object-spread-init-client',
+  description: 'Signal initializer spreads a prop-derived object, reads deferred to the client via /* @client */',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+
+type Item = { id: string; done: boolean }
+
+export function SignalObjectSpreadInitClient({ base }: { base: Item }) {
+  const [merged] = createSignal({ ...base, done: true })
+  return (
+    <div>
+      <span>{/* @client */ merged().id}</span>
+      <span>{/* @client */ merged().done ? 'yes' : 'no'}</span>
+    </div>
+  )
+}
+`,
+  props: { base: { id: 'row-1', done: false } },
+  expectedHtml: `
+    <div bf-s="test">
+      <span bf="s1"></span>
+      <span bf="s3"><!--bf-cond-start:s2--><!--bf-cond-end:s2--></span>
+    </div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/signal-object-spread-init.ts
+++ b/packages/adapter-tests/fixtures/signal-object-spread-init.ts
@@ -13,6 +13,14 @@ import { createFixture } from '../src/types'
  * `dict(…, **…)` / `bf_merge` / …, #2696 Step 2), not just a static default.
  * Overriding a field the spread source ALSO sets (`done`) exercises JS
  * object-spread's override direction: the trailing prop wins.
+ *
+ * The Go template adapter has no such live-expression lowering (it bakes an
+ * object-typed signal/memo into Go SOURCE at constructor time, and that
+ * baker is static-only) — it now refuses this shape loudly with BF101
+ * (https://github.com/piconic-ai/barefootjs/issues/2700) instead of
+ * silently seeding a Go zero value, pinned in its own `conformance-pins.ts`.
+ * `signal-object-spread-init-client` is the verified-working `/* @client *\/`
+ * escape twin.
  */
 export const fixture = createFixture({
   id: 'signal-object-spread-init',
@@ -40,4 +48,5 @@ export function SignalObjectSpreadInit({ base }: { base: Item }) {
       <span bf="s3"><!--bf-cond-start:s2-->yes<!--bf-cond-end:s2--></span>
     </div>
   `,
+  escapes: [{ kind: 'client-directive', fixture: 'signal-object-spread-init-client' }],
 })

--- a/packages/compat/src/__tests__/compat-engine.test.ts
+++ b/packages/compat/src/__tests__/compat-engine.test.ts
@@ -47,16 +47,18 @@ describe('compileForCompat', () => {
     // this adapter (buildCompatCell attributes by code, not by fixture —
     // see its docstring) — #2320 (this shape, nested filter callback,
     // successor to #2038), #2321 (static-array-from-props computed loop
-    // source), and #2805 (a named jsx-children prop routed into a child's
-    // rest bag, `jsx-element-prop-rest-bag-dynamic`) surface here even
-    // though this test only exercises the nested-filter-callback shape.
-    // Three pins are no longer among them, each because the shape got a
-    // real lowering rather than a narrower refusal: #2319
-    // (dangerous-inner-html-dynamic → a faithful raw-output lowering), #2208
-    // (static-array-children → the loop-source gate bakes a fully-static
-    // array-of-objects const), and #2448 (loop-row child prop override feeding
-    // a derived field → the child rebuilds itself per row through
-    // `bf_reprops`). See `go-template`'s `conformance-pins.ts`.
+    // source), #2700 (a `derived` object-literal signal/memo the
+    // constructor-time baker can't reproduce, `signal-object-spread-init`),
+    // and #2805 (a named jsx-children prop routed into a child's rest bag,
+    // `jsx-element-prop-rest-bag-dynamic`) surface here even though this
+    // test only exercises the nested-filter-callback shape. Three pins are
+    // no longer among them, each because the shape got a real lowering
+    // rather than a narrower refusal: #2319 (dangerous-inner-html-dynamic →
+    // a faithful raw-output lowering), #2208 (static-array-children → the
+    // loop-source gate bakes a fully-static array-of-objects const), and
+    // #2448 (loop-row child prop override feeding a derived field → the
+    // child rebuilds itself per row through `bf_reprops`). See
+    // `go-template`'s `conformance-pins.ts`.
     expect(cell.diagnostics).toEqual([
       {
         code: 'BF101',
@@ -64,6 +66,7 @@ describe('compileForCompat', () => {
         issues: [
           'https://github.com/piconic-ai/barefootjs/issues/2320',
           'https://github.com/piconic-ai/barefootjs/issues/2321',
+          'https://github.com/piconic-ai/barefootjs/issues/2700',
           'https://github.com/piconic-ai/barefootjs/issues/2805',
         ],
       },

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-conformance section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. This answers, per fixture and per adapter, whether the construct WORKS — not just whether it compiles. A construct works either as written (✓) or with a documented `/* @client */` comment (✓†, a verified, supported escape — most refusals have one). Fixtures absent from the table below work on every adapter — most as written, some via that documented escape; the headline says how many of each. Listed fixtures need attention somewhere: a bare diagnostic code is still-open debt with no escape yet, a code led by ✗ owes no escape at all (by design), and ≠ means the fixture compiles clean but its rendered output diverges from the reference.",
-    "totalFixtures": 362,
+    "totalFixtures": 363,
     "fixtures": {
       "aliased-loop-source": {
         "blade": {
@@ -3214,8 +3214,17 @@
       },
       "signal-object-spread-init": {
         "go-template": {
-          "kind": "render",
-          "reason": "PRE-EXISTING, unrelated to the #2696 Step 2 spread work this fixture pins: a `derived`-classified signal/memo whose value is an OBJECT literal has no live-template-expression lowering on Go — unlike the other six template-stash backends (e.g. minijinja emits `{% set merged = dict(base, done=true) %}`), Go always bakes an object-typed signal/memo field into Go SOURCE at `NewXxxProps` constructor time (`convertInitialValue`/`parsedLiteralToGo`), and that baker is STATIC-only (identifier/call/member operands defer, `parsed-literal-to-go.ts`'s own docstring) — it cannot reference a live prop at all. Reproduced identically with the spread REMOVED (`createSignal({ id: base.id, done: true })`), confirming the gap predates and is independent of spread: the signal seeds `nil` and every field read (`.Merged.ID`/`.Merged.Done`) reads the Go zero value regardless of `initialTodos`. Graduate by teaching the baker to emit prop-referencing Go expressions (https://github.com/piconic-ai/barefootjs/issues/2700)."
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2700"
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "signal-object-spread-init-client"
+          }
         }
       },
       "some-typeof-predicate": {
@@ -3731,6 +3740,10 @@
       "reduce-typeof-body-client": {
         "description": "Off-subset `.reduce()` body deferred to the client via /* @client */",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/reduce-typeof-body-client.ts"
+      },
+      "signal-object-spread-init-client": {
+        "description": "Signal initializer spreads a prop-derived object, reads deferred to the client via /* @client */",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/signal-object-spread-init-client.ts"
       },
       "some-typeof-predicate-client": {
         "description": "Off-subset `.some()` predicate deferred to the client via /* @client */",

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -1678,7 +1678,9 @@
             },
             {
               "fixture": "signal-object-spread-init",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2700"
+              ]
             },
             {
               "fixture": "some-typeof-predicate",
@@ -2552,7 +2554,9 @@
             },
             {
               "fixture": "signal-object-spread-init",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2700"
+              ]
             },
             {
               "fixture": "some-typeof-predicate",
@@ -3332,7 +3336,9 @@
             },
             {
               "fixture": "signal-object-spread-init",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2700"
+              ]
             },
             {
               "fixture": "some-typeof-predicate",
@@ -4132,7 +4138,9 @@
             },
             {
               "fixture": "signal-object-spread-init",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2700"
+              ]
             },
             {
               "fixture": "some-typeof-predicate",
@@ -4736,7 +4744,9 @@
             },
             {
               "fixture": "signal-object-spread-init",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2700"
+              ]
             },
             {
               "fixture": "static-array-from-props",
@@ -7954,7 +7964,9 @@
             },
             {
               "fixture": "signal-object-spread-init",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2700"
+              ]
             }
           ]
         },
@@ -8491,7 +8503,9 @@
             },
             {
               "fixture": "signal-object-spread-init",
-              "issues": []
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2700"
+              ]
             },
             {
               "fixture": "some-typeof-predicate",

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -1450,11 +1450,11 @@
       }
     },
     "call": {
-      "total": 239,
+      "total": 240,
       "cells": {
         "hono": {
-          "pass": 238,
-          "total": 239,
+          "pass": 239,
+          "total": 240,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1465,8 +1465,8 @@
           ]
         },
         "blade": {
-          "pass": 223,
-          "total": 239,
+          "pass": 224,
+          "total": 240,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -1545,8 +1545,8 @@
           ]
         },
         "erb": {
-          "pass": 224,
-          "total": 239,
+          "pass": 225,
+          "total": 240,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -1619,8 +1619,8 @@
           ]
         },
         "go-template": {
-          "pass": 222,
-          "total": 239,
+          "pass": 223,
+          "total": 240,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -1705,8 +1705,8 @@
           ]
         },
         "jinja": {
-          "pass": 223,
-          "total": 239,
+          "pass": 224,
+          "total": 240,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -1785,8 +1785,8 @@
           ]
         },
         "minijinja": {
-          "pass": 223,
-          "total": 239,
+          "pass": 224,
+          "total": 240,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -1865,8 +1865,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 224,
-          "total": 239,
+          "pass": 225,
+          "total": 240,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -1939,8 +1939,8 @@
           ]
         },
         "twig": {
-          "pass": 223,
-          "total": 239,
+          "pass": 224,
+          "total": 240,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -2019,8 +2019,8 @@
           ]
         },
         "xslate": {
-          "pass": 223,
-          "total": 239,
+          "pass": 224,
+          "total": 240,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -2244,11 +2244,11 @@
       }
     },
     "identifier": {
-      "total": 340,
+      "total": 341,
       "cells": {
         "hono": {
-          "pass": 337,
-          "total": 340,
+          "pass": 338,
+          "total": 341,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2271,8 +2271,8 @@
           ]
         },
         "blade": {
-          "pass": 320,
-          "total": 340,
+          "pass": 321,
+          "total": 341,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -2371,8 +2371,8 @@
           ]
         },
         "erb": {
-          "pass": 321,
-          "total": 340,
+          "pass": 322,
+          "total": 341,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -2465,8 +2465,8 @@
           ]
         },
         "go-template": {
-          "pass": 317,
-          "total": 340,
+          "pass": 318,
+          "total": 341,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -2581,8 +2581,8 @@
           ]
         },
         "jinja": {
-          "pass": 320,
-          "total": 340,
+          "pass": 321,
+          "total": 341,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -2681,8 +2681,8 @@
           ]
         },
         "minijinja": {
-          "pass": 320,
-          "total": 340,
+          "pass": 321,
+          "total": 341,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -2781,8 +2781,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 320,
-          "total": 340,
+          "pass": 321,
+          "total": 341,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -2879,8 +2879,8 @@
           ]
         },
         "twig": {
-          "pass": 320,
-          "total": 340,
+          "pass": 321,
+          "total": 341,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -2979,8 +2979,8 @@
           ]
         },
         "xslate": {
-          "pass": 320,
-          "total": 340,
+          "pass": 321,
+          "total": 341,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -3144,11 +3144,11 @@
       }
     },
     "literal": {
-      "total": 271,
+      "total": 272,
       "cells": {
         "hono": {
-          "pass": 270,
-          "total": 271,
+          "pass": 271,
+          "total": 272,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -3159,8 +3159,8 @@
           ]
         },
         "blade": {
-          "pass": 258,
-          "total": 271,
+          "pass": 259,
+          "total": 272,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -3221,8 +3221,8 @@
           ]
         },
         "erb": {
-          "pass": 258,
-          "total": 271,
+          "pass": 259,
+          "total": 272,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -3283,8 +3283,8 @@
           ]
         },
         "go-template": {
-          "pass": 256,
-          "total": 271,
+          "pass": 257,
+          "total": 272,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -3357,8 +3357,8 @@
           ]
         },
         "jinja": {
-          "pass": 258,
-          "total": 271,
+          "pass": 259,
+          "total": 272,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -3419,8 +3419,8 @@
           ]
         },
         "minijinja": {
-          "pass": 258,
-          "total": 271,
+          "pass": 259,
+          "total": 272,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -3481,8 +3481,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 258,
-          "total": 271,
+          "pass": 259,
+          "total": 272,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -3543,8 +3543,8 @@
           ]
         },
         "twig": {
-          "pass": 258,
-          "total": 271,
+          "pass": 259,
+          "total": 272,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -3605,8 +3605,8 @@
           ]
         },
         "xslate": {
-          "pass": 258,
-          "total": 271,
+          "pass": 259,
+          "total": 272,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -3828,11 +3828,11 @@
       }
     },
     "member": {
-      "total": 195,
+      "total": 196,
       "cells": {
         "hono": {
-          "pass": 192,
-          "total": 195,
+          "pass": 193,
+          "total": 196,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3855,8 +3855,8 @@
           ]
         },
         "blade": {
-          "pass": 175,
-          "total": 195,
+          "pass": 176,
+          "total": 196,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -3955,8 +3955,8 @@
           ]
         },
         "erb": {
-          "pass": 176,
-          "total": 195,
+          "pass": 177,
+          "total": 196,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -4049,8 +4049,8 @@
           ]
         },
         "go-template": {
-          "pass": 172,
-          "total": 195,
+          "pass": 173,
+          "total": 196,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -4165,8 +4165,8 @@
           ]
         },
         "jinja": {
-          "pass": 175,
-          "total": 195,
+          "pass": 176,
+          "total": 196,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -4265,8 +4265,8 @@
           ]
         },
         "minijinja": {
-          "pass": 175,
-          "total": 195,
+          "pass": 176,
+          "total": 196,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -4365,8 +4365,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 175,
-          "total": 195,
+          "pass": 176,
+          "total": 196,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -4463,8 +4463,8 @@
           ]
         },
         "twig": {
-          "pass": 175,
-          "total": 195,
+          "pass": 176,
+          "total": 196,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -4563,8 +4563,8 @@
           ]
         },
         "xslate": {
-          "pass": 175,
-          "total": 195,
+          "pass": 176,
+          "total": 196,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -4676,15 +4676,15 @@
       }
     },
     "object-literal": {
-      "total": 66,
+      "total": 67,
       "cells": {
         "hono": {
-          "pass": 66,
-          "total": 66
+          "pass": 67,
+          "total": 67
         },
         "blade": {
-          "pass": 62,
-          "total": 66,
+          "pass": 63,
+          "total": 67,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -4707,8 +4707,8 @@
           ]
         },
         "erb": {
-          "pass": 62,
-          "total": 66,
+          "pass": 63,
+          "total": 67,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -4731,8 +4731,8 @@
           ]
         },
         "go-template": {
-          "pass": 61,
-          "total": 66,
+          "pass": 62,
+          "total": 67,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -4761,8 +4761,8 @@
           ]
         },
         "jinja": {
-          "pass": 62,
-          "total": 66,
+          "pass": 63,
+          "total": 67,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -4785,8 +4785,8 @@
           ]
         },
         "minijinja": {
-          "pass": 62,
-          "total": 66,
+          "pass": 63,
+          "total": 67,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -4809,8 +4809,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 62,
-          "total": 66,
+          "pass": 63,
+          "total": 67,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -4833,8 +4833,8 @@
           ]
         },
         "twig": {
-          "pass": 62,
-          "total": 66,
+          "pass": 63,
+          "total": 67,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -4857,8 +4857,8 @@
           ]
         },
         "xslate": {
-          "pass": 62,
-          "total": 66,
+          "pass": 63,
+          "total": 67,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -7896,11 +7896,11 @@
       }
     },
     "literal:boolean": {
-      "total": 58,
+      "total": 59,
       "cells": {
         "hono": {
-          "pass": 57,
-          "total": 58,
+          "pass": 58,
+          "total": 59,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -7911,8 +7911,8 @@
           ]
         },
         "blade": {
-          "pass": 56,
-          "total": 58,
+          "pass": 57,
+          "total": 59,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -7927,8 +7927,8 @@
           ]
         },
         "erb": {
-          "pass": 56,
-          "total": 58,
+          "pass": 57,
+          "total": 59,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -7943,8 +7943,8 @@
           ]
         },
         "go-template": {
-          "pass": 54,
-          "total": 58,
+          "pass": 55,
+          "total": 59,
           "gaps": [
             {
               "fixture": "jsx-element-prop-rest-bag-dynamic",
@@ -7971,8 +7971,8 @@
           ]
         },
         "jinja": {
-          "pass": 56,
-          "total": 58,
+          "pass": 57,
+          "total": 59,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -7987,8 +7987,8 @@
           ]
         },
         "minijinja": {
-          "pass": 56,
-          "total": 58,
+          "pass": 57,
+          "total": 59,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -8003,8 +8003,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 56,
-          "total": 58,
+          "pass": 57,
+          "total": 59,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -8019,8 +8019,8 @@
           ]
         },
         "twig": {
-          "pass": 56,
-          "total": 58,
+          "pass": 57,
+          "total": 59,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -8035,8 +8035,8 @@
           ]
         },
         "xslate": {
-          "pass": 56,
-          "total": 58,
+          "pass": 57,
+          "total": 59,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -8375,15 +8375,15 @@
       }
     },
     "literal:string": {
-      "total": 189,
+      "total": 190,
       "cells": {
         "hono": {
-          "pass": 189,
-          "total": 189
+          "pass": 190,
+          "total": 190
         },
         "blade": {
-          "pass": 180,
-          "total": 189,
+          "pass": 181,
+          "total": 190,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -8426,8 +8426,8 @@
           ]
         },
         "erb": {
-          "pass": 180,
-          "total": 189,
+          "pass": 181,
+          "total": 190,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -8470,8 +8470,8 @@
           ]
         },
         "go-template": {
-          "pass": 179,
-          "total": 189,
+          "pass": 180,
+          "total": 190,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -8520,8 +8520,8 @@
           ]
         },
         "jinja": {
-          "pass": 180,
-          "total": 189,
+          "pass": 181,
+          "total": 190,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -8564,8 +8564,8 @@
           ]
         },
         "minijinja": {
-          "pass": 180,
-          "total": 189,
+          "pass": 181,
+          "total": 190,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -8608,8 +8608,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 180,
-          "total": 189,
+          "pass": 181,
+          "total": 190,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -8652,8 +8652,8 @@
           ]
         },
         "twig": {
-          "pass": 180,
-          "total": 189,
+          "pass": 181,
+          "total": 190,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -8696,8 +8696,8 @@
           ]
         },
         "xslate": {
-          "pass": 180,
-          "total": 189,
+          "pass": 181,
+          "total": 190,
           "gaps": [
             {
               "fixture": "aliased-loop-source",


### PR DESCRIPTION
## Summary

- A `derived`-classified signal seeded from an object literal that references a live prop/signal (`createSignal({ ...base, done: true })`) silently kept the field's Go zero value in the SSR template whenever the constructor-time baker (`convertInitialValue`) couldn't reproduce it — that baker is static-only (identifier/member/call operands defer, `parsed-literal-to-go.ts`'s own docstring), so `merged().id` / `merged().done` reads on real Go always saw the zero value with no diagnostic at all.
- Added `CompileState.templateReadRootFields`, populated by `rootFieldRef` — the single door every SSR template read of a root-scope field passes through (`identifier`/`call`/`member`'s zero-arg-getter and bare-name lowering, plus the typed-expression emitter). `generate()` renders the template before `generateTypes()` runs, so the set is complete by the time `generateNewPropsFunction`'s signal loop consults it.
- New `refuseUnbakeableDerivedObjectLiteral` fires a loud `BF101` only when **both** hold: the signal's `SsrSeedPlan` step is `derived` with a **non-empty free set**, and `templateReadRootFields` shows the template **actually reads** the field. This keeps two known-safe shapes unaffected:
  - A signal that only feeds a JSX spread bag (`{...merged()}`) never reaches `rootFieldRef` — spread bags bake through their own `.Spread_<slot>` route (`emitSpreadBagInits`) — so it isn't double-refused (it still gets the pre-existing, unrelated "JSX spread has no Go template lowering" BF101).
  - A fully-static object literal (`createSignal({ id: 'row-1' })`) hits the same `nil` fallback today but is scoped OUT on purpose (empty free set) — a separate, untracked silent-divergence shape with no fixture of its own, left for its own issue rather than silently widened into this fix.
- A verified-working `/* @client */` escape twin (`signal-object-spread-init-client`, new fixture) exists — wrapping every SSR read defers evaluation to the client, so the template never reaches `rootFieldRef` for the signal at all. Declared on `signal-object-spread-init`'s `escapes` and pinned in `conformance-pins.ts`.
- No memo-side counterpart: the analyzer deliberately never attaches a structured `parsed` tree to an object-returning memo body (`analyzer.ts`, "isn't lowered from the parsed tree yet" — a pre-existing, unrelated exclusion), so there's no structural handle to reach this check for a memo without re-parsing `computation` as text, which the repo's own conventions rule out. #2700's own reproduction and fixture are signal-only.
- Reclassifies #2700 from `bug` to `enhancement` (the divergence is now a loud, `/* @client */`-escapable refusal, not a silent wrong render) and graduates the `signal-object-spread-init` render-divergence pin.

## Test plan

- [x] New unit tests in `go-template-adapter.test.ts`: untyped object-literal signal refuses, typed (`createSignal<Item>`) variant also refuses, `/* @client */` on every read suppresses the refusal (constructor still bakes `nil`, but no diagnostic), and a signal only spread into attrs does not double-refuse.
- [x] `signal-object-spread-init` fixture on real Go: now refuses with `BF101` (was silently wrong output); new `signal-object-spread-init-client` twin compiles clean and renders correctly, matching Hono's reference `expectedHtml`.
- [x] `bun test packages/compat` → 522 pass, 0 fail (`escape-coverage.test.ts` verifies the escape twin actually works; `compat-engine.test.ts` updated for the new BF101 issue-URL union entry).
- [x] `ui/compat.lock.json` / `ui/support-matrix.lock.json` regenerated (after rebuilding all 8 dist-resolved adapter packages first) and confirmed via the compat suite.
- [x] `generate-expected-html.ts` run — zero diff on tracked fixtures (Hono reference unaffected).
- [x] Full go-template suite: `GOTOOLCHAIN=go1.25.6 bun test packages/adapter-go-template/src/__tests__` → 1884 pass, 0 fail, 26 skip.

Stacked on #2817 (`claude/fix-2800-go-nested-struct-synthesis`), which stacks on #2816 → #2814 → #2812 → #2811, per the ongoing bug-fix marathon in piconic-ai/barefootjs.

Closes #2700.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198yG2px5ygfvmdoMkhRS13

---
_Generated by [Claude Code](https://claude.ai/code/session_0198yG2px5ygfvmdoMkhRS13)_