### PR TITLE
Fix #2785: refuse to write a truncated support-matrix/compat lock

### DIFF
--- a/.changeset/support-matrix-cli-missing-adapter-guard-2785.md
+++ b/.changeset/support-matrix-cli-missing-adapter-guard-2785.md
@@ -1,0 +1,7 @@
+---
+"@barefootjs/compat": patch
+---
+
+Fix #2785: `support-matrix:lock` and `compat:lock` discover adapters by dynamic-importing each registered package (`adapter-registry.ts`'s `loadCompatAdapters`) and silently skip any that fail to resolve — e.g. an unbuilt `dist/`. Their generators then wrote a lock file containing only the adapters that happened to load, with no warning, deleting the missing adapters' rows from the committed `ui/support-matrix.lock.json` / `ui/compat.lock.json`. The freshness/drift check then compared against this now-truncated lock and passed on it.
+
+`loadAllCompatAdapters`/`requireAllCompatAdapters` (`adapter-registry.ts`) are a new all-or-throw wrapper around the existing degrade-to-skip loader: `MissingCompatAdaptersError` names every package that failed to load, its reason, and the exact `bun run --filter ... build` command to fix it. `support-matrix-cli.ts` (always a lock generator) and `cli.ts`'s `--out` path (`compat:lock`) now refuse to write and exit 1 instead of silently writing a subset; the ad-hoc `bun run compat <component>` (no `--out`) keeps its prior best-effort behavior, since that path was never a committed artifact.

--- a/packages/compat/src/__tests__/adapter-registry.test.ts
+++ b/packages/compat/src/__tests__/adapter-registry.test.ts
@@ -1,0 +1,55 @@
+// #2785 — `support-matrix:lock`/`compat:lock` used to silently write a lock
+// containing only whichever adapters happened to be built, deleting the
+// rest from the committed artifact with no warning. `requireAllCompatAdapters`
+// is the pure gate lock generators now go through instead of the
+// degrade-to-skip `loadCompatAdapters` directly.
+
+import { describe, test, expect } from 'bun:test'
+import {
+  loadAllCompatAdapters,
+  MissingCompatAdaptersError,
+  requireAllCompatAdapters,
+  type LoadedCompatAdapter,
+} from '../adapter-registry'
+
+function fakeLoaded(id: string): LoadedCompatAdapter {
+  return { id, pkg: `@barefootjs/${id}`, factory: () => { throw new Error('unused in this test') }, pins: {}, renderDivergences: {} }
+}
+
+describe('requireAllCompatAdapters (#2785)', () => {
+  test('returns `loaded` unchanged when nothing was skipped', () => {
+    const loaded = [fakeLoaded('hono'), fakeLoaded('erb')]
+    expect(requireAllCompatAdapters({ loaded, skipped: [] })).toBe(loaded)
+  })
+
+  test('throws MissingCompatAdaptersError naming every skipped package, its reason, and a build command', () => {
+    const loaded = [fakeLoaded('hono')]
+    const skipped = [
+      { pkg: '@barefootjs/erb', reason: "Cannot find module '@barefootjs/erb' from '/x'" },
+      { pkg: '@barefootjs/twig', reason: "Cannot find module '@barefootjs/twig' from '/x'" },
+    ]
+
+    let thrown: unknown
+    try {
+      requireAllCompatAdapters({ loaded, skipped })
+    } catch (err) {
+      thrown = err
+    }
+
+    expect(thrown).toBeInstanceOf(MissingCompatAdaptersError)
+    const err = thrown as MissingCompatAdaptersError
+    expect(err.skipped).toBe(skipped)
+    expect(err.message).toContain('2 of 3')
+    expect(err.message).toContain('@barefootjs/erb')
+    expect(err.message).toContain("Cannot find module '@barefootjs/erb' from '/x'")
+    expect(err.message).toContain('@barefootjs/twig')
+    expect(err.message).toContain("bun run --filter '@barefootjs/erb' --filter '@barefootjs/twig' build")
+  })
+})
+
+describe('loadAllCompatAdapters (#2785)', () => {
+  test('resolves every registered adapter in this monorepo (mirrors compat-pins.test.ts\'s skipped===[] assertion)', async () => {
+    const loaded = await loadAllCompatAdapters()
+    expect(loaded.length).toBeGreaterThan(0)
+  })
+})

