### PR TITLE
Fix #2771: refuse loudly when a reactive primitive is called through an unresolved namespace import

### DIFF
--- a/.changeset/namespace-import-primitive-2771.md
+++ b/.changeset/namespace-import-primitive-2771.md
@@ -1,0 +1,7 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Fix #2771: `import * as bf from '@barefootjs/client'` followed by `bf.createSignal(0)` (or any other reactive primitive — createMemo/createEffect/onMount/onCleanup/createSearchParams — accessed off the namespace binding) compiled with zero diagnostics, but the analyzer's fast-path primitive detection only recognizes a bare identifier callee. The checker-based slow path that DOES resolve a namespace-qualified call only runs when a shared `ts.Program` is supplied (`CompileOptions.program`, which `@barefootjs/vite` always provides) — without one, the declaration was silently dropped from the compiled output and every reference to it threw `ReferenceError` at hydrate.
+
+New `BF013` diagnostic (`validateNamespaceQualifiedPrimitives`, `analyzer.ts`) refuses loudly instead, gated on non-recognition rather than on the namespace-import shape itself — a compile that supplies a program is untouched, since `resolvePrimitiveKind`'s checker-aided path already lowers the shape correctly there. Suggests importing the primitive by name as the fix. Adds the `namespace-import-primitive` fixture (pinned identically across all nine adapters, since the refusal fires ahead of any adapter's `generate()`) and its named-import escape twin.

--- a/docs/core/advanced/error-codes.md
+++ b/docs/core/advanced/error-codes.md
@@ -58,7 +58,7 @@ export function Counter() { ... }
 
 ---
 
-## Signal Errors (BF011)
+## Signal Errors (BF011–BF013)
 
 <a id="bf011"></a>
 
