### PR TITLE
Reclassify #2719 to bare known-limitation (ledger only, no code fix)

### DIFF
--- a/packages/adapter-tests/e2e/oracle-quarantine.ts
+++ b/packages/adapter-tests/e2e/oracle-quarantine.ts
@@ -175,10 +175,23 @@ export const ORACLE_QUARANTINE: Readonly<Record<string, QuarantineEntry>> = {
   // attribute is corrected) and not #2715 (no named-prop mirror). Stays
   // quarantined as the executable record: this oracle cannot tell an
   // explicit @client placeholder fill apart from a hydration defect.
+  //
+  // Not an exhaustive @client inventory (pullfrog review, PR #2824):
+  // TodoApp.tsx has a FIFTH `/* @client */` site — the toggle-all
+  // checkbox's `checked={/* @client */ todos().every(t => t.done)}`
+  // (line ~177) — that this list and the reason string below don't name.
+  // It doesn't currently widen the divergence: SSR omits the `checked`
+  // attribute entirely rather than emitting a wrong value, and this
+  // fixture's `initialTodos` has 2 of 3 items undone, so `every()`
+  // evaluates `false` — coincidentally the same as the absent-attribute
+  // default. If `initialTodos` ever becomes all-done, `every()` would
+  // evaluate `true` and this fifth region would start diverging too,
+  // which the "four regions and nothing else" framing above would then
+  // misdescribe.
   'todo-app': {
     oracles: ['snap', 'three-point'],
     reason:
-      'SSR emits the four /* @client */ placeholders empty (<ul class="todo-list"> loop l0, <strong bf="s7"> count, cond s8 \'item\'/\'items\', cond s13 clear-completed button); hydration materializes them. Everything outside those regions is byte-identical, and the three-point\'s hydrated-vs-csr-mount leg agrees — by-design client-only rendering, not a hydration defect.',
+      'SSR emits the four /* @client */ placeholders empty (<ul class="todo-list"> loop l0, <strong bf="s7"> count, cond s8 \'item\'/\'items\', cond s13 clear-completed button); hydration materializes them. Everything outside those regions is byte-identical, and the three-point\'s hydrated-vs-csr-mount leg agrees — by-design client-only rendering, not a hydration defect. (A fifth /* @client */ site, the toggle-all checkbox\'s `checked` binding, is untouched by this masking — SSR omits the attribute entirely and the fixture\'s seeded data happens to match that default; see the module comment above.)',
     issue: 'https://github.com/piconic-ai/barefootjs/issues/2719',
   },
 }

--- a/packages/adapter-tests/e2e/oracle-quarantine.ts
+++ b/packages/adapter-tests/e2e/oracle-quarantine.ts
@@ -163,9 +163,22 @@ export const ORACLE_QUARANTINE: Readonly<Record<string, QuarantineEntry>> = {
       "three-point: csr-mount's default-active TabsTrigger disagrees with the hydrated leg on aria-selected/data-state/data-value (see module comment above) — a distinct, previously-masked divergence, not the #2716 .value shape. Idempotence: replaying its two click steps times out (10s) waiting for the second tab trigger — its [data-value] locator never matches in one leg; may or may not share a root cause with the three-point row.",
     issue: 'https://github.com/piconic-ai/barefootjs/issues/2728',
   },
+  // `/* @client */` placeholders populated after hydration (#2719, narrowed):
+  // TodoApp.tsx marks its filtered keyed loop, both todo-count text
+  // expressions, and the clear-completed conditional `/* @client */`, so SSR
+  // emits empty markers by contract (spec/callback-fidelity.md §4) and the
+  // client materializes them — the "large structural divergence" is exactly
+  // those four regions and nothing else: with them masked out of the
+  // hydrated tree it is byte-identical to SSR, hydrated ≡ csr-mount agree
+  // structurally and in DOM state, idempotence passes, and the marker-free
+  // twin `todo-app-ssr` passes all three oracles. Not #2714 (no SSR-present
+  // attribute is corrected) and not #2715 (no named-prop mirror). Stays
+  // quarantined as the executable record: this oracle cannot tell an
+  // explicit @client placeholder fill apart from a hydration defect.
   'todo-app': {
     oracles: ['snap', 'three-point'],
-    reason: 'Large structural divergence after hydration (footer/filter/count section reflow) — needs a focused diff, not yet narrowed to one attribute/element.',
+    reason:
+      'SSR emits the four /* @client */ placeholders empty (<ul class="todo-list"> loop l0, <strong bf="s7"> count, cond s8 \'item\'/\'items\', cond s13 clear-completed button); hydration materializes them. Everything outside those regions is byte-identical, and the three-point\'s hydrated-vs-csr-mount leg agrees — by-design client-only rendering, not a hydration defect.',
     issue: 'https://github.com/piconic-ai/barefootjs/issues/2719',
   },
 }