--- a/packages/compat/src/adapter-registry.ts
+++ b/packages/compat/src/adapter-registry.ts
@@ -14,6 +14,15 @@
 // (e.g. unbuilt dist) degrades to a reported skip instead of a hard
 // crash, keeping the loader total. The monorepo always has all 9
 // installed, so a run from this repo loads every adapter.
+//
+// `loadCompatAdapters` itself stays total (see above) because an ad-hoc
+// `bun run compat <component>` run should still cover every adapter it
+// CAN load. A generator that WRITES a committed lock artifact
+// (`support-matrix:lock`, `compat:lock`) must not: a lock computed from a
+// subset silently drops those adapters' columns, and the committed lock
+// then becomes the (wrong) expectation the freshness test compares
+// against (#2785). Those callers use `loadAllCompatAdapters` below, which
+// throws instead of returning a subset.
 
 import type { ConformancePins, RenderDivergences, TemplateAdapter } from '@barefootjs/jsx'
 
@@ -106,4 +115,51 @@ export async function loadCompatAdapters(): Promise<{
   }
 
   return { loaded, skipped }
+}
+
+/** Thrown by {@link loadAllCompatAdapters} when a lock generator would otherwise emit output missing registered adapter columns. */
+export class MissingCompatAdaptersError extends Error {
+  readonly skipped: readonly SkippedCompatAdapter[]
+
+  constructor(skipped: readonly SkippedCompatAdapter[], total: number) {
+    super(formatMissingCompatAdapters(skipped, total))
+    this.name = 'MissingCompatAdaptersError'
+    this.skipped = skipped
+  }
+}
+
+function formatMissingCompatAdapters(skipped: readonly SkippedCompatAdapter[], total: number): string {
+  const filters = skipped.map(s => `--filter '${s.pkg}'`).join(' ')
+  return [
+    `Refusing to write: ${skipped.length} of ${total} registered adapter packages did not load, so the output would silently drop their columns.`,
+    ...skipped.map(s => `  - ${s.pkg}: ${s.reason}`),
+    `Build them first:`,
+    `  bun run ${filters} build`,
+    `(or \`bun run build\` for every workspace package), then re-run.`,
+  ].join('\n')
+}
+
+/**
+ * Pure gate over a {@link loadCompatAdapters} result: returns `loaded` when
+ * nothing was skipped, otherwise throws {@link MissingCompatAdaptersError}.
+ * Split out from {@link loadAllCompatAdapters} so the refusal is
+ * unit-testable without an actual unbuilt package on disk.
+ */
+export function requireAllCompatAdapters(result: {
+  loaded: LoadedCompatAdapter[]
+  skipped: SkippedCompatAdapter[]
+}): LoadedCompatAdapter[] {
+  if (result.skipped.length > 0) {
+    throw new MissingCompatAdaptersError(result.skipped, result.loaded.length + result.skipped.length)
+  }
+  return result.loaded
+}
+
+/**
+ * {@link loadCompatAdapters} for lock generators: all registered adapters or
+ * a thrown {@link MissingCompatAdaptersError}, never a silently truncated
+ * subset (#2785).
+ */
+export async function loadAllCompatAdapters(): Promise<LoadedCompatAdapter[]> {
+  return requireAllCompatAdapters(await loadCompatAdapters())
 }

--- a/packages/compat/src/cli.ts
+++ b/packages/compat/src/cli.ts
@@ -30,7 +30,7 @@ import { existsSync, readFileSync, writeFileSync } from 'fs'
 import { glob as fsGlob } from 'node:fs/promises'
 import { fileURLToPath } from 'node:url'
 import path from 'path'
-import { loadCompatAdapters } from './adapter-registry'
+import { loadCompatAdapters, MissingCompatAdaptersError, requireAllCompatAdapters } from './adapter-registry'
 import { computeComponentDocs, computeFixtureDocs } from './component-docs'
 import { buildCompatCell, compileForCompat, type CompatCell } from './engine'
 import { buildCompatReport, buildFixtureDivergences, formatCompatJson, formatCompatMarkdown, type CompatReport } from './report'
