### PR TITLE
Fix #2741: reactive-effect prop rewrite no longer touches object-literal keys

### DIFF
--- a/.changeset/reactive-effect-prop-rewrite-object-keys-2741.md
+++ b/.changeset/reactive-effect-prop-rewrite-object-keys-2741.md
@@ -1,0 +1,9 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Fix #2741: `rewriteDestructuredPropsInExpr` (the reactive `createEffect` update path's destructured-prop rewrite) ran a bare `\b<prop>\b` regex over the whole expression text, so an object literal whose property KEY happened to share a destructured prop's name (`queryHref(base, { tag: tag, page: page ? page : '' })`) had the KEY rewritten too (`{ _p.tag: _p.tag, ... }`) — not valid JS, so the whole client module failed to parse. No diagnostic was raised; the invalid module was written out silently.
+
+`rewriteDestructuredPropsInExpr` now delegates to `rewriteBarePropRefs` (`prop-rewrite.ts`) — the same AST walk the hydrate template lambda already used, which distinguishes a value reference from an object-literal key, a property-access name, a shorthand property, or a name shadowed by an inner binding (`items.map((tag) => tag.a)`). `applyScopedPropRefRewrite` and `applyRegexPropRefRewrite` (its unparseable-text fallback) gained an optional `replacementFor` override so the effect path's `(_p.x ?? <default>)` destructure-default wrapping stays call-site-specific without a second copy of the walk.
+
+Graduates the `query-href` CSR-conformance skip entry (`packages/adapter-tests/src/csr-skip-set.ts`); the CSR test harness also gained a `queryHref` runtime mirror (`csr-render.ts`), a second, previously-masked gap the syntax error had hidden (the harness strips real imports and stubs each runtime helper a fixture's generated code calls, and `queryHref` had no stub yet).

--- a/packages/adapter-tests/src/csr-render.ts
+++ b/packages/adapter-tests/src/csr-render.ts
@@ -491,6 +491,24 @@ function formatDate(dateArg, pattern, timeZone = 'UTC', names = []) {
       : nameAt(31 + weekday),
   )
 }