@@ -101,6 +101,38 @@ export function Counter() {
   return <button onClick={() => setCount(count() + 1)}>{count()}</button>
 }
 ```
+
+---
+
+<a id="bf013"></a>
+
+### BF013 — Reactive Primitive Called Through a Namespace Import
+
+**Trigger:** A reactive primitive (`createSignal`, `createMemo`, `createEffect`, `onMount`, `onCleanup`, `createSearchParams`) invoked through a namespace import of `@barefootjs/client` (`import * as ns from '@barefootjs/client'`) that the analyzer could not resolve. Without a shared `ts.Program` (`CompileOptions.program`), the analyzer's fast path only recognizes a bare identifier callee — `ns.createSignal(...)` is dropped from the compiled output, and every reference to it throws `ReferenceError` at hydrate.
+
+```tsx
+'use client'
+// ❌ BF013 — namespace-qualified call is not recognized
+import * as bf from '@barefootjs/client'
+export function Counter() {
+  const [count, setCount] = bf.createSignal(0)
+  return <button onClick={() => setCount(count() + 1)}>{count()}</button>
+}
+```
+
+**Fix:** Import the primitive by name instead of through the namespace.
+
+```tsx
+'use client'
+import { createSignal } from '@barefootjs/client'
+
+export function Counter() {
+  const [count, setCount] = createSignal(0)
+  return <button onClick={() => setCount(count() + 1)}>{count()}</button>
+}
+```
+
+A shared `ts.Program` passed via `CompileOptions.program` (as `@barefootjs/vite` always supplies) lets the analyzer resolve the namespace-qualified form through the TypeScript `TypeChecker` — this diagnostic only fires when no such program is available.
 
 ---
 
@@ -451,6 +483,7 @@ function Component({ checked }: Props) {
 | BF001 | Error | Missing `"use client"` directive |
 | BF003 | Error | Client component importing server component |
 | BF011 | Error | Module-level reactive declaration without `/* @client */` |
+| BF013 | Error | Reactive primitive called through an unresolved namespace import |
 | BF021 | Error | Unsupported JSX pattern for SSR |
 | BF023 | Error | Missing key in list |
 | BF043 | Warning | Props destructuring breaks reactivity |

--- a/packages/adapter-blade/src/conformance-pins.ts
+++ b/packages/adapter-blade/src/conformance-pins.ts
@@ -64,4 +64,11 @@ export const conformancePins: ConformancePins = {
   // `rich-prop-client-read` above.
   'jsx-element-prop-ternary': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2667' }],
   'jsx-element-prop-array': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2667' }],
+  // #2771: a reactive primitive invoked through a namespace import
+  // (`import * as bf from '@barefootjs/client'`, `bf.createSignal(...)`)
+  // that the analyzer's checker-less fast path cannot recognize refuses
+  // loudly (BF013) instead of silently dropping the declaration — fired
+  // in the shared analyzer pass ahead of any adapter's `adapter.generate()`,
+  // so all nine adapters (including Hono) pin this identically.
+  'namespace-import-primitive': [{ code: 'BF013', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2771' }],
 }

--- a/packages/adapter-erb/src/conformance-pins.ts
+++ b/packages/adapter-erb/src/conformance-pins.ts
@@ -56,4 +56,11 @@ export const conformancePins: ConformancePins = {
   // `rich-prop-client-read` above.
   'jsx-element-prop-ternary': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2667' }],
   'jsx-element-prop-array': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2667' }],
+  // #2771: a reactive primitive invoked through a namespace import
+  // (`import * as bf from '@barefootjs/client'`, `bf.createSignal(...)`)
+  // that the analyzer's checker-less fast path cannot recognize refuses
+  // loudly (BF013) instead of silently dropping the declaration — fired
+  // in the shared analyzer pass ahead of any adapter's `adapter.generate()`,
+  // so all nine adapters (including Hono) pin this identically.
+  'namespace-import-primitive': [{ code: 'BF013', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2771' }],
 }

--- a/packages/adapter-go-template/src/conformance-pins.ts
+++ b/packages/adapter-go-template/src/conformance-pins.ts
@@ -88,4 +88,11 @@ export const conformancePins: ConformancePins = {
     severity: 'error',
     issue: 'https://github.com/piconic-ai/barefootjs/issues/2700',
   }],
+  // #2771: a reactive primitive invoked through a namespace import
+  // (`import * as bf from '@barefootjs/client'`, `bf.createSignal(...)`)
+  // that the analyzer's checker-less fast path cannot recognize refuses
+  // loudly (BF013) instead of silently dropping the declaration — fired
+  // in the shared analyzer pass ahead of any adapter's `adapter.generate()`,
+  // so all nine adapters (including Hono) pin this identically.
+  'namespace-import-primitive': [{ code: 'BF013', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2771' }],
 }

--- a/packages/adapter-hono/src/conformance-pins.ts
+++ b/packages/adapter-hono/src/conformance-pins.ts
@@ -21,4 +21,11 @@ export const conformancePins: ConformancePins = {
   // `rich-prop-client-read` above.
   'jsx-element-prop-ternary': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2667' }],
   'jsx-element-prop-array': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2667' }],
+  // #2771: a reactive primitive invoked through a namespace import
+  // (`import * as bf from '@barefootjs/client'`, `bf.createSignal(...)`)
+  // that the analyzer's checker-less fast path cannot recognize refuses
+  // loudly (BF013) instead of silently dropping the declaration — fired
+  // in the shared analyzer pass ahead of any adapter's `adapter.generate()`,
+  // so all nine adapters (including Hono) pin this identically.
+  'namespace-import-primitive': [{ code: 'BF013', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2771' }],
 }

--- a/packages/adapter-jinja/src/conformance-pins.ts
+++ b/packages/adapter-jinja/src/conformance-pins.ts
@@ -63,4 +63,11 @@ export const conformancePins: ConformancePins = {
   // `rich-prop-client-read` above.
   'jsx-element-prop-ternary': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2667' }],
   'jsx-element-prop-array': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2667' }],
+  // #2771: a reactive primitive invoked through a namespace import
+  // (`import * as bf from '@barefootjs/client'`, `bf.createSignal(...)`)
+  // that the analyzer's checker-less fast path cannot recognize refuses
+  // loudly (BF013) instead of silently dropping the declaration — fired
+  // in the shared analyzer pass ahead of any adapter's `adapter.generate()`,
+  // so all nine adapters (including Hono) pin this identically.
+  'namespace-import-primitive': [{ code: 'BF013', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2771' }],
 }

--- a/packages/adapter-mojolicious/src/conformance-pins.ts
+++ b/packages/adapter-mojolicious/src/conformance-pins.ts
@@ -56,4 +56,11 @@ export const conformancePins: ConformancePins = {
   // `rich-prop-client-read` above.
   'jsx-element-prop-ternary': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2667' }],
   'jsx-element-prop-array': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2667' }],
+  // #2771: a reactive primitive invoked through a namespace import
+  // (`import * as bf from '@barefootjs/client'`, `bf.createSignal(...)`)
+  // that the analyzer's checker-less fast path cannot recognize refuses
+  // loudly (BF013) instead of silently dropping the declaration — fired
+  // in the shared analyzer pass ahead of any adapter's `adapter.generate()`,
+  // so all nine adapters (including Hono) pin this identically.
+  'namespace-import-primitive': [{ code: 'BF013', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2771' }],
 }

--- a/packages/adapter-rust/src/conformance-pins.ts
+++ b/packages/adapter-rust/src/conformance-pins.ts
@@ -64,4 +64,11 @@ export const conformancePins: ConformancePins = {
   // `rich-prop-client-read` above.
   'jsx-element-prop-ternary': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2667' }],
   'jsx-element-prop-array': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2667' }],
+  // #2771: a reactive primitive invoked through a namespace import
+  // (`import * as bf from '@barefootjs/client'`, `bf.createSignal(...)`)
+  // that the analyzer's checker-less fast path cannot recognize refuses
+  // loudly (BF013) instead of silently dropping the declaration — fired
+  // in the shared analyzer pass ahead of any adapter's `adapter.generate()`,
+  // so all nine adapters (including Hono) pin this identically.
+  'namespace-import-primitive': [{ code: 'BF013', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2771' }],
 }

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -3631,6 +3631,29 @@
         "text"
       ]
     },
+    "namespace-import-primitive": {
+      "kinds": [
+        "call",
+        "identifier"
+      ],
+      "axes": [],
+      "contexts": [
+        "text"
+      ]
+    },
+    "namespace-import-primitive-named-escape": {
+      "kinds": [
+        "call",
+        "identifier",
+        "literal"
+      ],
+      "axes": [
+        "literal:number"
+      ],
+      "contexts": [
+        "text"
+      ]
+    },
     "native-select-spread-children": {
       "kinds": [
         "identifier"
@@ -5835,11 +5858,11 @@
     "array-method": 71,
     "arrow": 71,
     "binary": 94,
-    "call": 241,
+    "call": 243,
     "conditional": 27,
-    "identifier": 342,
+    "identifier": 344,
     "index-access": 14,
-    "literal": 273,
+    "literal": 274,
     "logical": 47,
     "member": 196,
     "object-literal": 67,
@@ -5884,7 +5907,7 @@
     "binary:>=": 1,
     "literal:boolean": 59,
     "literal:null": 23,
-    "literal:number": 115,
+    "literal:number": 116,
     "literal:string": 191,
     "logical:&&": 7,
     "logical:??": 41,

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -186,6 +186,8 @@ import { fixture as eventHandlers } from './event-handlers'
 import { fixture as defaultProps } from './default-props'
 import { fixture as untypedPropsReads } from './untyped-props-reads'
 import { fixture as bareTextOptionalScalar } from './bare-text-optional-scalar'
+import { fixture as namespaceImportPrimitive } from './namespace-import-primitive'
+import { fixture as namespaceImportPrimitiveNamedEscape } from './namespace-import-primitive-named-escape'
 import { fixture as nullishCoalescingText } from './nullish-coalescing-text'
 import { fixture as nullishCoalescingDestructured } from './nullish-coalescing-destructured'
 import { fixture as nullishCoalescingJsx } from './nullish-coalescing-jsx'
@@ -695,6 +697,8 @@ export const jsxFixtures: JSXFixture[] = [
   defaultProps,
   untypedPropsReads,
   bareTextOptionalScalar,
+  namespaceImportPrimitive,
+  namespaceImportPrimitiveNamedEscape,
   nullishCoalescingText,
   nullishCoalescingDestructured,
   nullishCoalescingJsx,

--- a/packages/adapter-tests/fixtures/namespace-import-primitive-named-escape.ts
+++ b/packages/adapter-tests/fixtures/namespace-import-primitive-named-escape.ts
@@ -1,0 +1,24 @@
+import { createFixture } from '../src/types'
+
+/**
+ * `escapes` twin of `namespace-import-primitive` (#2771, BF013) — the
+ * same component with `createSignal` imported by NAME instead of through
+ * a `@barefootjs/client` namespace import, which resolves via
+ * `resolvePrimitiveKind`'s ordinary fast path and compiles/renders
+ * identically to Hono on every adapter.
+ */
+export const fixture = createFixture({
+  id: 'namespace-import-primitive-named-escape',
+  description: 'A named import of the reactive primitive (the BF013 escape) compiles and renders correctly',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function NamespaceImportPrimitiveNamedEscape() {
+  const [count, setCount] = createSignal(0)
+  return <button onClick={() => setCount(count() + 1)}>{count()}</button>
+}
+`,
+  expectedHtml: `
+    <button bf-s="test" bf="s1"><!--bf:s0-->0<!--/--></button>
+  `,
+})