@@ -197,14 +197,33 @@ async function main(): Promise<void> {
     return
   }
 
-  const { loaded, skipped } = await loadCompatAdapters()
-  for (const s of skipped) {
-    console.error(`Skipping ${s.pkg}: ${s.reason}`)
-  }
-  if (loaded.length === 0) {
-    console.error('No adapters resolved — cannot build a compat matrix.')
-    process.exit(1)
-    return
+  const loadResult = await loadCompatAdapters()
+  let loaded: typeof loadResult.loaded
+  if (outPath) {
+    // Writing a committed lock artifact (compat:lock = --all --json --out):
+    // a subset lock silently drops the missing adapters' columns, and the
+    // committed lock then becomes the (wrong) expectation the freshness
+    // test compares against (#2785) — refuse instead of warning.
+    try {
+      loaded = requireAllCompatAdapters(loadResult)
+    } catch (err) {
+      if (err instanceof MissingCompatAdaptersError) {
+        console.error(err.message)
+        process.exit(1)
+        return
+      }
+      throw err
+    }
+  } else {
+    for (const s of loadResult.skipped) {
+      console.error(`Skipping ${s.pkg}: ${s.reason}`)
+    }
+    loaded = loadResult.loaded
+    if (loaded.length === 0) {
+      console.error('No adapters resolved — cannot build a compat matrix.')
+      process.exit(1)
+      return
+    }
   }
 
   const cells: Record<string, Record<string, CompatCell>> = {}

--- a/packages/compat/src/cli.ts
+++ b/packages/compat/src/cli.ts
@@ -199,11 +199,14 @@ async function main(): Promise<void> {
 
   const loadResult = await loadCompatAdapters()
   let loaded: typeof loadResult.loaded
-  if (outPath) {
+  if (all && outPath) {
     // Writing a committed lock artifact (compat:lock = --all --json --out):
     // a subset lock silently drops the missing adapters' columns, and the
     // committed lock then becomes the (wrong) expectation the freshness
-    // test compares against (#2785) — refuse instead of warning.
+    // test compares against (#2785) — refuse instead of warning. An ad-hoc
+    // named-component run with `--out` (e.g. `compat Button --out
+    // /tmp/report.json`) is not this scenario — it stays best-effort, per
+    // adapter-registry.ts's header.
     try {
       loaded = requireAllCompatAdapters(loadResult)
     } catch (err) {

--- a/packages/compat/src/support-matrix-cli.ts
+++ b/packages/compat/src/support-matrix-cli.ts
@@ -12,13 +12,24 @@
 import { writeFileSync } from 'fs'
 import { fileURLToPath } from 'node:url'
 import path from 'path'
+import { MissingCompatAdaptersError } from './adapter-registry'
 import { computeSupportMatrix, formatSupportMatrixJson } from './support-matrix'
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..')
 const OUT_PATH = path.join(REPO_ROOT, 'ui/support-matrix.lock.json')
 
 async function main(): Promise<void> {
-  const report = await computeSupportMatrix()
+  let report: Awaited<ReturnType<typeof computeSupportMatrix>>
+  try {
+    report = await computeSupportMatrix()
+  } catch (err) {
+    if (err instanceof MissingCompatAdaptersError) {
+      console.error(err.message)
+      process.exit(1)
+      return
+    }
+    throw err
+  }
   writeFileSync(OUT_PATH, formatSupportMatrixJson(report))
 
   const kindCount = Object.keys(report.kinds).length

--- a/packages/compat/src/support-matrix.ts
+++ b/packages/compat/src/support-matrix.ts
@@ -28,7 +28,7 @@
 
 import { PARSED_EXPR_KINDS } from '@barefootjs/jsx'
 import coverageMapJson from '../../adapter-tests/coverage-map.json' with { type: 'json' }
-import { loadCompatAdapters } from './adapter-registry'
+import { loadAllCompatAdapters } from './adapter-registry'
 import { computeConstructExamples, type ConstructExample } from './construct-examples'
 import { computeConstructSourceLinks, resolveAxisLink, resolveKindLink, type SourceLink } from './construct-source-links'
 import { compareAdapterIds, KNOWN_LIMITATION_LABEL } from './report'
@@ -191,13 +191,17 @@ export function buildSupportMatrix(
 
 /**
  * Real-input entry point: the committed `coverage-map.json` joined
- * against every adapter `loadCompatAdapters()` resolves. Adapters it
- * can't resolve are silently skipped (same degrade-to-skip contract as
- * `loadCompatAdapters` itself) — the monorepo always has all 9
- * installed, so a run from this repo covers every adapter.
+ * against every registered adapter. This is a lock generator (its output
+ * is committed to `ui/support-matrix.lock.json`), so it uses
+ * `loadAllCompatAdapters` rather than `loadCompatAdapters` directly: a
+ * matrix computed from a subset of adapters would silently drop those
+ * adapters' columns from the committed lock, and the freshness test would
+ * then compare against that wrong lock instead of catching it (#2785).
+ * Throws `MissingCompatAdaptersError` if any registered adapter fails to
+ * load.
  */
 export async function computeSupportMatrix(): Promise<SupportMatrixReport> {
-  const { loaded } = await loadCompatAdapters()
+  const loaded = await loadAllCompatAdapters()
   const coverage = coverageMapJson as SupportMatrixCoverageMap
   const report = buildSupportMatrix(coverage, loaded)
   return attachConstructDocs(report, coverage)


### PR DESCRIPTION
## Summary

- `support-matrix:lock` and `compat:lock` discover adapters by dynamic-importing each registered package (`adapter-registry.ts`'s `loadCompatAdapters`); a package that fails to resolve (e.g. an unbuilt `dist/`) degrades to a silently reported skip rather than a hard failure — by design, so an ad-hoc `bun run compat <component>` run still covers whatever it can load.
- Both lock GENERATORS inherited that same degrade-to-skip behavior, which is wrong for them: they write a committed artifact (`ui/support-matrix.lock.json` / `ui/compat.lock.json`), so a subset of adapters silently becomes the new "expected" set once committed — the freshness/drift check then compares against this truncated lock and passes on it. Reproduced: removing `packages/adapter-erb/dist` and running either script wrote a lock missing the `erb` column, with no error and exit code 0.
- Adds `requireAllCompatAdapters`/`loadAllCompatAdapters` (`adapter-registry.ts`) — an all-or-throw wrapper around the existing loader. `MissingCompatAdaptersError` names every package that failed, its reason, and the exact `bun run --filter '<pkg>' build` command to fix it.
- `support-matrix-cli.ts` (always a lock generator) now catches this and exits 1 with the message instead of writing. `cli.ts`'s `--out` path (`compat:lock` = `--all --json --out ...`) does the same; the `--out`-less ad-hoc path (`bun run compat <component>`, never a committed artifact) keeps its prior best-effort warn-and-continue behavior.
- No change needed to `coverage-map.ts`, `generate-expected-html.ts`, or `meta:extract` — none of them discover an adapter set from build state (verified: single static Hono import, fixture-only, and a source-file glob respectively).

## Test plan

- [x] New `packages/compat/src/__tests__/adapter-registry.test.ts`: `requireAllCompatAdapters` returns `loaded` unchanged when nothing was skipped; throws `MissingCompatAdaptersError` naming every skipped package, its reason, and the build command when something was; `loadAllCompatAdapters()` resolves all 9 registered adapters in this monorepo.
- [x] Manual repro-then-fix verification: removed `packages/adapter-erb/dist`, ran both `support-matrix:lock` and `compat:lock` — both refuse with the expected message and exit code 1, neither writes its lock file (`git status` clean on both locks); restored `dist`, re-ran — both succeed as before.
- [x] `bun test packages/compat`: 525 pass, 0 fail.
- [x] `tsc --noEmit` in `packages/compat`: only the pre-existing, unrelated `escape-coverage.ts` error remains (confirmed present identically on this branch's base, before this change).

Stacked on #2820 (`claude/fix-2702-fragment-conditional-prop-bfmarkup`), which stacks on #2819 → #2818 → #2817 → #2816 → #2814 → #2812 → #2811, per the ongoing bug-fix marathon in piconic-ai/barefootjs.

Closes #2785.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198yG2px5ygfvmdoMkhRS13

---
_Generated by [Claude Code](https://claude.ai/code/session_0198yG2px5ygfvmdoMkhRS13)_