+// Mirror @barefootjs/client's queryHref (#2741 graduation): a pure
+// base-path + query-params URL builder. Same stripped-imports reasoning
+// as \`date\`/\`formatDate\` above — the user's own
+// \`import { queryHref } from '@barefootjs/client'\` is stripped with
+// every other import, so a call in template/effect code needs this
+// mirror or the fixture fails with "queryHref is not defined".
+function queryHref(base, params) {
+  const u = new URLSearchParams()
+  for (const [key, value] of Object.entries(params)) {
+    if (Array.isArray(value)) {
+      for (const member of value) if (member) u.append(key, member)
+    } else if (value) {
+      u.set(key, value)
+    }
+  }
+  const qs = u.toString()
+  return qs ? \`\${base}?\${qs}\` : base
+}
 
 // --- Execute client JS (registers templates via hydrate()) ---
 ${strippedCode}

--- a/packages/adapter-tests/src/csr-skip-set.ts
+++ b/packages/adapter-tests/src/csr-skip-set.ts
@@ -4,12 +4,6 @@
  * the same set without the two silently drifting apart.
  */
 export const CSR_SKIP_FIXTURES: ReadonlySet<string> = new Set([
-  // #2741: the effect-update emit prop-rewrites the queryHref params
-  // object's KEYS (`{ _p.tag: _p.tag }`) — the client module is a syntax
-  // error. The hydrate template lambda in the same output is correct;
-  // SSR conformance pins the contract. Graduation: fix the rewrite,
-  // delete this entry.
-  'query-href',
   // #2073: `.map(format)` closes over a module-scope const, which is not
   // available at CSR template module scope (CSR templates only have access
   // to props and signals); Hono render conformance covers the real-JS runtime.

--- a/packages/jsx/src/__tests__/rewrite-destructured-props.test.ts
+++ b/packages/jsx/src/__tests__/rewrite-destructured-props.test.ts
@@ -71,3 +71,56 @@ export { Btn }
     expect(js).not.toMatch(/\(_p\.size[^)]*\)-[0-9]/)
   })
 })
+
+// #2741: `rewriteDestructuredPropsInExpr` (the reactive `createEffect`
+// update path) used to run a bare `\b<prop>\b` regex over the whole
+// expression text, so an object-literal property whose KEY happened to
+// share a prop's name (`{ tag: tag }`) had the KEY rewritten too
+// (`{ _p.tag: _p.tag }`), which is not valid JS — the whole client module
+// failed to parse, silently (no diagnostic). Now delegates to the same
+// AST-based `rewriteBarePropRefs` (`prop-rewrite.ts`) the hydrate template
+// lambda already used, which distinguishes a key from a value reference.
+describe('reactive-effect prop rewrite does not touch object-literal keys (#2741)', () => {
+  test('an explicit-key object literal used in a reactive attribute keeps its keys', () => {
+    const source = `
+"use client"
+import { queryHref } from '@barefootjs/client'
+function Comp({ base, tag, page }: { base: string; tag: string; page: string }) {
+  return <a href={queryHref(base, { tag: tag, page: page ? page : '' })}>filter</a>
+}
+export { Comp }
+`
+    const js = compileClientJs(source)
+    expect(js).toContain("{ tag: _p.tag, page: _p.page ? _p.page : '' }")
+    expect(js).not.toContain('_p.tag:')
+    expect(js).not.toContain('_p.page:')
+  })
+
+  test('a keyed prop with a destructure default still gets the (_p.x ?? default) wrap only in value position', () => {
+    const source = `
+"use client"
+import { queryHref } from '@barefootjs/client'
+function Comp({ base, tag = 'all', page }: { base: string; tag?: string; page: string }) {
+  return <a href={queryHref(base, { tag: tag, page: page ? page : '' })}>filter</a>
+}
+export { Comp }
+`
+    const js = compileClientJs(source)
+    expect(js).toContain("{ tag: (_p.tag ?? 'all'), page: _p.page ? _p.page : '' }")
+    expect(js).not.toContain("(_p.tag ?? 'all'):")
+  })
+
+  test('a prop name shadowed by an inner callback parameter is not rewritten inside that callback', () => {
+    const source = `
+"use client"
+import { createSignal } from '@barefootjs/client'
+function Comp({ tag, items }: { tag: string; items: { a: string }[] }) {
+  const [n] = createSignal(0)
+  return <div data-x={n() + items.map((tag) => tag.a).join(',') + tag}></div>
+}
+export { Comp }
+`
+    const js = compileClientJs(source)
+    expect(js).toContain("items.map((tag) => tag.a).join(',') + _p.tag")
+  })
+})

--- a/packages/jsx/src/ir-to-client-js/emit-reactive.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-reactive.ts
@@ -15,6 +15,7 @@ import { datePlugin, DATE_METHODS } from '../date-lowering.ts'
 import { toLocaleDatePlugin, foldedArgToClientJs } from '../to-locale-date-lowering.ts'
 import { tsNodeToParsedExpr } from '../expression-parser.ts'
 import type { LoweringMatcher } from '../lowering-registry.ts'
+import { rewriteBarePropRefs } from '../prop-rewrite.ts'
 
 /**
  * Profile mode (#1690, SR3/SR4): the id appended to a DOM-binding effect so the
@@ -127,28 +128,43 @@ export function emitAttrUpdate(target: string, attrName: string, expression: str
 /**
  * Rewrite destructured prop names in an expression to `(props.xxx ?? default)`.
  * Only applies when the component uses destructured props (not props.xxx style).
+ *
+ * Delegates the actual walk to `rewriteBarePropRefs` (`prop-rewrite.ts`) — the
+ * one AST walk in the compiler that already distinguishes a VALUE reference
+ * from an object-literal key, a property-access name, a shorthand property,
+ * or a name shadowed by an inner binding (`items.map((tag) => tag.x)`).
+ * This function used to run its own `\btag\b`-style regex over the raw
+ * expression text with no such distinction, so `queryHref(base, { tag: tag })`
+ * rewrote the KEY too (`{ _p.tag: _p.tag }`, a syntax error) — #2741. Only
+ * the default-value `(_p.x ?? <default>)` wrapping is specific to this call
+ * site, supplied via `replacementFor` rather than a second copy of the walk.
  */
 export function rewriteDestructuredPropsInExpr(expr: string, ctx: ClientJsContext): string {
   if (ctx.propsObjectName) return expr
 
-  const { protect, restore } = createTemplateAwareStringProtector()
-  let result = protect(expr)
-
+  const propNames = new Set<string>()
+  const propAliases = new Map<string, string>()
+  const propsByName = new Map<string, ClientJsContext['propsParams'][number]>()
   for (const prop of ctx.propsParams) {
     if (prop.name === 'children') continue
-    const pattern = new RegExp(`(?<![-.])\\b${prop.name}\\b`, 'g')
-    if (!pattern.test(result)) continue
-
+    propNames.add(prop.name)
+    propsByName.set(prop.name, prop)
     // `_p` is always keyed by the caller-facing name (#2524 CSR half).
-    const callerKey = prop.sourceName ?? prop.name
-    const defaultVal = prop.defaultValue
-    const replacement = defaultVal
-      ? `(${PROPS_PARAM}.${callerKey} ?? ${prop.defaultContainsArrow ? `(${defaultVal})` : defaultVal})`
-      : `${PROPS_PARAM}.${callerKey}`
-    result = result.replace(new RegExp(`(?<![-.])\\b${prop.name}\\b`, 'g'), replacement)
+    if (prop.sourceName && prop.sourceName !== prop.name) propAliases.set(prop.name, prop.sourceName)
+  }
+  if (propNames.size === 0) return expr
+
+  const replacementFor = (localName: string, callerKey: string): string => {
+    const defaultVal = propsByName.get(localName)?.defaultValue
+    if (!defaultVal) return `${PROPS_PARAM}.${callerKey}`
+    const defaultContainsArrow = propsByName.get(localName)?.defaultContainsArrow
+    return `(${PROPS_PARAM}.${callerKey} ?? ${defaultContainsArrow ? `(${defaultVal})` : defaultVal})`
   }
 
-  return restore(result)
+  // Parenthesized so an object-literal or arrow-function expression parses
+  // standalone — same convention `applyScopedPropRefRewrite` itself uses.
+  const sourceFile = ts.createSourceFile('__bf_reactive_expr.ts', `(${expr}\n)`, ts.ScriptTarget.Latest, true)
+  return rewriteBarePropRefs(expr, sourceFile, propNames, undefined, propAliases, replacementFor) ?? expr
 }
 
 /**

--- a/packages/jsx/src/prop-rewrite.ts
+++ b/packages/jsx/src/prop-rewrite.ts
@@ -132,6 +132,16 @@ export function collectAstPropRefs(
  * (`{ org }` → `{ org: _p.org }`) so the result stays syntactically
  * valid.
  *
+ * `replacementFor` overrides the substitution text for a value
+ * reference (default `${PROPS_PARAM}.<callerKey>`) — e.g. the reactive
+ * client-JS emit path (`emit-reactive.ts`'s `rewriteDestructuredPropsInExpr`)
+ * wraps it in a `(_p.x ?? <default>)` fallback for a prop with a
+ * destructure default. Kept as a caller override rather than a
+ * duplicate AST walk in that module, per the "one decision, one
+ * implementation" rule (CLAUDE.md) — this walk is already the one place
+ * that correctly distinguishes a value reference from an object-literal
+ * key / property-access name / shorthand property / binding name.
+ *
  * Returns null when `text` does not parse cleanly as an expression —
  * the caller falls back to the legacy regex rewrite.
  */
@@ -139,6 +149,7 @@ function applyScopedPropRefRewrite(
   text: string,
   propRefs: Set<string>,
   propAliases?: ReadonlyMap<string, string>,
+  replacementFor?: (localName: string, callerKey: string) => string,
 ): string | null {
   // Wrap in parens so object literals and arrows parse as expressions.
   const prefix = '('
@@ -157,11 +168,12 @@ function applyScopedPropRefRewrite(
     // — #2524 CSR half); the local binding (`n.text`) only survives on the
     // left of a shorthand expansion.
     const callerKey = propAliases?.get(n.text) ?? n.text
+    const value = replacementFor ? replacementFor(n.text, callerKey) : `${PROPS_PARAM}.${callerKey}`
     if (parent && ts.isShorthandPropertyAssignment(parent) && parent.name === n) {
-      edits.push({ start, end, replacement: `${n.text}: ${PROPS_PARAM}.${callerKey}` })
+      edits.push({ start, end, replacement: `${n.text}: ${value}` })
       return
     }
-    edits.push({ start, end, replacement: `${PROPS_PARAM}.${callerKey}` })
+    edits.push({ start, end, replacement: value })
   })
 
   if (edits.length === 0) return text
@@ -186,6 +198,7 @@ export function applyRegexPropRefRewrite(
   text: string,
   propRefs: Iterable<string>,
   propAliases?: ReadonlyMap<string, string>,
+  replacementFor?: (localName: string, callerKey: string) => string,
 ): string {
   const { protect, restore } = createTemplateAwareStringProtector()
   let result = protect(text)
@@ -193,6 +206,7 @@ export function applyRegexPropRefRewrite(
   for (const propName of propRefs) {
     // `_p` is always keyed by the caller-facing name (#2524 CSR half).
     const callerKey = propAliases?.get(propName) ?? propName
+    const value = replacementFor ? replacementFor(propName, callerKey) : `${PROPS_PARAM}.${callerKey}`
     const pattern = new RegExp(`(?<!${PROPS_PARAM}\\.)(?<!['"\\w.-])\\b${propName}\\b(?![a-zA-Z0-9_$])`, 'g')
     result = result.replace(pattern, (match, offset, str) => {
       // Skip object literal keys: preceded by { or , and followed by :
@@ -201,7 +215,7 @@ export function applyRegexPropRefRewrite(
         const before = str.slice(0, offset)
         if (/[{,]\s*$/.test(before)) return match
       }
-      return `${PROPS_PARAM}.${callerKey}`
+      return value
     })
   }
 
@@ -225,6 +239,9 @@ export function applyRegexPropRefRewrite(
  *   `_p` is always keyed by the caller-facing name (#2524 CSR half); a name
  *   absent from this map emits `_p.<name>` unchanged (the un-aliased case,
  *   where `sourceName ?? name` is an identity).
+ * @param replacementFor - Override the substitution text for a value
+ *   reference (default `${PROPS_PARAM}.<callerKey>`) — see
+ *   `applyScopedPropRefRewrite`'s docstring.
  */
 export function rewriteBarePropRefs(
   text: string,
@@ -232,6 +249,7 @@ export function rewriteBarePropRefs(
   propNames: Set<string>,
   extraPropRefs?: ReadonlySet<string>,
   propAliases?: ReadonlyMap<string, string>,
+  replacementFor?: (localName: string, callerKey: string) => string,
 ): string | undefined {
   // Walk AST to find which prop names are actually used as value references
   const foundPropRefs = new Set<string>()
@@ -243,7 +261,7 @@ export function rewriteBarePropRefs(
   }
   if (foundPropRefs.size === 0) return undefined
   return (
-    applyScopedPropRefRewrite(text, foundPropRefs, propAliases) ??
-    applyRegexPropRefRewrite(text, foundPropRefs, propAliases)
+    applyScopedPropRefRewrite(text, foundPropRefs, propAliases, replacementFor) ??
+    applyRegexPropRefRewrite(text, foundPropRefs, propAliases, replacementFor)
   )
 }


### PR DESCRIPTION
## Summary

- `rewriteDestructuredPropsInExpr` (`emit-reactive.ts`) — the reactive `createEffect` update path's destructured-prop rewrite — ran a bare `\b\b` regex over the whole expression text with no structural distinction between a value reference and an object-literal key. So `queryHref(base, { tag: tag, page: page ? page : '' })` on a component destructuring `{ base, tag, page }` had the KEY rewritten too: `{ _p.tag: _p.tag, ... }` — not valid JS, so the whole client module failed to parse. No diagnostic was raised; the invalid module was silently written out (only surfacing as a `[barefootjs] pruneUnusedPropExtractions: generated code did not parse; skipping prune` warning with no indication of the actual cause).
- The hydrate template lambda in the same output was always correct — it already goes through `rewriteBarePropRefs` (`prop-rewrite.ts`), the one AST walk in the compiler that distinguishes a value reference from an object-literal key, a property-access name, a shorthand property, or a name shadowed by an inner binding (`items.map((tag) => tag.a)`). Per CLAUDE.md's "one decision, two implementations, no test comparing them" rule, `rewriteDestructuredPropsInExpr` now **delegates to that same function** instead of carrying a third, regex-based copy of the same decision.
- `applyScopedPropRefRewrite` and its unparseable-text fallback `applyRegexPropRefRewrite` (both in `prop-rewrite.ts`) gained an optional `replacementFor` override so the effect path's `(_p.x ?? <default>)` destructure-default wrapping stays call-site-specific — the walk itself, and its key/value distinction, is not duplicated.
- Graduates the `query-href` CSR-conformance skip entry (`csr-skip-set.ts`).
- Along the way, running the actual CSR-conformance test surfaced a **second, previously-masked** gap: the CSR test harness (`csr-render.ts`) strips real ES module imports from generated code and provides its own runtime-helper mirrors (`escapeAttr`, `date`, `formatDate`, `spreadAttrs`, …) — but had none for `queryHref`, so once the syntax error was fixed the fixture failed with `ReferenceError: queryHref is not defined` instead. Added a `queryHref` mirror matching the real implementation, in the same style as its neighbors.
- Deliberately does **not** touch a separate, pre-existing gap noted during investigation: a prop referenced only via object-literal **shorthand** (`{ page }`) is not currently discovered as a value reference by `collectAstPropRefs` at all (a Phase-1 exclusion, unaffected by this change) — filed as #2828 (pullfrog review, PR #2819), a distinct bug with its own fix and fixture needed.

## Test plan

- [x] New unit tests in `rewrite-destructured-props.test.ts`: explicit-key object literal keeps its keys and rewrites only values; a keyed prop with a destructure default still wraps only in value position; a prop name shadowed by an inner callback parameter is not rewritten inside that callback.
- [x] Full `packages/jsx` test suite: 3182 pass, 0 fail (two pre-existing, unrelated `pruneUnusedPropExtractions` warnings confirmed present on `main` too, via `git stash`).
- [x] `query-href` fixture: `csr-conformance.test.ts` now passes (was silently emitting invalid JS before, masked by the skip entry).
- [x] Full CSR conformance suite (`csr-conformance.test.ts`): 336 pass, 0 fail.
- [x] `csr-skip-rot.test.ts`: 23 pass, 0 fail (skip-set entry removal is consistent with the harness).
- [x] `generate-expected-html.ts` run — zero diff on tracked fixtures (this is a client-JS-only fix; SSR output is unaffected on every adapter).
- [x] `bun test packages/compat` → 521 pass, 1 timeout (re-ran standalone with a longer timeout: 8 pass, 0 fail — confirmed transient, not a regression).

Stacked on #2818 (`claude/fix-2700-go-signal-object-literal-loud-refusal`), which stacks on #2817 → #2816 → #2814 → #2812 → #2811, per the ongoing bug-fix marathon in piconic-ai/barefootjs.

Closes #2741.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198yG2px5ygfvmdoMkhRS13

---
_Generated by [Claude Code](https://claude.ai/code/session_0198yG2px5ygfvmdoMkhRS13)_