### PR TITLE
Remove stuck changeset targeting an ignored package

### DIFF
--- a/.changeset/support-matrix-cli-missing-adapter-guard-2785.md
+++ b/.changeset/support-matrix-cli-missing-adapter-guard-2785.md
@@ -1,7 +1,0 @@
----
-"@barefootjs/compat": patch
----
-
-Fix #2785: `support-matrix:lock` and `compat:lock` discover adapters by dynamic-importing each registered package (`adapter-registry.ts`'s `loadCompatAdapters`) and silently skip any that fail to resolve — e.g. an unbuilt `dist/`. Their generators then wrote a lock file containing only the adapters that happened to load, with no warning, deleting the missing adapters' rows from the committed `ui/support-matrix.lock.json` / `ui/compat.lock.json`. The freshness/drift check then compared against this now-truncated lock and passed on it.
-
-`loadAllCompatAdapters`/`requireAllCompatAdapters` (`adapter-registry.ts`) are a new all-or-throw wrapper around the existing degrade-to-skip loader: `MissingCompatAdaptersError` names every package that failed to load, its reason, and the exact `bun run --filter ... build` command to fix it. `support-matrix-cli.ts` (always a lock generator) and `cli.ts`'s `--out` path (`compat:lock`) now refuse to write and exit 1 instead of silently writing a subset; the ad-hoc `bun run compat <component>` (no `--out`) keeps its prior best-effort behavior, since that path was never a committed artifact.


### PR DESCRIPTION
## Summary

PR #2810 ("Version Packages", bumping packages to 0.33.5) merged successfully, but the release that should have followed it never happened: npm still serves 0.33.4 as latest for every package (e.g. `@barefootjs/jsx`, `@barefootjs/blade`), no `v0.33.5`-tagged GitHub Releases exist, and the very next push to `main` produced *another* Version Packages PR (#2836, now targeting 0.33.6) instead of a publish run.

Root cause: `.changeset/support-matrix-cli-missing-adapter-guard-2785.md` (added by #2821, fixing #2785) carries a patch bump for `@barefootjs/compat` only — a package listed in `.changeset/config.json`'s `ignore` array. `changeset version` cannot apply a release to an ignored package, so it silently leaves the changeset file in place instead of consuming it, rather than erroring or deleting it.

Confirmed by diffing `.changeset/` across PR #2810's merge commit (`a99e268a`) against its base (`38431b85`): every other pending changeset present at the base was consumed by the version bump, this one alone survived into the merged tree. Because the file never gets deleted, every subsequent push to `main` still sees a "pending changeset" and `changesets/action` keeps taking the *version* branch, never *publish* — so the 0.33.5 bump from #2810 was never actually released, and neither will any future version bump be, until this file is removed.

## Fix

Delete the stuck changeset file. It documents a real fix (#2785) that already landed in the code via #2821 — deleting the changeset itself doesn't undo the code change, it only removes the release-note entry for an intentionally unreleased (`ignore`d, `private: true`) internal package, so no user-facing changelog entry is lost.

Once this merges, the next push to `main` should let `changesets/action` see zero pending changesets and take the publish branch, releasing the currently-merged commits (0.33.5/0.33.6 worth of changes, whatever's accumulated) to npm.

## Test plan

- [x] Verified `packages/compat/package.json` has `"name": "@barefootjs/compat"` and `"private": true`, and that name is listed in `.changeset/config.json`'s `ignore` array.
- [x] Verified via `get_file_contents` on GitHub that the deleted changeset was the only one still present in `.changeset/` at PR #2810's merge commit that wasn't consumed.
- [x] Verified via the npm registry that `@barefootjs/jsx` / `@barefootjs/blade` are still published at 0.33.4, confirming 0.33.5 was never released.
- No code changes — this is a repo-metadata-only fix (removing a stray file), so no build/test suite is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ESsXdfVjymkkL2LQKknRu

---
_Generated by [Claude Code](https://claude.ai/code/session_014ESsXdfVjymkkL2LQKknRu)_