--- a/packages/adapter-tests/e2e/oracle-quarantine.ts
+++ b/packages/adapter-tests/e2e/oracle-quarantine.ts
@@ -176,18 +176,14 @@ export const ORACLE_QUARANTINE: Readonly<Record<string, QuarantineEntry>> = {
   // quarantined as the executable record: this oracle cannot tell an
   // explicit @client placeholder fill apart from a hydration defect.
   //
-  // Not an exhaustive @client inventory (pullfrog review, PR #2824):
-  // TodoApp.tsx has a FIFTH `/* @client */` site — the toggle-all
-  // checkbox's `checked={/* @client */ todos().every(t => t.done)}`
-  // (line ~177) — that this list and the reason string below don't name.
-  // It doesn't currently widen the divergence: SSR omits the `checked`
-  // attribute entirely rather than emitting a wrong value, and this
-  // fixture's `initialTodos` has 2 of 3 items undone, so `every()`
-  // evaluates `false` — coincidentally the same as the absent-attribute
-  // default. If `initialTodos` ever becomes all-done, `every()` would
-  // evaluate `true` and this fifth region would start diverging too,
-  // which the "four regions and nothing else" framing above would then
-  // misdescribe.
+  // A fifth `/* @client */` site, the toggle-all checkbox's
+  // `checked={/* @client */ todos().every(t => t.done)}`, is untouched by
+  // the masking above. It doesn't currently widen the divergence: SSR omits
+  // the `checked` attribute entirely, and this fixture's `initialTodos` has
+  // 2 of 3 items undone, so `every()` evaluates `false` — coincidentally
+  // the same as the absent-attribute default. If `initialTodos` ever became
+  // all-done, `every()` would flip `true` and this region would start
+  // diverging too.
   'todo-app': {
     oracles: ['snap', 'three-point'],
     reason:


### PR DESCRIPTION
## Summary

- Re-measured #2719's `todo-app` oracle divergence against the current stack head (none of the intervening fixes — #2737/#2778/#2794/#2800/#2700/#2741/#2702 — touch `TodoApp.tsx`'s SSR markup or client JS, so the result is unaffected by exactly which commit is used).
- The "large structural divergence" is fully narrowed: `TodoApp.tsx` marks four regions `/* @client */` (the filtered keyed loop, both todo-count text expressions, the clear-completed conditional). Per `spec/callback-fidelity.md` §4, SSR renders those as empty placeholders BY CONTRACT and the client fills them in — that is exactly what `snap`/`three-point` are flagging, and it isn't a divergence from the compiler's contract.
- Verified: masking the four regions out of the hydrated tree makes it byte-identical to SSR; the three-point oracle's hydrated-vs-csr-mount leg agrees; `idempotence` passes; the marker-free twin `todo-app-ssr` passes all three oracles cleanly. Not #2714 (no SSR-present attribute is corrected) and not #2715 (no named-prop mirror) — different mechanism from both.
- This makes #2719 a gap in the ORACLE's expressiveness (no way to declare "this region is an intentional `@client` placeholder"), not a bug in the compiler or in `TodoApp.tsx` — per `CLAUDE.md`'s compatibility-policy tiers, that's an accepted permanent design position (bare `known-limitation`), not `+ bug`.
- Relabeled the GitHub issue (`bug` removed, `known-limitation` kept), retitled it to describe the narrowed mechanism, and updated `packages/adapter-tests/e2e/oracle-quarantine.ts`'s `todo-app` reason string (and added an explanatory comment) to match — no compiler/component/runtime code changed.

## Test plan

- [x] No code fix — this is a doc/ledger-only change. `oracle-quarantine.ts` loads and parses correctly (`bun -e "import(...)"` sanity check).
- [x] The empirical re-measurement (masked-tree diff, hydrated-vs-csr-mount comparison, `todo-app-ssr` control) was run directly against the actual Playwright oracle harness in this environment; full details in the linked issue comment.

Stacked on #2823 (`claude/fix-2777-aliased-import-child-registry`), which stacks on #2821 → #2820 → #2819 → #2818 → #2817 → #2816 → #2814 → #2812 → #2811, per the ongoing bug-fix marathon in piconic-ai/barefootjs.

Addresses #2719 (reclassification, not a code fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198yG2px5ygfvmdoMkhRS13

---
_Generated by [Claude Code](https://claude.ai/code/session_0198yG2px5ygfvmdoMkhRS13)_