--- a/packages/adapter-tests/fixtures/namespace-import-primitive.ts
+++ b/packages/adapter-tests/fixtures/namespace-import-primitive.ts
@@ -1,0 +1,43 @@
+import { createFixture } from '../src/types'
+
+/**
+ * #2771 — a reactive primitive invoked through a namespace import
+ * (`import * as bf from '@barefootjs/client'`, `bf.createSignal(...)`)
+ * compiled with ZERO diagnostics before this fixture's fix landed:
+ * `resolvePrimitiveKind`'s fast path only matches a bare identifier
+ * callee, and its checker-based slow path (which DOES resolve this
+ * shape) only runs when a shared `ts.Program` is supplied
+ * (`CompileOptions.program`) — this compile has none. The declaration
+ * was silently dropped from `ctx.signals`, so the compiled client JS
+ * never declared `n`/`setN` while every reference to them survived,
+ * throwing `ReferenceError` at hydrate.
+ *
+ * Refused loudly instead (BF013), fired in the shared analyzer pass
+ * ahead of any adapter's `adapter.generate()` — mirrors
+ * `jsx-element-prop-ternary`'s reasoning, so all nine adapters
+ * (including Hono) pin this identically in their own
+ * `conformance-pins.ts`.
+ *
+ * IMPORTANT for anyone editing this fixture: it must stay free of
+ * `.map(`, `createSelector`, and `@barefootjs/form` — any of those makes
+ * the compiler's `needsTypeBasedDetection` build a per-file `ts.Program`
+ * for OTHER reasons, which would make the checker's slow path resolve
+ * this shape correctly and the pinned BF013 refusal would stop firing.
+ *
+ * `escapes` twin: `namespace-import-primitive-named-escape` — the SAME
+ * component with the primitive imported by name instead of through the
+ * namespace, which resolves via the ordinary fast path.
+ */
+export const fixture = createFixture({
+  id: 'namespace-import-primitive',
+  description: 'A reactive primitive called through a namespace import refuses with BF013',
+  source: `
+'use client'
+import * as bf from '@barefootjs/client'
+export function NamespaceImportPrimitive() {
+  const [count, setCount] = bf.createSignal(0)
+  return <button onClick={() => setCount(count() + 1)}>{count()}</button>
+}
+`,
+  escapes: [{ kind: 'rewrite', fixture: 'namespace-import-primitive-named-escape' }],
+})

