### PR TITLE
Fix CI flake: date-lowering.test.ts leaked the built-in 'date' plugin out of the shared registry

### DIFF
--- a/packages/jsx/src/__tests__/date-lowering.test.ts
+++ b/packages/jsx/src/__tests__/date-lowering.test.ts
@@ -7,12 +7,12 @@
  * also fire BF021, while an un-catalogued Date method on the same receiver
  * still does.
  */
-import { describe, test, expect, afterEach } from 'bun:test'
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test'
 import { compileJSX, type ComponentIR } from '../index'
 import { TestAdapter } from '../adapters/test-adapter'
 import { parseExpression, type ParsedExpr } from '../expression-parser'
 import { datePlugin, DATE_METHODS } from '../date-lowering'
-import { registerLoweringPlugin, __resetLoweringPluginsForTest, getLoweringPlugins } from '../lowering-registry'
+import { registerLoweringPlugin, __resetLoweringPluginsForTest, getLoweringPlugins, type LoweringPlugin } from '../lowering-registry'
 import { ErrorCodes } from '../errors'
 
 function metadata(src: string): ComponentIR['metadata'] {
@@ -156,8 +156,22 @@ describe('datePlugin matcher recognition (#2274)', () => {
 })
 
 describe('BF021 exemption via the real datePlugin (#2274 seam)', () => {
-  afterEach(() => {
-    __resetLoweringPluginsForTest(getLoweringPlugins().filter((p) => p.name !== 'date'))
+  // Snapshot + restore around the WHOLE describe block (not a per-test
+  // afterEach filtering 'date' out of whatever's currently registered) —
+  // `bun test` runs every file in one process, so a per-test filter leaves
+  // 'date' permanently missing from the shared registry once this block's
+  // LAST test finishes, silently breaking any later-executing test file
+  // that depends on the real built-in (e.g. client-only-date-lowering.test.ts's
+  // reactive-attribute lowering) — bun does not guarantee file execution
+  // order matches argument/discovery order, so this doesn't reliably
+  // reproduce locally but did intermittently fail in CI. Mirrors the same
+  // snapshot/restore shape `rich-type-method-refusal.test.ts` already uses.
+  let savedPlugins: readonly LoweringPlugin[]
+  beforeAll(() => {
+    savedPlugins = getLoweringPlugins()
+  })
+  afterAll(() => {
+    __resetLoweringPluginsForTest(savedPlugins)
   })
 
   function bf021Count(source: string): number {


### PR DESCRIPTION
## Summary

Root-causes and fixes the persistent `test (jsx-2)` CI flake tracked in #2831 — the failing assertion (`#2641 — reactive attribute bindings route catalogued calls through the runtime helper > non-@client reactive attribute, a catalogued call`) has recurred across many unrelated PRs/commits throughout an extended bug-fix effort on this repo, always identical, never reproducible locally despite matching CI's pinned bun version and the shard script's exact file list.

## Root cause

`packages/jsx/src/__tests__/date-lowering.test.ts`'s "BF021 exemption via the real datePlugin" describe block used a per-test `afterEach` that filtered `'date'` out of *whatever was currently in* the shared lowering-plugin registry:

```ts
afterEach(() => {
  __resetLoweringPluginsForTest(getLoweringPlugins().filter((p) => p.name !== 'date'))
})
```

`bun test` runs every file in one process, sharing the registry's module-level state (a global array mutated via `registerLoweringPlugin`/`__resetLoweringPluginsForTest`). Once this describe block's *last* test ran, the built-in `datePlugin` — registered once, at process start, by `@barefootjs/jsx`'s own module-load side effect (`index.ts`'s `__registerBuiltins()`) — was permanently removed for the rest of the process, with nothing to restore it. Confirmed directly by instrumentation: after this file finishes, the registry is missing `date`.

Any *later-executing* test file that depends on the real built-in `date` plugin for its reactive-attribute/catalogued-call lowering (e.g. `client-only-date-lowering.test.ts`'s `#2641` suite) then silently gets no lowering: `.toISOString()` etc. is left raw instead of rewritten to `date(...)` — exactly the observed failure.

**Why this only ever showed up on CI, never locally**: `bun test` does not execute files in the order given on the command line, nor in pure alphabetical order (confirmed empirically — forcing this exact two-file combination locally reproducibly shows neither ordering). Whatever governs bun's actual file execution order, it appears sensitive to filesystem metadata that's stable within one persistent local clone but can vary across separate fresh CI checkouts — which explains why the flake never reproduced locally (my clone's relative order happens to always be safe) yet failed intermittently on CI, including twice in a row on one run of the exact same commit.

## Fix

Snapshot the registry once in `beforeAll` and restore it in `afterAll` around the whole describe block, instead of filtering per test — the same safe shape `rich-type-method-refusal.test.ts` already uses for its own registry manipulation (its own docstring explicitly calls out the exact hazard this PR fixes: *"Snapshot + clear + restore around the whole file so this suite's result never depends on which other test files happened to run first in the same process"*).

`lowering-registry.test.ts`'s own `afterEach` was audited too and confirmed safe: it only ever removes the sample plugin it itself registers, never a built-in another file depends on.

## Verification

- `bun test packages/jsx/src/__tests__/date-lowering.test.ts` — 14 pass, 0 fail.
- Direct instrumentation (temporary, not committed) confirmed: before the fix, the registry ends up empty/missing `date` after this file runs; after the fix, it's correctly restored to `["queryHref", "date", "formatDate", "toLocaleDateString"]`.
- Full `packages/jsx` suite locally — 3235 pass, 0 fail (259 files).
- Full CI — all 42 checks green, including `test (jsx-2)` and `fixture-hydrate`.

No production code changes — test-isolation hygiene only, so no changeset.

---

Base is `main` (not stacked) — this fixes the CI flake that's been affecting the in-progress stacked PR chain (#2824→#2825→#2826→#2829), which have been rebased onto this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198yG2px5ygfvmdoMkhRS13

---
_Generated by [Claude Code](https://claude.ai/code/session_0198yG2px5ygfvmdoMkhRS13)_