--- a/packages/adapter-twig/src/conformance-pins.ts
+++ b/packages/adapter-twig/src/conformance-pins.ts
@@ -63,4 +63,11 @@ export const conformancePins: ConformancePins = {
   // `rich-prop-client-read` above.
   'jsx-element-prop-ternary': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2667' }],
   'jsx-element-prop-array': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2667' }],
+  // #2771: a reactive primitive invoked through a namespace import
+  // (`import * as bf from '@barefootjs/client'`, `bf.createSignal(...)`)
+  // that the analyzer's checker-less fast path cannot recognize refuses
+  // loudly (BF013) instead of silently dropping the declaration — fired
+  // in the shared analyzer pass ahead of any adapter's `adapter.generate()`,
+  // so all nine adapters (including Hono) pin this identically.
+  'namespace-import-primitive': [{ code: 'BF013', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2771' }],
 }

--- a/packages/adapter-xslate/src/conformance-pins.ts
+++ b/packages/adapter-xslate/src/conformance-pins.ts
@@ -63,4 +63,11 @@ export const conformancePins: ConformancePins = {
   // `rich-prop-client-read` above.
   'jsx-element-prop-ternary': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2667' }],
   'jsx-element-prop-array': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2667' }],
+  // #2771: a reactive primitive invoked through a namespace import
+  // (`import * as bf from '@barefootjs/client'`, `bf.createSignal(...)`)
+  // that the analyzer's checker-less fast path cannot recognize refuses
+  // loudly (BF013) instead of silently dropping the declaration — fired
+  // in the shared analyzer pass ahead of any adapter's `adapter.generate()`,
+  // so all nine adapters (including Hono) pin this identically.
+  'namespace-import-primitive': [{ code: 'BF013', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2771' }],
 }

--- a/packages/jsx/src/__tests__/namespace-import-primitive.test.ts
+++ b/packages/jsx/src/__tests__/namespace-import-primitive.test.ts
@@ -92,6 +92,30 @@ describe('#2771 — BF013: reactive primitive called through an unresolved names
     expect(err).toBeDefined()
   })
 
+  test('bf.onCleanup(...) (expression statement) fires BF013', () => {
+    const err = bf013(`
+      'use client'
+      import * as bf from '@barefootjs/client'
+      export function Counter() {
+        bf.onCleanup(() => { console.log('cleaned up') })
+        return <div>static</div>
+      }
+    `)
+    expect(err).toBeDefined()
+  })
+
+  test('bf.createSearchParams(...) (array destructure) fires BF013', () => {
+    const err = bf013(`
+      'use client'
+      import * as bf from '@barefootjs/client'
+      export function Counter() {
+        const [searchParams] = bf.createSearchParams()
+        return <div>{searchParams().get('sort')}</div>
+      }
+    `)
+    expect(err).toBeDefined()
+  })
+
   test('bf.createSignal(0)[0] (element access) fires BF013', () => {
     const err = bf013(`
       'use client'

--- a/packages/jsx/src/__tests__/namespace-import-primitive.test.ts
+++ b/packages/jsx/src/__tests__/namespace-import-primitive.test.ts
@@ -1,0 +1,220 @@
+/**
+ * #2771 — `import * as bf from '@barefootjs/client'` followed by
+ * `bf.createSignal(0)` (or any other reactive primitive accessed off the
+ * namespace binding) compiled with ZERO diagnostics, but `resolvePrimitiveKind`'s
+ * fast path only matches a bare identifier callee — the checker-based slow
+ * path that DOES understand a namespace-qualified call only runs when a
+ * shared `ts.Program` is supplied (`CompileOptions.program`). Without one,
+ * the declaration is silently dropped from the compiled output and every
+ * reference to it throws `ReferenceError` at hydrate.
+ *
+ * BF013 refuses loudly instead, gated on NON-recognition — a compile that
+ * DOES supply a program (see `primitive-resolver-alias.test.ts`'s pattern)
+ * must never see this diagnostic, since that path already lowers the shape
+ * correctly.
+ */
+import { describe, test, expect } from 'bun:test'
+import path from 'path'
+import ts from 'typescript'
+import { compileJSX } from '../compiler'
+import { analyzeComponent } from '../index'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+function errorsFor(source: string): Array<{ code?: string; severity: string }> {
+  const result = compileJSX(source, 'Counter.tsx', { adapter })
+  return result.errors.map(e => ({ code: e.code, severity: e.severity }))
+}
+
+function bf013(source: string) {
+  return errorsFor(source).find(e => e.code === 'BF013')
+}
+
+describe('#2771 — BF013: reactive primitive called through an unresolved namespace import', () => {
+  test('bf.createSignal(...) (array destructure) fires BF013', () => {
+    const result = compileJSX(
+      `
+      'use client'
+      import * as bf from '@barefootjs/client'
+      export function Counter() {
+        const [n, setN] = bf.createSignal(0)
+        return <button onClick={() => setN(n() + 1)}>{n()}</button>
+      }
+    `,
+      'Counter.tsx',
+      { adapter },
+    )
+    const err = result.errors.find(e => e.code === 'BF013')
+    expect(err).toBeDefined()
+    expect(err!.severity).toBe('error')
+    expect(err!.message).toContain('bf.createSignal')
+    expect(err!.suggestion?.escape).toEqual([{ kind: 'rewrite' }])
+  })
+
+  test('bf.createMemo(...) (array destructure) fires BF013', () => {
+    const err = bf013(`
+      'use client'
+      import * as bf from '@barefootjs/client'
+      import { createSignal } from '@barefootjs/client'
+      export function Counter() {
+        const [n] = createSignal(1)
+        const [doubled] = bf.createMemo(() => n() * 2)
+        return <div>{doubled()}</div>
+      }
+    `)
+    expect(err).toBeDefined()
+  })
+
+  test('bf.createEffect(...) (expression statement) fires BF013', () => {
+    const err = bf013(`
+      'use client'
+      import * as bf from '@barefootjs/client'
+      import { createSignal } from '@barefootjs/client'
+      export function Counter() {
+        const [n] = createSignal(0)
+        bf.createEffect(() => { console.log(n()) })
+        return <div>{n()}</div>
+      }
+    `)
+    expect(err).toBeDefined()
+  })
+
+  test('bf.onMount(...) (expression statement) fires BF013', () => {
+    const err = bf013(`
+      'use client'
+      import * as bf from '@barefootjs/client'
+      export function Counter() {
+        bf.onMount(() => { console.log('mounted') })
+        return <div>static</div>
+      }
+    `)
+    expect(err).toBeDefined()
+  })
+
+  test('bf.createSignal(0)[0] (element access) fires BF013', () => {
+    const err = bf013(`
+      'use client'
+      import * as bf from '@barefootjs/client'
+      export function Counter() {
+        const n = bf.createSignal(0)[0]
+        return <div>{n()}</div>
+      }
+    `)
+    expect(err).toBeDefined()
+  })
+
+  test('a bare named import is unaffected (no BF013)', () => {
+    const errs = errorsFor(`
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+      export function Counter() {
+        const [n, setN] = createSignal(0)
+        return <button onClick={() => setN(n() + 1)}>{n()}</button>
+      }
+    `)
+    expect(errs.find(e => e.code === 'BF013')).toBeUndefined()
+  })
+
+  test('a namespace import of a DIFFERENT module is unaffected (no BF013)', () => {
+    const result = compileJSX(
+      `
+      'use client'
+      import * as store from './store'
+      export function Counter() {
+        const [n, setN] = store.createSignal(0)
+        return <button onClick={() => setN(n() + 1)}>{n()}</button>
+      }
+    `,
+      'Counter.tsx',
+      { adapter },
+    )
+    expect(result.errors.find(e => e.code === 'BF013')).toBeUndefined()
+  })
+
+  test('a component-local binding shadowing the namespace name is unaffected (no BF013)', () => {
+    const result = compileJSX(
+      `
+      'use client'
+      import * as bf from '@barefootjs/client'
+      export function Counter() {
+        const bf = { createSignal: (x: number) => [() => x, (v: number) => {}] as const }
+        const [n, setN] = bf.createSignal(0)
+        return <button onClick={() => setN(n() + 1)}>{n()}</button>
+      }
+    `,
+      'Counter.tsx',
+      { adapter },
+    )
+    expect(result.errors.find(e => e.code === 'BF013')).toBeUndefined()
+  })
+
+  test('a type-only namespace import is unaffected (no BF013)', () => {
+    const result = compileJSX(
+      `
+      'use client'
+      import type * as bf from '@barefootjs/client'
+      export function Counter() {
+        return <div>static</div>
+      }
+    `,
+      'Counter.tsx',
+      { adapter },
+    )
+    expect(result.errors.find(e => e.code === 'BF013')).toBeUndefined()
+  })
+})
+
+describe('#2771 — checker-path pin: a shared Program resolves the namespace and never fires BF013', () => {
+  const CLIENT_DIR = path.resolve(__dirname, '../../../client/src')
+
+  function programFor(filePath: string, source: string): ts.Program {
+    const absolute = path.resolve(filePath)
+    const compilerOptions: ts.CompilerOptions = {
+      target: ts.ScriptTarget.Latest,
+      module: ts.ModuleKind.ESNext,
+      moduleResolution: ts.ModuleResolutionKind.Bundler,
+      jsx: ts.JsxEmit.ReactJSX,
+      strict: true,
+      skipLibCheck: true,
+      noEmit: true,
+      esModuleInterop: true,
+      baseUrl: path.dirname(absolute),
+    }
+    const defaultHost = ts.createCompilerHost(compilerOptions)
+    const host: ts.CompilerHost = {
+      ...defaultHost,
+      getSourceFile(fileName, languageVersion) {
+        if (path.resolve(fileName) === absolute) {
+          return ts.createSourceFile(fileName, source, languageVersion, true, ts.ScriptKind.TSX)
+        }
+        return defaultHost.getSourceFile(fileName, languageVersion)
+      },
+      fileExists(fileName) {
+        if (path.resolve(fileName) === absolute) return true
+        return defaultHost.fileExists(fileName)
+      },
+      readFile(fileName) {
+        if (path.resolve(fileName) === absolute) return source
+        return defaultHost.readFile(fileName)
+      },
+    }
+    return ts.createProgram([absolute], compilerOptions, host)
+  }
+
+  test('with a shared Program, bf.createSignal resolves and BF013 never fires', () => {
+    const source = `
+      'use client'
+      import * as bf from '@barefootjs/client'
+      export function Counter() {
+        const [n, setN] = bf.createSignal(0)
+        return <button onClick={() => setN(n() + 1)}>{n()}</button>
+      }
+    `
+    const testFile = path.join(CLIENT_DIR, '__ns_primitive_checker_pin__.tsx')
+    const program = programFor(testFile, source)
+    const ctx = analyzeComponent(source, testFile, undefined, program)
+    expect(ctx.signals.length).toBe(1)
+    expect(ctx.errors.find(e => e.code === 'BF013')).toBeUndefined()
+  })
+})

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -3889,6 +3889,11 @@ function validateContext(ctx: AnalyzerContext): void {
   // failures before factory inlining landed (#931).
   validateReactiveFactoryCalls(ctx)
 
+  // BF013: flag a reactive primitive invoked through a namespace import
+  // that the analyzer could not resolve (#2771) — same "silently dropped,
+  // ReferenceError at hydrate" failure shape as BF011.
+  validateNamespaceQualifiedPrimitives(ctx)
+
   // BF003: a `"use client"` file may not import a component from a
   // non-`"use client"` source file (#1501). Server-side knowledge must
   // not transitively cross into the client bundle, and hydration-marker
@@ -5862,6 +5867,116 @@ export function validateReactiveFactoryCalls(ctx: AnalyzerContext): void {
       }
     }
   }
+}
+
+/**
+ * BF013 (#2771): a reactive primitive called through a namespace import
+ * (`import * as bf from '@barefootjs/client'`, `bf.createSignal(...)`)
+ * that `resolvePrimitiveKind`'s checker-based slow path could not resolve
+ * — no shared `ts.Program` was supplied for this compile. Fast-path
+ * recognition only matches a bare identifier callee, so the call is
+ * silently dropped from `ctx.signals`/`ctx.memos`/etc. while every
+ * reference to its result survives in the emitted output, throwing
+ * ReferenceError at hydrate.
+ *
+ * Gated on non-recognition, not on the namespace-import shape itself:
+ * when a checker IS available (vite always supplies one via
+ * `corpus-program.ts`), `resolvePrimitiveKind` already resolves this
+ * shape soundly end-to-end, and this pass must not flag what the
+ * checker-aided path already handles correctly.
+ *
+ * Scoped to the component's own top-level statements, mirroring
+ * `validateReactiveFactoryCalls` above — a namespace-qualified call
+ * inside a handler/effect body is emitted verbatim and runs fine at
+ * hydrate (the namespace import itself is re-emitted, #2767 follow-up),
+ * so walking into nested bodies would produce false refusals.
+ */
+function validateNamespaceQualifiedPrimitives(ctx: AnalyzerContext): void {
+  if (!ctx.componentNode) return
+  const body = ts.isFunctionDeclaration(ctx.componentNode)
+    ? ctx.componentNode.body
+    : (ts.isBlock(ctx.componentNode.body) ? ctx.componentNode.body : null)
+  if (!body) return
+
+  for (const stmt of body.statements) {
+    const calls: ts.CallExpression[] = []
+    if (ts.isVariableStatement(stmt)) {
+      for (const decl of stmt.declarationList.declarations) {
+        let init = decl.initializer
+        // `const [n] = bf.createSignal(0)[0]` — vanishingly rare, but the
+        // element-access wrapper must not hide the call underneath it.
+        if (init && ts.isElementAccessExpression(init)) init = init.expression
+        if (init && ts.isCallExpression(init)) calls.push(init)
+      }
+    } else if (ts.isExpressionStatement(stmt) && ts.isCallExpression(stmt.expression)) {
+      calls.push(stmt.expression) // `bf.createEffect(...)`, `bf.onMount(...)`
+    }
+
+    for (const call of calls) {
+      const callee = call.expression
+      if (!ts.isPropertyAccessExpression(callee) || !ts.isIdentifier(callee.expression)) continue
+      const primitive = callee.name.text
+      if (!(primitive in PRIMITIVE_CANONICAL_NAMES)) continue
+      if (resolvePrimitiveKind(call, ctx) !== null) continue // checker resolved it — sound, no diagnostic
+      const ns = callee.expression.text
+      if (!isClientNamespaceImportName(ns, ctx)) continue // import identity, not the bare name
+      if (isNamespaceNameShadowedAtComponentTopLevel(ns, body, ctx)) continue
+
+      const loc = getSourceLocation(stmt, ctx.sourceFile, ctx.filePath)
+      ctx.errors.push(
+        createError(ErrorCodes.PRIMITIVE_VIA_NAMESPACE_IMPORT, loc, {
+          severity: 'error',
+          message:
+            `'${ns}.${primitive}(...)' calls a @barefootjs/client reactive primitive through the namespace ` +
+            `import 'import * as ${ns}' and was not recognized by the analyzer. The declaration is dropped ` +
+            `from the compiled output and every reference to it throws ReferenceError at hydrate.`,
+          suggestion: {
+            message:
+              `Import the primitive by name: import { ${primitive} } from '@barefootjs/client' and call ` +
+              `${primitive}(...) directly. (A shared ts.Program passed via CompileOptions.program lets the ` +
+              `analyzer resolve the namespace through the TypeChecker; without one the named form is required.)`,
+            escape: [{ kind: 'rewrite' }],
+          },
+        })
+      )
+    }
+  }
+}
+
+/** Is `name` bound to a namespace import of `@barefootjs/client` (`import * as name from '@barefootjs/client'`)? */
+function isClientNamespaceImportName(name: string, ctx: AnalyzerContext): boolean {
+  return ctx.imports.some(
+    imp =>
+      imp.source === '@barefootjs/client' &&
+      !imp.isTypeOnly &&
+      imp.specifiers.some(s => s.isNamespace && s.name === name)
+  )
+}
+
+/**
+ * A component-top-level binding that shadows the namespace import name
+ * (a local `const bf = ...`/function `bf`, or a prop param/props-object
+ * named `bf`) means `bf.createSignal` in THIS component isn't the client
+ * namespace at all — refusing would be a false positive. Does not model a
+ * shadow introduced in a nested block above the call site (same accepted
+ * posture as the checker-aided fast path).
+ */
+function isNamespaceNameShadowedAtComponentTopLevel(
+  name: string,
+  body: ts.Block,
+  ctx: AnalyzerContext
+): boolean {
+  if (ctx.propsObjectName === name) return true
+  if (ctx.propsParams.some(p => p.name === name)) return true
+  for (const stmt of body.statements) {
+    if (ts.isFunctionDeclaration(stmt) && stmt.name?.text === name) return true
+    if (ts.isVariableStatement(stmt)) {
+      for (const decl of stmt.declarationList.declarations) {
+        if (ts.isIdentifier(decl.name) && decl.name.text === name) return true
+      }
+    }
+  }
+  return false
 }
 
 /**

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -5909,7 +5909,7 @@ function validateNamespaceQualifiedPrimitives(ctx: AnalyzerContext): void {
         if (init && ts.isCallExpression(init)) calls.push(init)
       }
     } else if (ts.isExpressionStatement(stmt) && ts.isCallExpression(stmt.expression)) {
-      calls.push(stmt.expression) // `bf.createEffect(...)`, `bf.onMount(...)`
+      calls.push(stmt.expression)
     }
 
     for (const call of calls) {
@@ -5943,7 +5943,6 @@ function validateNamespaceQualifiedPrimitives(ctx: AnalyzerContext): void {
   }
 }
 
-/** Is `name` bound to a namespace import of `@barefootjs/client` (`import * as name from '@barefootjs/client'`)? */
 function isClientNamespaceImportName(name: string, ctx: AnalyzerContext): boolean {
   return ctx.imports.some(
     imp =>

--- a/packages/jsx/src/errors.ts
+++ b/packages/jsx/src/errors.ts
@@ -19,8 +19,18 @@ export const ErrorCodes = {
   MISSING_USE_CLIENT: 'BF001',
   CLIENT_IMPORTING_SERVER: 'BF003',
 
-  // Signal/Memo errors (BF011-BF019)
+  // Signal/Memo errors (BF011-BF019). BF012 is retired (see
+  // `invalid-signal-usage.audit.test.ts`) — BF013 is the next free slot.
   SIGNAL_OUTSIDE_COMPONENT: 'BF011',
+  // A reactive primitive (createSignal/createMemo/createEffect/onMount/
+  // onCleanup/createSearchParams) called through a namespace import
+  // (`import * as bf from '@barefootjs/client'`, `bf.createSignal(...)`)
+  // that the analyzer could not resolve — no shared `ts.Program` was
+  // supplied, so `resolvePrimitiveKind`'s checker-based slow path never
+  // ran. Same failure shape as BF011: the declaration is silently dropped
+  // from the compiled output and every reference to it throws
+  // ReferenceError at hydrate. #2771.
+  PRIMITIVE_VIA_NAMESPACE_IMPORT: 'BF013',
 
   // JSX errors (BF021-BF029). BF022 was retired (see
   // `invalid-jsx-attribute.audit.test.ts`) and BF026 is reserved by
@@ -150,6 +160,9 @@ const errorMessages: Record<ErrorCode, string> = {
     'Module-level reactive declaration (createSignal / createMemo) is not allowed. ' +
     'The downstream codegen drops the declaration silently and every reference becomes a ReferenceError at SSR and at hydrate. ' +
     'Move the declaration inside a component function so each mount gets its own state.',
+  [ErrorCodes.PRIMITIVE_VIA_NAMESPACE_IMPORT]:
+    "Reactive primitive called through a namespace import of '@barefootjs/client' (import * as ns) is not recognized; " +
+    'the declaration is dropped and its references throw ReferenceError at hydrate. Import the primitive by name instead.',
 
   [ErrorCodes.UNSUPPORTED_JSX_PATTERN]: 'Unsupported JSX pattern',
   [ErrorCodes.MISSING_KEY_IN_LIST]:

--- a/spec/compiler.md
+++ b/spec/compiler.md
@@ -860,6 +860,7 @@ symbol of each JSX tag through to the resolver; tracked as a follow-up.
 | BF001 | Missing 'use client' directive |
 | BF003 | Client component importing server component |
 | BF011 | Module-level reactive declaration without `/* @client */` |
+| BF013 | Reactive primitive (createSignal/createMemo/createEffect/onMount/onCleanup/createSearchParams) called through a namespace import of `@barefootjs/client` (`import * as ns from '@barefootjs/client'`) the analyzer could not resolve — only fires when no shared `ts.Program` was supplied (#2771) |
 | BF021 | Unsupported JSX pattern (e.g., filter predicate or sort comparator too complex for template compilation; method call on a host rich-typed prop with no catalogued lowering, #2273; a ternary or array literal wrapping JSX at a non-`children` component prop position, #2667) |
 | BF023 | Missing `key` attribute in `.map()` loop — root JSX element has no `key` prop |
 | BF024 | Missing `key` attribute in nested `.map()` loop — inner loop root JSX element has no `key` prop |

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-conformance section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. This answers, per fixture and per adapter, whether the construct WORKS — not just whether it compiles. A construct works either as written (✓) or with a documented `/* @client */` comment (✓†, a verified, supported escape — most refusals have one). Fixtures absent from the table below work on every adapter — most as written, some via that documented escape; the headline says how many of each. Listed fixtures need attention somewhere: a bare diagnostic code is still-open debt with no escape yet, a code led by ✗ owes no escape at all (by design), and ≠ means the fixture compiles clean but its rendered output diverges from the reference.",
-    "totalFixtures": 364,
+    "totalFixtures": 366,
     "fixtures": {
       "aliased-import-child-component": {
         "blade": {
@@ -2917,6 +2917,89 @@
           }
         }
       },
+      "namespace-import-primitive": {
+        "blade": {
+          "kind": "refusal",
+          "codes": [
+            "BF013"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2771"
+          ]
+        },
+        "erb": {
+          "kind": "refusal",
+          "codes": [
+            "BF013"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2771"
+          ]
+        },
+        "go-template": {
+          "kind": "refusal",
+          "codes": [
+            "BF013"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2771"
+          ]
+        },
+        "hono": {
+          "kind": "refusal",
+          "codes": [
+            "BF013"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2771"
+          ]
+        },
+        "jinja": {
+          "kind": "refusal",
+          "codes": [
+            "BF013"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2771"
+          ]
+        },
+        "minijinja": {
+          "kind": "refusal",
+          "codes": [
+            "BF013"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2771"
+          ]
+        },
+        "mojolicious": {
+          "kind": "refusal",
+          "codes": [
+            "BF013"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2771"
+          ]
+        },
+        "twig": {
+          "kind": "refusal",
+          "codes": [
+            "BF013"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2771"
+          ]
+        },
+        "xslate": {
+          "kind": "refusal",
+          "codes": [
+            "BF013"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2771"
+          ]
+        }
+      },
       "preamble-cells": {
         "blade": {
           "kind": "refusal",
@@ -3702,6 +3785,10 @@
       "map-array-builder-escaping": {
         "description": "special characters in array-builder leaf text escape identically at SSR and CSR",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/map-array-builder-escaping.ts"
+      },
+      "namespace-import-primitive": {
+        "description": "A reactive primitive called through a namespace import refuses with BF013",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/namespace-import-primitive.ts"
       },
       "preamble-cells": {
         "description": "keyed .map() row with a preamble-built leaf child — patched in place on same-key update, not frozen",

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -1450,23 +1450,29 @@
       }
     },
     "call": {
-      "total": 241,
+      "total": 243,
       "cells": {
         "hono": {
-          "pass": 240,
-          "total": 241,
+          "pass": 241,
+          "total": 243,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2356"
               ]
+            },
+            {
+              "fixture": "namespace-import-primitive",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2771"
+              ]
             }
           ]
         },
         "blade": {
-          "pass": 224,
-          "total": 241,
+          "pass": 225,
+          "total": 243,
           "gaps": [
             {
               "fixture": "aliased-import-child-component",
@@ -1513,6 +1519,12 @@
             {
               "fixture": "flatmap-typeof-projection",
               "issues": []
+            },
+            {
+              "fixture": "namespace-import-primitive",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2771"
+              ]
             },
             {
               "fixture": "preamble-cells",
@@ -1549,8 +1561,8 @@
           ]
         },
         "erb": {
-          "pass": 225,
-          "total": 241,
+          "pass": 226,
+          "total": 243,
           "gaps": [
             {
               "fixture": "aliased-import-child-component",
@@ -1593,6 +1605,12 @@
               "issues": []
             },
             {
+              "fixture": "namespace-import-primitive",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2771"
+              ]
+            },
+            {
               "fixture": "preamble-cells",
               "issues": []
             },
@@ -1627,8 +1645,8 @@
           ]
         },
         "go-template": {
-          "pass": 223,
-          "total": 241,
+          "pass": 224,
+          "total": 243,
           "gaps": [
             {
               "fixture": "aliased-import-child-component",
@@ -1675,6 +1693,12 @@
             {
               "fixture": "flatmap-typeof-projection",
               "issues": []
+            },
+            {
+              "fixture": "namespace-import-primitive",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2771"
+              ]
             },
             {
               "fixture": "preamble-cells",
@@ -1717,8 +1741,8 @@
           ]
         },
         "jinja": {
-          "pass": 224,
-          "total": 241,
+          "pass": 225,
+          "total": 243,
           "gaps": [
             {
               "fixture": "aliased-import-child-component",
@@ -1765,6 +1789,12 @@
             {
               "fixture": "flatmap-typeof-projection",
               "issues": []
+            },
+            {
+              "fixture": "namespace-import-primitive",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2771"
+              ]
             },
             {
               "fixture": "preamble-cells",
@@ -1801,8 +1831,8 @@
           ]
         },
         "minijinja": {
-          "pass": 224,
-          "total": 241,
+          "pass": 225,
+          "total": 243,
           "gaps": [
             {
               "fixture": "aliased-import-child-component",
@@ -1849,6 +1879,12 @@
             {
               "fixture": "flatmap-typeof-projection",
               "issues": []
+            },
+            {
+              "fixture": "namespace-import-primitive",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2771"
+              ]
             },
             {
               "fixture": "preamble-cells",
@@ -1885,8 +1921,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 225,
-          "total": 241,
+          "pass": 226,
+          "total": 243,
           "gaps": [
             {
               "fixture": "aliased-import-child-component",
@@ -1927,6 +1963,12 @@
             {
               "fixture": "flatmap-typeof-projection",
               "issues": []
+            },
+            {
+              "fixture": "namespace-import-primitive",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2771"
+              ]
             },
             {
               "fixture": "preamble-cells",
@@ -1963,8 +2005,8 @@
           ]
         },
         "twig": {
-          "pass": 224,
-          "total": 241,
+          "pass": 225,
+          "total": 243,
           "gaps": [
             {
               "fixture": "aliased-import-child-component",
@@ -2011,6 +2053,12 @@
             {
               "fixture": "flatmap-typeof-projection",
               "issues": []
+            },
+            {
+              "fixture": "namespace-import-primitive",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2771"
+              ]
             },
             {
               "fixture": "preamble-cells",
@@ -2047,8 +2095,8 @@
           ]
         },
         "xslate": {
-          "pass": 224,
-          "total": 241,
+          "pass": 225,
+          "total": 243,
           "gaps": [
             {
               "fixture": "aliased-import-child-component",
@@ -2095,6 +2143,12 @@
             {
               "fixture": "flatmap-typeof-projection",
               "issues": []
+            },
+            {
+              "fixture": "namespace-import-primitive",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2771"
+              ]
             },
             {
               "fixture": "preamble-cells",
@@ -2276,11 +2330,11 @@
       }
     },
     "identifier": {
-      "total": 342,
+      "total": 344,
       "cells": {
         "hono": {
-          "pass": 339,
-          "total": 342,
+          "pass": 340,
+          "total": 344,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2299,12 +2353,18 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2667"
               ]
+            },
+            {
+              "fixture": "namespace-import-primitive",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2771"
+              ]
             }
           ]
         },
         "blade": {
-          "pass": 321,
-          "total": 342,
+          "pass": 322,
+          "total": 344,
           "gaps": [
             {
               "fixture": "aliased-import-child-component",
@@ -2373,6 +2433,12 @@
               "issues": []
             },
             {
+              "fixture": "namespace-import-primitive",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2771"
+              ]
+            },
+            {
               "fixture": "preamble-cells",
               "issues": []
             },
@@ -2407,8 +2473,8 @@
           ]
         },
         "erb": {
-          "pass": 322,
-          "total": 342,
+          "pass": 323,
+          "total": 344,
           "gaps": [
             {
               "fixture": "aliased-import-child-component",
@@ -2471,6 +2537,12 @@
               "issues": []
             },
             {
+              "fixture": "namespace-import-primitive",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2771"
+              ]
+            },
+            {
               "fixture": "preamble-cells",
               "issues": []
             },
@@ -2505,8 +2577,8 @@
           ]
         },
         "go-template": {
-          "pass": 318,
-          "total": 342,
+          "pass": 319,
+          "total": 344,
           "gaps": [
             {
               "fixture": "aliased-import-child-component",
@@ -2585,6 +2657,12 @@
               "issues": []
             },
             {
+              "fixture": "namespace-import-primitive",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2771"
+              ]
+            },
+            {
               "fixture": "preamble-cells",
               "issues": []
             },
@@ -2625,8 +2703,8 @@
           ]
         },
         "jinja": {
-          "pass": 321,
-          "total": 342,
+          "pass": 322,
+          "total": 344,
           "gaps": [
             {
               "fixture": "aliased-import-child-component",
@@ -2693,6 +2771,12 @@
             {
               "fixture": "map-array-builder-escaping",
               "issues": []
+            },
+            {
+              "fixture": "namespace-import-primitive",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2771"
+              ]
             },
             {
               "fixture": "preamble-cells",
@@ -2729,8 +2813,8 @@
           ]
         },
         "minijinja": {
-          "pass": 321,
-          "total": 342,
+          "pass": 322,
+          "total": 344,
           "gaps": [
             {
               "fixture": "aliased-import-child-component",
@@ -2799,6 +2883,12 @@
               "issues": []
             },
             {
+              "fixture": "namespace-import-primitive",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2771"
+              ]
+            },
+            {
               "fixture": "preamble-cells",
               "issues": []
             },
@@ -2833,8 +2923,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 321,
-          "total": 342,
+          "pass": 322,
+          "total": 344,
           "gaps": [
             {
               "fixture": "aliased-import-child-component",
@@ -2901,6 +2991,12 @@
               "issues": []
             },
             {
+              "fixture": "namespace-import-primitive",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2771"
+              ]
+            },
+            {
               "fixture": "preamble-cells",
               "issues": []
             },
@@ -2935,8 +3031,8 @@
           ]
         },
         "twig": {
-          "pass": 321,
-          "total": 342,
+          "pass": 322,
+          "total": 344,
           "gaps": [
             {
               "fixture": "aliased-import-child-component",
@@ -3003,6 +3099,12 @@
             {
               "fixture": "map-array-builder-escaping",
               "issues": []
+            },
+            {
+              "fixture": "namespace-import-primitive",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2771"
+              ]
             },
             {
               "fixture": "preamble-cells",
@@ -3039,8 +3141,8 @@
           ]
         },
         "xslate": {
-          "pass": 321,
-          "total": 342,
+          "pass": 322,
+          "total": 344,
           "gaps": [
             {
               "fixture": "aliased-import-child-component",
@@ -3107,6 +3209,12 @@
             {
               "fixture": "map-array-builder-escaping",
               "issues": []
+            },
+            {
+              "fixture": "namespace-import-primitive",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2771"
+              ]
             },
             {
               "fixture": "preamble-cells",
@@ -3208,11 +3316,11 @@
       }
     },
     "literal": {
-      "total": 273,
+      "total": 274,
       "cells": {
         "hono": {
-          "pass": 272,
-          "total": 273,
+          "pass": 273,
+          "total": 274,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -3223,8 +3331,8 @@
           ]
         },
         "blade": {
-          "pass": 259,
-          "total": 273,
+          "pass": 260,
+          "total": 274,
           "gaps": [
             {
               "fixture": "aliased-import-child-component",
@@ -3289,8 +3397,8 @@
           ]
         },
         "erb": {
-          "pass": 259,
-          "total": 273,
+          "pass": 260,
+          "total": 274,
           "gaps": [
             {
               "fixture": "aliased-import-child-component",
@@ -3355,8 +3463,8 @@
           ]
         },
         "go-template": {
-          "pass": 257,
-          "total": 273,
+          "pass": 258,
+          "total": 274,
           "gaps": [
             {
               "fixture": "aliased-import-child-component",
@@ -3433,8 +3541,8 @@
           ]
         },
         "jinja": {
-          "pass": 259,
-          "total": 273,
+          "pass": 260,
+          "total": 274,
           "gaps": [
             {
               "fixture": "aliased-import-child-component",
@@ -3499,8 +3607,8 @@
           ]
         },
         "minijinja": {
-          "pass": 259,
-          "total": 273,
+          "pass": 260,
+          "total": 274,
           "gaps": [
             {
               "fixture": "aliased-import-child-component",
@@ -3565,8 +3673,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 259,
-          "total": 273,
+          "pass": 260,
+          "total": 274,
           "gaps": [
             {
               "fixture": "aliased-import-child-component",
@@ -3631,8 +3739,8 @@
           ]
         },
         "twig": {
-          "pass": 259,
-          "total": 273,
+          "pass": 260,
+          "total": 274,
           "gaps": [
             {
               "fixture": "aliased-import-child-component",
@@ -3697,8 +3805,8 @@
           ]
         },
         "xslate": {
-          "pass": 259,
-          "total": 273,
+          "pass": 260,
+          "total": 274,
           "gaps": [
             {
               "fixture": "aliased-import-child-component",
@@ -8211,15 +8319,15 @@
       }
     },
     "literal:number": {
-      "total": 115,
+      "total": 116,
       "cells": {
         "hono": {
-          "pass": 115,
-          "total": 115
+          "pass": 116,
+          "total": 116
         },
         "blade": {
-          "pass": 109,
-          "total": 115,
+          "pass": 110,
+          "total": 116,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -8248,8 +8356,8 @@
           ]
         },
         "erb": {
-          "pass": 109,
-          "total": 115,
+          "pass": 110,
+          "total": 116,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -8278,8 +8386,8 @@
           ]
         },
         "go-template": {
-          "pass": 109,
-          "total": 115,
+          "pass": 110,
+          "total": 116,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -8308,8 +8416,8 @@
           ]
         },
         "jinja": {
-          "pass": 109,
-          "total": 115,
+          "pass": 110,
+          "total": 116,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -8338,8 +8446,8 @@
           ]
         },
         "minijinja": {
-          "pass": 109,
-          "total": 115,
+          "pass": 110,
+          "total": 116,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -8368,8 +8476,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 109,
-          "total": 115,
+          "pass": 110,
+          "total": 116,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -8398,8 +8506,8 @@
           ]
         },
         "twig": {
-          "pass": 109,
-          "total": 115,
+          "pass": 110,
+          "total": 116,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -8428,8 +8536,8 @@
           ]
         },
         "xslate": {
-          "pass": 109,
-          "total": 115,
+          "pass": 110,
+          "total": 116,
           "gaps": [
             {
               "fixture": "aliased-loop-source",


### PR DESCRIPTION
## Summary

- `import * as bf from '@barefootjs/client'` followed by `bf.createSignal(0)` (or any other reactive primitive — `createMemo`/`createEffect`/`onMount`/`onCleanup`/`createSearchParams` — accessed off the namespace binding) compiled with zero diagnostics. `resolvePrimitiveKind`'s fast path only matches a bare identifier callee; its checker-based slow path, which DOES resolve a namespace-qualified call, only runs when a shared `ts.Program` is supplied via `CompileOptions.program` (which `@barefootjs/vite` always provides, but a bare `compileJSX` call — the adapter-conformance runner, `packages/compat`'s engine — does not). Without one, the declaration was silently dropped from `ctx.signals`/etc. while every reference to it survived in the emitted output, throwing `ReferenceError` at hydrate.
- New `BF013` diagnostic (`validateNamespaceQualifiedPrimitives`, `analyzer.ts`, wired into `validateContext` right after the existing BF110 pass) refuses loudly instead — gated on **non-recognition**, not on the namespace-import shape itself, so a compile that DOES supply a program is completely untouched (pinned by a dedicated checker-path test using the same `programFor` harness as `primitive-resolver-alias.test.ts`).
- False-positive guards: a namespace import of a different module, a component-local binding that shadows the namespace name, and a type-only namespace import are all confirmed unaffected.
- Suggests importing the primitive by name as the fix (`suggestion.escape: [{ kind: 'rewrite' }]` — a named import genuinely resolves this, unlike a `/* @client */` escape which wouldn't help here).
- Adds the `namespace-import-primitive` fixture (refused ahead of any adapter's `generate()`, so pinned identically across all nine adapters — the same reasoning as `jsx-element-prop-ternary`'s BF021) and its named-import escape twin `namespace-import-primitive-named-escape`.
- Docs: new `### BF013` section + quick-reference row in `docs/core/advanced/error-codes.md` (renamed the surrounding `## Signal Errors` heading to `BF011–BF013`), and a table row in `spec/compiler.md`.

## Test plan

- [x] New `packages/jsx/src/__tests__/namespace-import-primitive.test.ts`: `bf.createSignal`/`bf.createMemo`/`bf.createEffect`/`bf.onMount`/`bf.createSignal(0)[0]` all fire BF013; a bare named import, a namespace import of an unrelated module, a component-local shadow of the namespace name, and a type-only namespace import all do NOT fire it; a shared-`ts.Program` compile resolves the signal and never fires BF013.
- [x] `namespace-import-primitive` / `namespace-import-primitive-named-escape` fixtures: all nine adapters' conformance suites pass (the refused fixture correctly skips via each adapter's new `conformancePins` entry; the escape twin's `expectedHtml`, regenerated from Hono, renders correctly everywhere).
- [x] `docs/core/advanced/error-codes.md`'s own per-`BFxxx` doc-example matcher test passes for the new BF013 section.
- [x] Full `packages/jsx` test suite: 3242 pass, 0 fail.
- [x] `bun test packages/compat`: 542 pass, 0 fail.
- [x] `bun run compat:lock` / `bun run support-matrix:lock` / `coverage-map.ts` regenerated after rebuilding all adapter packages.

Stacked on #2824 (`claude/fix-2719-todo-app-client-placeholder-reclassify`), which stacks on #2823 → #2821 → #2820 → #2819 → #2818 → #2817 → #2816 → #2814 → #2812 → #2811, per the ongoing bug-fix marathon in piconic-ai/barefootjs.

Closes #2771.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198yG2px5ygfvmdoMkhRS13

---
_Generated by [Claude Code](https://claude.ai/code/session_0198yG2px5ygfvmdoMkhRS13)_