### PR TITLE
Fix #2743: Go adapter's queryHref href no longer percent-encodes base

### DIFF
--- a/.changeset/go-query-href-attr-context-2743.md
+++ b/.changeset/go-query-href-attr-context-2743.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/go-template": patch
+---
+
+Fix #2743: `<a href={queryHref(base, {…})}>` on the Go adapter no longer diverges from the JS reference (Hono) when `base` contains non-URL-safe or multibyte bytes. `html/template` infers a URL context from the attribute name and percent-encodes the whole value there; the reference only HTML-escapes. A `queryHref`-produced (`query` guard-list) attribute value now emits the whole attribute via a new `bf_attr` runtime helper (`template.HTMLAttr`), the same technique `bf_spread_attrs`/`bfHydrationAttrs` already use to bypass html/template's contextual auto-escaping — keyed on the neutral `helper === 'query'` fact rather than the attribute name, so any URL-context attribute (`src`, `title`, …), not just `href`, gets the same byte parity.

--- a/packages/adapter-blade/src/conformance-pins.ts
+++ b/packages/adapter-blade/src/conformance-pins.ts
@@ -15,7 +15,7 @@ export const conformancePins: ConformancePins = {
   // rendering — it never consults the lowering registry for a branch the
   // way the direct-call attribute path does, so it falls to the generic
   // expression emitter, which refuses the params object literal.
-  'query-href-ternary': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2843' }],
+  'query-href-ternary': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2843', unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2843' } }],
   'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
   'map-array-builder-body': [{ code: 'BF021', severity: 'error' }],
   'map-array-builder-escaping': [{ code: 'BF021', severity: 'error' }],

--- a/packages/adapter-blade/src/conformance-pins.ts
+++ b/packages/adapter-blade/src/conformance-pins.ts
@@ -10,6 +10,12 @@
 import type { ConformancePins } from '@barefootjs/jsx'
 
 export const conformancePins: ConformancePins = {
+  // #2843: a lowering-registry call (e.g. queryHref) inside a ternary
+  // attribute branch isn't recognized by this adapter's ternary-attribute
+  // rendering — it never consults the lowering registry for a branch the
+  // way the direct-call attribute path does, so it falls to the generic
+  // expression emitter, which refuses the params object literal.
+  'query-href-ternary': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2843' }],
   'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
   'map-array-builder-body': [{ code: 'BF021', severity: 'error' }],
   'map-array-builder-escaping': [{ code: 'BF021', severity: 'error' }],

--- a/packages/adapter-erb/src/conformance-pins.ts
+++ b/packages/adapter-erb/src/conformance-pins.ts
@@ -15,7 +15,7 @@ export const conformancePins: ConformancePins = {
   // rendering — it never consults the lowering registry for a branch the
   // way the direct-call attribute path does, so it falls to the generic
   // expression emitter, which refuses the params object literal.
-  'query-href-ternary': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2843' }],
+  'query-href-ternary': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2843', unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2843' } }],
   'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
   'map-array-builder-body': [{ code: 'BF021', severity: 'error' }],
   'map-array-builder-escaping': [{ code: 'BF021', severity: 'error' }],

--- a/packages/adapter-erb/src/conformance-pins.ts
+++ b/packages/adapter-erb/src/conformance-pins.ts
@@ -10,6 +10,12 @@
 import type { ConformancePins } from '@barefootjs/jsx'
 
 export const conformancePins: ConformancePins = {
+  // #2843: a lowering-registry call (e.g. queryHref) inside a ternary
+  // attribute branch isn't recognized by this adapter's ternary-attribute
+  // rendering — it never consults the lowering registry for a branch the
+  // way the direct-call attribute path does, so it falls to the generic
+  // expression emitter, which refuses the params object literal.
+  'query-href-ternary': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2843' }],
   'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
   'map-array-builder-body': [{ code: 'BF021', severity: 'error' }],
   'map-array-builder-escaping': [{ code: 'BF021', severity: 'error' }],

--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -215,6 +215,10 @@ func FuncMap() template.FuncMap {
 		// JSX intrinsic-element spread lowering (#1407)
 		"bf_spread_attrs": SpreadAttrs,
 
+		// Whole-attribute emission that bypasses html/template's contextual
+		// auto-escaper (#2743): see Attr's docstring.
+		"bf_attr": Attr,
+
 		// Reverse the loop-row field-access Go-casing before a whole-item
 		// spread reaches `bf_spread_attrs` (#2490): a row's dot context is
 		// necessarily keyed `ID`/`Title`/`DataKind` (the same casing that
@@ -307,6 +311,22 @@ func Query(base string, triples ...any) string {
 		b.WriteString(formEscape(p.val))
 	}
 	return base + b.String()
+}
+
+// Attr emits one complete `name="value"` HTML attribute as a
+// template.HTMLAttr, HTML-escaping value with template.HTMLEscapeString (the
+// same escaper SpreadAttrs uses) and nothing else — no URL normalization, no
+// scheme filter. (#2743) html/template infers a URL context from the
+// attribute NAME for a `name="{{pipeline}}"` action (href/src/action/
+// data-*/anything containing src|uri|url/…) and percent-encodes the whole
+// value there, which the JS reference (Hono) never does — it only
+// HTML-escapes. Returning HTMLAttr for the WHOLE attribute bypasses that
+// contextual inference by design, the same technique SpreadAttrs /
+// HydrationAttrs already use for attributes and StyleObjectToCSS uses for
+// CSS. `name` is a compiler-emitted constant, never data; `value` goes
+// through String (nil → "").
+func Attr(name string, value any) template.HTMLAttr {
+	return template.HTMLAttr(name + `="` + template.HTMLEscapeString(String(value)) + `"`)
 }
 
 // Date implements the `date` helper (spec/template-helpers.md, #2274) — the

--- a/packages/adapter-go-template/runtime/bf_test.go
+++ b/packages/adapter-go-template/runtime/bf_test.go
@@ -2397,6 +2397,49 @@ func TestQuery(t *testing.T) {
 	}
 }
 
+// Attr (`bf_attr`, #2743) emits a whole `name="value"` attribute as
+// template.HTMLAttr, HTML-escaping the value and nothing else — no URL
+// normalization, no scheme filter.
+func TestAttr(t *testing.T) {
+	tests := []struct {
+		name  string
+		attr  string
+		value any
+		want  string
+	}{
+		{"markup value is HTML-escaped only", "href", `<b>&"'</b>`, `href="&lt;b&gt;&amp;&#34;&#39;&lt;/b&gt;"`},
+		{"multibyte passes through untouched", "href", "日本語", `href="日本語"`},
+		{"nil value renders empty", "href", nil, `href=""`},
+		{"composition with Query preserves + for space, drops %-encoding", "href", Query("日本語", true, "q", "a b"), `href="日本語?q=a+b"`},
+	}
+	for _, tt := range tests {
+		if got := string(Attr(tt.attr, tt.value)); got != tt.want {
+			t.Errorf("%s: Attr(%q, %v) = %q, want %q", tt.name, tt.attr, tt.value, got, tt.want)
+		}
+	}
+}
+
+// TestAttr_BypassesContextualURLEscaper is the end-to-end assertion that
+// `bf_attr` actually defeats html/template's URL-context auto-escaping
+// (#2743) — not just that the Go function returns the right string in
+// isolation, but that html/template doesn't re-escape it when the whole
+// attribute is inserted via a real template execution. A `javascript:`
+// scheme and an embedded `<z>` survive verbatim (HTML-escaped, never
+// percent-encoded, never replaced with `#ZgotmplZ`).
+func TestAttr_BypassesContextualURLEscaper(t *testing.T) {
+	tmpl := template.Must(template.New("t").Funcs(FuncMap()).Parse(
+		`<a {{bf_attr "href" .U}}>x</a>`,
+	))
+	var buf strings.Builder
+	if err := tmpl.Execute(&buf, struct{ U string }{U: "javascript:x?y=<z>"}); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	want := `<a href="javascript:x?y=&lt;z&gt;">x</a>`
+	if got := buf.String(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 // AsMap normalizes any string-keyed map kind held in an interface{} prop
 // field into map[string]interface{} for object-valued context bindings, and
 // returns nil for every "absent" shape so the generated `?? {}` fallback

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -129,14 +129,6 @@ runAdapterConformanceTests({
     // produces no complete template.
     'jsx-element-prop-rest-bag-dynamic',
   ]),
-  skipDataPoints: new Set<string>([
-    // #2743: html/template's URL-context autoescape percent-encodes the
-    // queryHref BASE in href position (`日本語` → `%e6%97%a5…`); the JS
-    // reference only HTML-escapes. The bf_query helper itself is faithful —
-    // the divergence is Go's contextual escaper on the whole href value.
-    'query-href:gen:base:markup',
-    'query-href:gen:base:multibyte',
-  ]),
   onRenderError: (err, id) => {
     if (err instanceof GoNotAvailableError) {
       console.log(`Skipping [${id}]: ${err.message}`)

--- a/packages/adapter-go-template/src/__tests__/lowering-plugin.test.ts
+++ b/packages/adapter-go-template/src/__tests__/lowering-plugin.test.ts
@@ -149,6 +149,11 @@ export function P(props: { config: object }) {
     // naming exactly — the formula generalises, it isn't a lookup table
     // limited to `query`.
     expect(template).toContain('bf_custom_serialize .Config')
+    // #2743: the whole-attribute `bf_attr` route is keyed on the neutral
+    // `guard-list` + `helper === 'query'` shape specifically — a
+    // `helper-call` node (this plugin's shape) is a different node kind and
+    // must not be routed through it.
+    expect(template).not.toContain('bf_attr')
   })
 
   test('without the plugin registered, the call falls back to the generic (unsupported) lowering', () => {

--- a/packages/adapter-go-template/src/__tests__/query-href.test.ts
+++ b/packages/adapter-go-template/src/__tests__/query-href.test.ts
@@ -176,4 +176,54 @@ export function P(props: { base: string; q: Record<string, string> }) {
     const { template } = generate(src)
     expect(template).not.toContain('bf_query')
   })
+
+  // #2743: a `queryHref` value in an ATTRIBUTE position emits the whole
+  // attribute via `bf_attr` (template.HTMLAttr) so html/template's
+  // contextual URL-context autoescape (keyed off the attribute NAME) never
+  // percent-encodes the base — see `lowerRegisteredAttrCall`.
+  test('an href-attribute queryHref value routes through bf_attr, not `href="{{...}}"`', () => {
+    const src = `
+'use client'
+import { queryHref } from '@barefootjs/client'
+export function P(props: { base: string; tag: string }) {
+  return <a href={queryHref(props.base, { tag: props.tag })}>x</a>
+}
+`
+    const { template } = generate(src)
+    expect(template).toContain('{{bf_attr "href" (bf_query .Base (true) "tag" .Tag)}}')
+    expect(template).not.toContain('href="{{')
+  })
+
+  // The route is keyed on the neutral `helper === 'query'` fact, not on the
+  // attribute name `href` — any attribute (e.g. `title`) gets the same
+  // treatment, since `queryHref` returns a plain string with nothing
+  // href-specific about it.
+  test('a non-href attribute (title) with a queryHref value also routes through bf_attr', () => {
+    const src = `
+'use client'
+import { queryHref } from '@barefootjs/client'
+export function P(props: { base: string; tag: string }) {
+  return <a title={queryHref(props.base, { tag: props.tag })}>x</a>
+}
+`
+    const { template } = generate(src)
+    expect(template).toContain('{{bf_attr "title" (bf_query .Base (true) "tag" .Tag)}}')
+    expect(template).not.toContain('title="{{')
+  })
+
+  // Text-position (non-attribute) use is unaffected — `bf_attr` only wraps
+  // the whole-attribute case; a queryHref value read as text still lowers
+  // to a bare `bf_query` pipeline.
+  test('a queryHref value in text position is not wrapped in bf_attr', () => {
+    const src = `
+'use client'
+import { queryHref } from '@barefootjs/client'
+export function P(props: { base: string; tag: string }) {
+  return <span>{queryHref(props.base, { tag: props.tag })}</span>
+}
+`
+    const { template } = generate(src)
+    expect(template).toContain('bf_query .Base (true) "tag" .Tag')
+    expect(template).not.toContain('bf_attr')
+  })
 })

--- a/packages/adapter-go-template/src/__tests__/query-href.test.ts
+++ b/packages/adapter-go-template/src/__tests__/query-href.test.ts
@@ -226,4 +226,45 @@ export function P(props: { base: string; tag: string }) {
     expect(template).toContain('bf_query .Base (true) "tag" .Tag')
     expect(template).not.toContain('bf_attr')
   })
+
+  // #2743 follow-up (pullfrog review on #2841): a ternary attribute value
+  // with a real (non-`undefined`) alternate is syntactically valid and
+  // already lowers both branches correctly via `bf_ternary` — but was still
+  // wrapped in the ordinary `name="{{...}}"` form, leaving it exposed to
+  // html/template's URL-context percent-encoding. This must route through
+  // `bf_attr` too, wrapping the whole `bf_ternary` pipeline.
+  test('a queryHref value in a ternary branch (non-undefined alternate) routes through bf_attr', () => {
+    const src = `
+'use client'
+import { queryHref } from '@barefootjs/client'
+export function P(props: { ok: boolean; base: string; tag: string }) {
+  return <a href={props.ok ? queryHref(props.base, { tag: props.tag }) : '/fallback'}>x</a>
+}
+`
+    const { template } = generate(src)
+    expect(template).toContain(
+      '{{bf_attr "href" (bf_ternary (bf_truthy .Ok) (bf_query .Base (true) "tag" .Tag) "/fallback")}}',
+    )
+    expect(template).not.toContain('href="{{')
+  })
+
+  // The `undefined`-alternate omission shape (`cond ? queryHref(...) :
+  // undefined`) is NOT handled by the ternary bf_attr route — its
+  // consequent-only render doesn't consult the lowering registry at all and
+  // already emits invalid Go syntax independent of escaping (tracked
+  // separately as #2842). Pinning the current (broken) shape here so a
+  // future fix to #2842 is the one that changes this assertion, not an
+  // accidental side effect of a `bf_attr`-route change.
+  test('the undefined-alternate omission shape is unaffected by the ternary bf_attr route (pre-existing #2842 gap)', () => {
+    const src = `
+'use client'
+import { queryHref } from '@barefootjs/client'
+export function P(props: { ok: boolean; base: string; tag: string }) {
+  return <a href={props.ok ? queryHref(props.base, { tag: props.tag }) : undefined}>x</a>
+}
+`
+    const { template } = generate(src)
+    expect(template).not.toContain('bf_attr')
+    expect(template).not.toContain('bf_query')
+  })
 })

--- a/packages/adapter-go-template/src/adapter/expr/url-builder.ts
+++ b/packages/adapter-go-template/src/adapter/expr/url-builder.ts
@@ -165,6 +165,36 @@ export function lowerRegisteredCall(
 }
 
 /**
+ * Attribute-position twin of `lowerRegisteredCall` (#2743). When an intrinsic
+ * element attribute's value is a `query` guard-list (the neutral node the
+ * `queryHref` plugin — or any plugin reusing the `query` helper — produces),
+ * emit the WHOLE attribute as one `bf_attr` action returning
+ * `template.HTMLAttr`, instead of `name="{{bf_query …}}"`. html/template
+ * infers a URL context from the attribute NAME (`href`, `src`, `action`,
+ * `data-*`, anything containing `src`/`uri`/`url`, …) and percent-encodes the
+ * entire value there; the JS reference (Hono) only HTML-escapes. Keyed on the
+ * neutral `helper` id, not the attribute name (Go's URL-context table is a
+ * heuristic we must not re-implement) and not the JS API name. Returns null
+ * for a non-call, an unmatched call, or any other node kind/helper — the
+ * caller then takes its ordinary path.
+ */
+export function lowerRegisteredAttrCall(
+  ctx: GoEmitContext,
+  attrName: string,
+  parsed: ParsedExpr,
+): string | null {
+  if (parsed.kind !== 'call') return null
+  for (const matcher of ctx.state.loweringMatchers) {
+    const node = matcher(parsed.callee, parsed.args)
+    if (!node) continue
+    if (node.kind !== 'guard-list' || node.helper !== 'query') return null
+    const rendered = renderLoweringNode(ctx, node)
+    return rendered === null ? null : `{{bf_attr ${JSON.stringify(attrName)} (${rendered})}}`
+  }
+  return null
+}
+
+/**
  * Render a backend-neutral lowering node to a Go template expression, or null
  * when the node's `helper` has no Go mapping — the caller then declines
  * (generic lowering → BF101), rather than emitting the raw helper id, which

--- a/packages/adapter-go-template/src/adapter/expr/url-builder.ts
+++ b/packages/adapter-go-template/src/adapter/expr/url-builder.ts
@@ -177,12 +177,36 @@ export function lowerRegisteredCall(
  * heuristic we must not re-implement) and not the JS API name. Returns null
  * for a non-call, an unmatched call, or any other node kind/helper — the
  * caller then takes its ordinary path.
+ *
+ * Also accepts a `conditional` node directly (#2743 follow-up, pullfrog
+ * review on #2841): a ternary with a real, non-`undefined` alternate
+ * (`cond ? queryHref(...) : '/fallback'`) is syntactically valid and already
+ * lowers its branches correctly via `lowerTernary` — but the CALLER used to
+ * still wrap the resulting `(bf_ternary …)` pipeline in the ordinary
+ * `name="{{...}}"` form, which leaves it exposed to the same URL-context
+ * percent-encoding this function exists to route around. Whenever EITHER
+ * branch (recursing through a right-folded nested ternary chain, the same
+ * shape `lowerTernary` itself right-folds) is a `query` guard-list call, the
+ * whole ternary is wrapped in `bf_attr` too — matching the reference, which
+ * HTML-escapes the picked branch's value the same way regardless of which
+ * branch won. (The `undefined`-alternate omission shape, `cond ? queryHref(...)
+ * : undefined`, is NOT handled here — that shape's consequent-only render
+ * doesn't consult the lowering registry at all and emits invalid Go syntax
+ * independent of escaping, tracked separately as #2842.)
  */
 export function lowerRegisteredAttrCall(
   ctx: GoEmitContext,
   attrName: string,
   parsed: ParsedExpr,
 ): string | null {
+  if (parsed.kind === 'conditional') {
+    if (!ternaryHasQueryBranch(ctx, parsed.consequent, parsed.alternate)) return null
+    // `lowerTernary` already returns a complete parenthesised `(bf_ternary …)`
+    // pipeline — pass it straight through as `bf_attr`'s value argument
+    // rather than re-wrapping it in a redundant second set of parens.
+    const rendered = lowerTernary(ctx, parsed.test, parsed.consequent, parsed.alternate)
+    return `{{bf_attr ${JSON.stringify(attrName)} ${rendered}}}`
+  }
   if (parsed.kind !== 'call') return null
   for (const matcher of ctx.state.loweringMatchers) {
     const node = matcher(parsed.callee, parsed.args)
@@ -192,6 +216,32 @@ export function lowerRegisteredAttrCall(
     return rendered === null ? null : `{{bf_attr ${JSON.stringify(attrName)} (${rendered})}}`
   }
   return null
+}
+
+/** Whether a `call` node is a recognised `query` guard-list lowering. */
+function isQueryGuardListCall(ctx: GoEmitContext, node: ParsedExpr): boolean {
+  if (node.kind !== 'call') return false
+  for (const matcher of ctx.state.loweringMatchers) {
+    const lowered = matcher(node.callee, node.args)
+    if (!lowered) continue
+    return lowered.kind === 'guard-list' && lowered.helper === 'query'
+  }
+  return false
+}
+
+/**
+ * Whether either branch of a ternary is (or, for a right-folded chain,
+ * eventually resolves to) a `query` guard-list call — the trigger for
+ * routing the whole ternary through `bf_attr` in `lowerRegisteredAttrCall`.
+ */
+function ternaryHasQueryBranch(
+  ctx: GoEmitContext,
+  consequent: ParsedExpr,
+  alternate: ParsedExpr,
+): boolean {
+  const branchHasQuery = (n: ParsedExpr): boolean =>
+    n.kind === 'conditional' ? ternaryHasQueryBranch(ctx, n.consequent, n.alternate) : isQueryGuardListCall(ctx, n)
+  return branchHasQuery(consequent) || branchHasQuery(alternate)
 }
 
 /**

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -127,7 +127,7 @@ import { analyzeBakeableStaticChildLoop, scalarToGoLiteral, type BakedStaticChil
 import { analyzeBakeableStaticElementLoop } from "./analysis/static-element-loop-bake.ts"
 import type { GoEmitContext } from "./emit-context.ts"
 import { inlineLocalHelperCall } from "./expr/helper-inline.ts"
-import { lowerRegisteredCall, lowerTernary } from "./expr/url-builder.ts"
+import { lowerRegisteredAttrCall, lowerRegisteredCall, lowerTernary } from "./expr/url-builder.ts"
 import {
   convertInitialValue,
   jsLiteralToGo,
@@ -8034,6 +8034,12 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         // Inline Go template syntax with embedded `{{...}}` actions.
         return `${name}="${this.renderParsedExpr(parsed)}"`
       }
+      // #2743: a `query` guard-list value (queryHref) emits the WHOLE
+      // attribute via `bf_attr` (template.HTMLAttr) so html/template's
+      // URL-context inference on the attribute name never percent-encodes
+      // the base. See `lowerRegisteredAttrCall`.
+      const attrAction = lowerRegisteredAttrCall(this.emitCtx, name, parsed)
+      if (attrAction !== null) return attrAction
       // Nullish-attribute omission: when the attribute value is a BARE reference
       // to a nillable (`interface{}`) prop field, guard emission on `ne .X nil`
       // so an unset optional prop drops the attribute entirely instead of

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -8025,6 +8025,14 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
           const body = `${name}="{{${valueExpr}}}"`
           return `${preamble}{{if ${goCond}}}${body}{{end}}`
         }
+        // #2743 follow-up (pullfrog review on #2841): a `query` guard-list
+        // value (queryHref) reachable through EITHER branch of this ternary
+        // still needs the whole-attribute `bf_attr` route — otherwise the
+        // pipeline below lands inside the ordinary `name="{{...}}"` wrapper
+        // and html/template's URL-context inference still percent-encodes
+        // whichever branch wins at render time. See `lowerRegisteredAttrCall`.
+        const attrTernary = lowerRegisteredAttrCall(this.emitCtx, name, parsed)
+        if (attrTernary !== null) return attrTernary
         // #2335: the ternary lowers to the pipeline-position `(bf_ternary …)`
         // value (no longer a `{{if}}…{{end}}` fragment), so wrap it in a single
         // `{{…}}` action inside the attribute string — `name="{{bf_ternary …}}"`.

--- a/packages/adapter-jinja/src/conformance-pins.ts
+++ b/packages/adapter-jinja/src/conformance-pins.ts
@@ -15,7 +15,7 @@ export const conformancePins: ConformancePins = {
   // rendering — it never consults the lowering registry for a branch the
   // way the direct-call attribute path does, so it falls to the generic
   // expression emitter, which refuses the params object literal.
-  'query-href-ternary': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2843' }],
+  'query-href-ternary': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2843', unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2843' } }],
   'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
   'map-array-builder-body': [{ code: 'BF021', severity: 'error' }],
   'map-array-builder-escaping': [{ code: 'BF021', severity: 'error' }],

--- a/packages/adapter-jinja/src/conformance-pins.ts
+++ b/packages/adapter-jinja/src/conformance-pins.ts
@@ -10,6 +10,12 @@
 import type { ConformancePins } from '@barefootjs/jsx'
 
 export const conformancePins: ConformancePins = {
+  // #2843: a lowering-registry call (e.g. queryHref) inside a ternary
+  // attribute branch isn't recognized by this adapter's ternary-attribute
+  // rendering — it never consults the lowering registry for a branch the
+  // way the direct-call attribute path does, so it falls to the generic
+  // expression emitter, which refuses the params object literal.
+  'query-href-ternary': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2843' }],
   'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
   'map-array-builder-body': [{ code: 'BF021', severity: 'error' }],
   'map-array-builder-escaping': [{ code: 'BF021', severity: 'error' }],

--- a/packages/adapter-mojolicious/src/conformance-pins.ts
+++ b/packages/adapter-mojolicious/src/conformance-pins.ts
@@ -15,7 +15,7 @@ export const conformancePins: ConformancePins = {
   // rendering — it never consults the lowering registry for a branch the
   // way the direct-call attribute path does, so it falls to the generic
   // expression emitter, which refuses the params object literal.
-  'query-href-ternary': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2843' }],
+  'query-href-ternary': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2843', unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2843' } }],
   'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
   'map-array-builder-body': [{ code: 'BF021', severity: 'error' }],
   'map-array-builder-escaping': [{ code: 'BF021', severity: 'error' }],

--- a/packages/adapter-mojolicious/src/conformance-pins.ts
+++ b/packages/adapter-mojolicious/src/conformance-pins.ts
@@ -10,6 +10,12 @@
 import type { ConformancePins } from '@barefootjs/jsx'
 
 export const conformancePins: ConformancePins = {
+  // #2843: a lowering-registry call (e.g. queryHref) inside a ternary
+  // attribute branch isn't recognized by this adapter's ternary-attribute
+  // rendering — it never consults the lowering registry for a branch the
+  // way the direct-call attribute path does, so it falls to the generic
+  // expression emitter, which refuses the params object literal.
+  'query-href-ternary': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2843' }],
   'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
   'map-array-builder-body': [{ code: 'BF021', severity: 'error' }],
   'map-array-builder-escaping': [{ code: 'BF021', severity: 'error' }],

--- a/packages/adapter-rust/src/conformance-pins.ts
+++ b/packages/adapter-rust/src/conformance-pins.ts
@@ -15,7 +15,7 @@ export const conformancePins: ConformancePins = {
   // rendering — it never consults the lowering registry for a branch the
   // way the direct-call attribute path does, so it falls to the generic
   // expression emitter, which refuses the params object literal.
-  'query-href-ternary': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2843' }],
+  'query-href-ternary': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2843', unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2843' } }],
   'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
   'map-array-builder-body': [{ code: 'BF021', severity: 'error' }],
   'map-array-builder-escaping': [{ code: 'BF021', severity: 'error' }],

--- a/packages/adapter-rust/src/conformance-pins.ts
+++ b/packages/adapter-rust/src/conformance-pins.ts
@@ -10,6 +10,12 @@
 import type { ConformancePins } from '@barefootjs/jsx'
 
 export const conformancePins: ConformancePins = {
+  // #2843: a lowering-registry call (e.g. queryHref) inside a ternary
+  // attribute branch isn't recognized by this adapter's ternary-attribute
+  // rendering — it never consults the lowering registry for a branch the
+  // way the direct-call attribute path does, so it falls to the generic
+  // expression emitter, which refuses the params object literal.
+  'query-href-ternary': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2843' }],
   'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
   'map-array-builder-body': [{ code: 'BF021', severity: 'error' }],
   'map-array-builder-escaping': [{ code: 'BF021', severity: 'error' }],

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -4106,6 +4106,22 @@
         "attribute"
       ]
     },
+    "query-href-ternary": {
+      "kinds": [
+        "call",
+        "conditional",
+        "identifier",
+        "literal",
+        "object-literal"
+      ],
+      "axes": [
+        "literal:string",
+        "lowering:queryHref"
+      ],
+      "contexts": [
+        "attribute"
+      ]
+    },
     "radio-group": {
       "kinds": [
         "arrow",
@@ -5887,14 +5903,14 @@
     "array-method": 71,
     "arrow": 71,
     "binary": 94,
-    "call": 244,
-    "conditional": 27,
-    "identifier": 346,
+    "call": 245,
+    "conditional": 28,
+    "identifier": 347,
     "index-access": 14,
-    "literal": 275,
+    "literal": 276,
     "logical": 47,
     "member": 197,
-    "object-literal": 69,
+    "object-literal": 70,
     "template-literal": 30,
     "unary": 24,
     "unsupported": 42
@@ -5937,13 +5953,13 @@
     "literal:boolean": 59,
     "literal:null": 23,
     "literal:number": 116,
-    "literal:string": 192,
+    "literal:string": 193,
     "logical:&&": 7,
     "logical:??": 41,
     "logical:||": 14,
     "lowering:date": 4,
     "lowering:formatDate": 1,
-    "lowering:queryHref": 2,
+    "lowering:queryHref": 3,
     "lowering:toLocaleDateString": 4,
     "member:computed": 8,
     "member:optional": 1,

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -4093,6 +4093,19 @@
         "attribute"
       ]
     },
+    "query-href-src": {
+      "kinds": [
+        "call",
+        "identifier",
+        "object-literal"
+      ],
+      "axes": [
+        "lowering:queryHref"
+      ],
+      "contexts": [
+        "attribute"
+      ]
+    },
     "radio-group": {
       "kinds": [
         "arrow",
@@ -5874,14 +5887,14 @@
     "array-method": 71,
     "arrow": 71,
     "binary": 94,
-    "call": 243,
+    "call": 244,
     "conditional": 27,
-    "identifier": 345,
+    "identifier": 346,
     "index-access": 14,
     "literal": 275,
     "logical": 47,
     "member": 197,
-    "object-literal": 68,
+    "object-literal": 69,
     "template-literal": 30,
     "unary": 24,
     "unsupported": 42
@@ -5930,7 +5943,7 @@
     "logical:||": 14,
     "lowering:date": 4,
     "lowering:formatDate": 1,
-    "lowering:queryHref": 1,
+    "lowering:queryHref": 2,
     "lowering:toLocaleDateString": 4,
     "member:computed": 8,
     "member:optional": 1,

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -522,6 +522,7 @@ import { fixture as richPropPrecompute } from './rich-prop-precompute'
 import { fixture as formatDate } from './format-date'
 import { fixture as queryHref } from './query-href'
 import { fixture as queryHrefSrc } from './query-href-src'
+import { fixture as queryHrefTernary } from './query-href-ternary'
 import { fixture as dateToLocaleLiteral } from './date-tolocale-literal'
 import { fixture as dateToLocaleUnion } from './date-tolocale-union'
 import { fixture as dateToLocaleDateStyle } from './date-tolocale-datestyle'
@@ -945,6 +946,7 @@ export const jsxFixtures: JSXFixture[] = [
   formatDate,
   queryHref,
   queryHrefSrc,
+  queryHrefTernary,
   dateToLocaleLiteral,
   dateToLocaleUnion,
   dateToLocaleDateStyle,

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -521,6 +521,7 @@ import { fixture as richPropClientRead } from './rich-prop-client-read'
 import { fixture as richPropPrecompute } from './rich-prop-precompute'
 import { fixture as formatDate } from './format-date'
 import { fixture as queryHref } from './query-href'
+import { fixture as queryHrefSrc } from './query-href-src'
 import { fixture as dateToLocaleLiteral } from './date-tolocale-literal'
 import { fixture as dateToLocaleUnion } from './date-tolocale-union'
 import { fixture as dateToLocaleDateStyle } from './date-tolocale-datestyle'
@@ -943,6 +944,7 @@ export const jsxFixtures: JSXFixture[] = [
   richPropPrecompute,
   formatDate,
   queryHref,
+  queryHrefSrc,
   dateToLocaleLiteral,
   dateToLocaleUnion,
   dateToLocaleDateStyle,

--- a/packages/adapter-tests/fixtures/query-href-src.ts
+++ b/packages/adapter-tests/fixtures/query-href-src.ts
@@ -1,0 +1,27 @@
+import { createFixture } from '../src/types'
+
+/**
+ * `queryHref(base, { … })` landing in a NON-`href` attribute (`src`) —
+ * the attribute-agnostic twin of `query-href.ts` (#2743). `queryHref`
+ * itself returns a plain `string`; nothing about it is href-specific, so
+ * an adapter's fix for the `href` URL-context-escaper divergence must not
+ * be keyed on the attribute name `href` — any URL-context attribute
+ * (`src`, `action`, `data-*`, …) built from `queryHref` needs the same
+ * byte parity with the JS reference (Hono, HTML-escape only).
+ */
+export const fixture = createFixture({
+  id: 'query-href-src',
+  description: 'queryHref(base, {…}) lowers to the query helper in a non-href (src) attribute',
+  source: `
+import { queryHref } from '@barefootjs/client'
+
+function QueryHrefImage({ base, w }: { base: string; w: string }) {
+  return <img src={queryHref(base, { w: w })} alt="thumb" />
+}
+export { QueryHrefImage }
+`,
+  props: { base: '/thumb', w: '64' },
+  expectedHtml: `
+    <img alt="thumb" bf-s="test" bf="s0" src="/thumb?w=64">
+  `,
+})

--- a/packages/adapter-tests/fixtures/query-href-ternary.ts
+++ b/packages/adapter-tests/fixtures/query-href-ternary.ts
@@ -1,0 +1,35 @@
+import { createFixture } from '../src/types'
+
+/**
+ * `queryHref(base, { … })` inside a ternary attribute value with a real,
+ * non-`undefined` alternate (#2743 follow-up — pullfrog review on #2841).
+ * This shape is syntactically valid and distinct from the `undefined`-
+ * alternate omission shape (tracked separately as #2842, whose consequent-
+ * only render doesn't consult the lowering registry at all): here BOTH
+ * branches already lower correctly via `bf_ternary`, so the only question
+ * is whether the WHOLE ternary result gets the same html/template
+ * URL-context-escaping bypass a direct `queryHref` call gets (see
+ * `query-href.ts` / `query-href-src.ts`), regardless of which branch a
+ * given render picks.
+ */
+export const fixture = createFixture({
+  id: 'query-href-ternary',
+  description: 'queryHref(base, {…}) inside a ternary attribute branch (non-undefined alternate) lowers through the query helper',
+  source: `
+import { queryHref } from '@barefootjs/client'
+
+function QueryHrefTernaryLink({ ok, base, tag }: { ok: boolean; base: string; tag: string }) {
+  return <a href={ok ? queryHref(base, { tag: tag }) : '/fallback'}>link</a>
+}
+export { QueryHrefTernaryLink }
+`,
+  props: { ok: true, base: '/items', tag: 'sale' },
+  expectedHtml: `
+    <a bf-s="test" bf="s0" href="/items?tag=sale">link</a>
+  `,
+  dataPoints: [
+    // The other branch: when the condition is false, the query-lowered
+    // consequent is never reached — the fallback literal renders as-is.
+    { name: 'fallback-branch', props: { ok: false, base: '/items', tag: 'sale' } },
+  ],
+})

--- a/packages/adapter-tests/fixtures/query-href.ts
+++ b/packages/adapter-tests/fixtures/query-href.ts
@@ -25,4 +25,12 @@ export { QueryHrefLink }
   expectedHtml: `
     <a bf-s="test" bf="s0" href="/items?tag=sale&amp;page=2">filter</a>
   `,
+  dataPoints: [
+    // #2743: no adapter applies scheme filtering to a queryHref-produced
+    // href — the reference (Hono) only HTML-escapes, so a `javascript:`
+    // base passes through on every backend. Go previously replaced this
+    // with `#ZgotmplZ` via html/template's URL-context scheme filter;
+    // parity with the reference is the contract, not a regression.
+    { name: 'base-scheme-passthrough', props: { base: 'javascript:alert(1)', tag: 'sale', page: '2' } },
+  ],
 })

--- a/packages/adapter-tests/generated-data-points.json
+++ b/packages/adapter-tests/generated-data-points.json
@@ -2111,6 +2111,56 @@
       }
     }
   ],
+  "query-href-ternary": [
+    {
+      "name": "gen:base:empty",
+      "props": {
+        "ok": true,
+        "base": "",
+        "tag": "sale"
+      }
+    },
+    {
+      "name": "gen:base:markup",
+      "props": {
+        "ok": true,
+        "base": "<b>&\"'</b>",
+        "tag": "sale"
+      }
+    },
+    {
+      "name": "gen:base:multibyte",
+      "props": {
+        "ok": true,
+        "base": "日本語",
+        "tag": "sale"
+      }
+    },
+    {
+      "name": "gen:tag:empty",
+      "props": {
+        "ok": true,
+        "base": "/items",
+        "tag": ""
+      }
+    },
+    {
+      "name": "gen:tag:markup",
+      "props": {
+        "ok": true,
+        "base": "/items",
+        "tag": "<b>&\"'</b>"
+      }
+    },
+    {
+      "name": "gen:tag:multibyte",
+      "props": {
+        "ok": true,
+        "base": "/items",
+        "tag": "日本語"
+      }
+    }
+  ],
   "reduce-concat": [
     {
       "name": "gen:items:empty",

--- a/packages/adapter-tests/generated-data-points.json
+++ b/packages/adapter-tests/generated-data-points.json
@@ -2067,6 +2067,50 @@
       }
     }
   ],
+  "query-href-src": [
+    {
+      "name": "gen:base:empty",
+      "props": {
+        "base": "",
+        "w": "64"
+      }
+    },
+    {
+      "name": "gen:base:markup",
+      "props": {
+        "base": "<b>&\"'</b>",
+        "w": "64"
+      }
+    },
+    {
+      "name": "gen:base:multibyte",
+      "props": {
+        "base": "日本語",
+        "w": "64"
+      }
+    },
+    {
+      "name": "gen:w:empty",
+      "props": {
+        "base": "/thumb",
+        "w": ""
+      }
+    },
+    {
+      "name": "gen:w:markup",
+      "props": {
+        "base": "/thumb",
+        "w": "<b>&\"'</b>"
+      }
+    },
+    {
+      "name": "gen:w:multibyte",
+      "props": {
+        "base": "/thumb",
+        "w": "日本語"
+      }
+    }
+  ],
   "reduce-concat": [
     {
       "name": "gen:items:empty",

--- a/packages/adapter-twig/src/conformance-pins.ts
+++ b/packages/adapter-twig/src/conformance-pins.ts
@@ -15,7 +15,7 @@ export const conformancePins: ConformancePins = {
   // rendering — it never consults the lowering registry for a branch the
   // way the direct-call attribute path does, so it falls to the generic
   // expression emitter, which refuses the params object literal.
-  'query-href-ternary': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2843' }],
+  'query-href-ternary': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2843', unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2843' } }],
   'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
   'map-array-builder-body': [{ code: 'BF021', severity: 'error' }],
   'map-array-builder-escaping': [{ code: 'BF021', severity: 'error' }],

--- a/packages/adapter-twig/src/conformance-pins.ts
+++ b/packages/adapter-twig/src/conformance-pins.ts
@@ -10,6 +10,12 @@
 import type { ConformancePins } from '@barefootjs/jsx'
 
 export const conformancePins: ConformancePins = {
+  // #2843: a lowering-registry call (e.g. queryHref) inside a ternary
+  // attribute branch isn't recognized by this adapter's ternary-attribute
+  // rendering — it never consults the lowering registry for a branch the
+  // way the direct-call attribute path does, so it falls to the generic
+  // expression emitter, which refuses the params object literal.
+  'query-href-ternary': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2843' }],
   'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
   'map-array-builder-body': [{ code: 'BF021', severity: 'error' }],
   'map-array-builder-escaping': [{ code: 'BF021', severity: 'error' }],

--- a/packages/adapter-xslate/src/conformance-pins.ts
+++ b/packages/adapter-xslate/src/conformance-pins.ts
@@ -15,7 +15,7 @@ export const conformancePins: ConformancePins = {
   // rendering — it never consults the lowering registry for a branch the
   // way the direct-call attribute path does, so it falls to the generic
   // expression emitter, which refuses the params object literal.
-  'query-href-ternary': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2843' }],
+  'query-href-ternary': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2843', unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2843' } }],
   'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
   'map-array-builder-body': [{ code: 'BF021', severity: 'error' }],
   'map-array-builder-escaping': [{ code: 'BF021', severity: 'error' }],

--- a/packages/adapter-xslate/src/conformance-pins.ts
+++ b/packages/adapter-xslate/src/conformance-pins.ts
@@ -10,6 +10,12 @@
 import type { ConformancePins } from '@barefootjs/jsx'
 
 export const conformancePins: ConformancePins = {
+  // #2843: a lowering-registry call (e.g. queryHref) inside a ternary
+  // attribute branch isn't recognized by this adapter's ternary-attribute
+  // rendering — it never consults the lowering registry for a branch the
+  // way the direct-call attribute path does, so it falls to the generic
+  // expression emitter, which refuses the params object literal.
+  'query-href-ternary': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2843' }],
   'filter-typeof-predicate': [{ code: 'BF021', severity: 'error' }],
   'map-array-builder-body': [{ code: 'BF021', severity: 'error' }],
   'map-array-builder-escaping': [{ code: 'BF021', severity: 'error' }],

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -3048,6 +3048,92 @@
           }
         }
       },
+      "query-href-ternary": {
+        "blade": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2843"
+          ],
+          "escape": {
+            "state": "debt"
+          }
+        },
+        "erb": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2843"
+          ],
+          "escape": {
+            "state": "debt"
+          }
+        },
+        "jinja": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2843"
+          ],
+          "escape": {
+            "state": "debt"
+          }
+        },
+        "minijinja": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2843"
+          ],
+          "escape": {
+            "state": "debt"
+          }
+        },
+        "mojolicious": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2843"
+          ],
+          "escape": {
+            "state": "debt"
+          }
+        },
+        "twig": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2843"
+          ],
+          "escape": {
+            "state": "debt"
+          }
+        },
+        "xslate": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2843"
+          ],
+          "escape": {
+            "state": "debt"
+          }
+        }
+      },
       "reduce-right-typeof-body": {
         "blade": {
           "kind": "refusal",
@@ -3755,6 +3841,10 @@
       "preamble-cells": {
         "description": "keyed .map() row with a preamble-built leaf child — patched in place on same-key update, not frozen",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/preamble-cells.ts"
+      },
+      "query-href-ternary": {
+        "description": "queryHref(base, {…}) inside a ternary attribute branch (non-undefined alternate) lowers through the…",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/query-href-ternary.ts"
       },
       "reduce-right-typeof-body": {
         "description": "Off-subset `.reduceRight()` body (typeof) — JS-runtime faithful, DSL diagnostic",

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-conformance section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. This answers, per fixture and per adapter, whether the construct WORKS — not just whether it compiles. A construct works either as written (✓) or with a documented `/* @client */` comment (✓†, a verified, supported escape — most refusals have one). Fixtures absent from the table below work on every adapter — most as written, some via that documented escape; the headline says how many of each. Listed fixtures need attention somewhere: a bare diagnostic code is still-open debt with no escape yet, a code led by ✗ owes no escape at all (by design), and ≠ means the fixture compiles clean but its rendered output diverges from the reference.",
-    "totalFixtures": 367,
+    "totalFixtures": 368,
     "fixtures": {
       "aliased-loop-source": {
         "blade": {

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-conformance section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. This answers, per fixture and per adapter, whether the construct WORKS — not just whether it compiles. A construct works either as written (✓) or with a documented `/* @client */` comment (✓†, a verified, supported escape — most refusals have one). Fixtures absent from the table below work on every adapter — most as written, some via that documented escape; the headline says how many of each. Listed fixtures need attention somewhere: a bare diagnostic code is still-open debt with no escape yet, a code led by ✗ owes no escape at all (by design), and ≠ means the fixture compiles clean but its rendered output diverges from the reference.",
-    "totalFixtures": 368,
+    "totalFixtures": 369,
     "fixtures": {
       "aliased-loop-source": {
         "blade": {

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -1471,7 +1471,7 @@
           ]
         },
         "blade": {
-          "pass": 228,
+          "pass": 227,
           "total": 245,
           "gaps": [
             {
@@ -1527,6 +1527,12 @@
               "issues": []
             },
             {
+              "fixture": "query-href-ternary",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2843"
+              ]
+            },
+            {
               "fixture": "reduce-right-typeof-body",
               "issues": []
             },
@@ -1557,7 +1563,7 @@
           ]
         },
         "erb": {
-          "pass": 229,
+          "pass": 228,
           "total": 245,
           "gaps": [
             {
@@ -1605,6 +1611,12 @@
             {
               "fixture": "preamble-cells",
               "issues": []
+            },
+            {
+              "fixture": "query-href-ternary",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2843"
+              ]
             },
             {
               "fixture": "reduce-right-typeof-body",
@@ -1729,7 +1741,7 @@
           ]
         },
         "jinja": {
-          "pass": 228,
+          "pass": 227,
           "total": 245,
           "gaps": [
             {
@@ -1783,6 +1795,12 @@
             {
               "fixture": "preamble-cells",
               "issues": []
+            },
+            {
+              "fixture": "query-href-ternary",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2843"
+              ]
             },
             {
               "fixture": "reduce-right-typeof-body",
@@ -1815,7 +1833,7 @@
           ]
         },
         "minijinja": {
-          "pass": 228,
+          "pass": 227,
           "total": 245,
           "gaps": [
             {
@@ -1869,6 +1887,12 @@
             {
               "fixture": "preamble-cells",
               "issues": []
+            },
+            {
+              "fixture": "query-href-ternary",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2843"
+              ]
             },
             {
               "fixture": "reduce-right-typeof-body",
@@ -1901,7 +1925,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 229,
+          "pass": 228,
           "total": 245,
           "gaps": [
             {
@@ -1949,6 +1973,12 @@
             {
               "fixture": "preamble-cells",
               "issues": []
+            },
+            {
+              "fixture": "query-href-ternary",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2843"
+              ]
             },
             {
               "fixture": "reduce-right-typeof-body",
@@ -1981,7 +2011,7 @@
           ]
         },
         "twig": {
-          "pass": 228,
+          "pass": 227,
           "total": 245,
           "gaps": [
             {
@@ -2035,6 +2065,12 @@
             {
               "fixture": "preamble-cells",
               "issues": []
+            },
+            {
+              "fixture": "query-href-ternary",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2843"
+              ]
             },
             {
               "fixture": "reduce-right-typeof-body",
@@ -2067,7 +2103,7 @@
           ]
         },
         "xslate": {
-          "pass": 228,
+          "pass": 227,
           "total": 245,
           "gaps": [
             {
@@ -2121,6 +2157,12 @@
             {
               "fixture": "preamble-cells",
               "issues": []
+            },
+            {
+              "fixture": "query-href-ternary",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2843"
+              ]
             },
             {
               "fixture": "reduce-right-typeof-body",
@@ -2173,7 +2215,7 @@
           "total": 28
         },
         "blade": {
-          "pass": 26,
+          "pass": 25,
           "total": 28,
           "gaps": [
             {
@@ -2183,11 +2225,17 @@
             {
               "fixture": "preamble-cells",
               "issues": []
+            },
+            {
+              "fixture": "query-href-ternary",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2843"
+              ]
             }
           ]
         },
         "erb": {
-          "pass": 26,
+          "pass": 25,
           "total": 28,
           "gaps": [
             {
@@ -2197,6 +2245,12 @@
             {
               "fixture": "preamble-cells",
               "issues": []
+            },
+            {
+              "fixture": "query-href-ternary",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2843"
+              ]
             }
           ]
         },
@@ -2215,7 +2269,7 @@
           ]
         },
         "jinja": {
-          "pass": 26,
+          "pass": 25,
           "total": 28,
           "gaps": [
             {
@@ -2225,11 +2279,17 @@
             {
               "fixture": "preamble-cells",
               "issues": []
+            },
+            {
+              "fixture": "query-href-ternary",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2843"
+              ]
             }
           ]
         },
         "minijinja": {
-          "pass": 26,
+          "pass": 25,
           "total": 28,
           "gaps": [
             {
@@ -2239,11 +2299,17 @@
             {
               "fixture": "preamble-cells",
               "issues": []
+            },
+            {
+              "fixture": "query-href-ternary",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2843"
+              ]
             }
           ]
         },
         "mojolicious": {
-          "pass": 26,
+          "pass": 25,
           "total": 28,
           "gaps": [
             {
@@ -2253,11 +2319,17 @@
             {
               "fixture": "preamble-cells",
               "issues": []
+            },
+            {
+              "fixture": "query-href-ternary",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2843"
+              ]
             }
           ]
         },
         "twig": {
-          "pass": 26,
+          "pass": 25,
           "total": 28,
           "gaps": [
             {
@@ -2267,11 +2339,17 @@
             {
               "fixture": "preamble-cells",
               "issues": []
+            },
+            {
+              "fixture": "query-href-ternary",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2843"
+              ]
             }
           ]
         },
         "xslate": {
-          "pass": 26,
+          "pass": 25,
           "total": 28,
           "gaps": [
             {
@@ -2281,6 +2359,12 @@
             {
               "fixture": "preamble-cells",
               "issues": []
+            },
+            {
+              "fixture": "query-href-ternary",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2843"
+              ]
             }
           ]
         }
@@ -2331,7 +2415,7 @@
           ]
         },
         "blade": {
-          "pass": 326,
+          "pass": 325,
           "total": 347,
           "gaps": [
             {
@@ -2407,6 +2491,12 @@
               "issues": []
             },
             {
+              "fixture": "query-href-ternary",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2843"
+              ]
+            },
+            {
               "fixture": "reduce-right-typeof-body",
               "issues": []
             },
@@ -2437,7 +2527,7 @@
           ]
         },
         "erb": {
-          "pass": 327,
+          "pass": 326,
           "total": 347,
           "gaps": [
             {
@@ -2505,6 +2595,12 @@
             {
               "fixture": "preamble-cells",
               "issues": []
+            },
+            {
+              "fixture": "query-href-ternary",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2843"
+              ]
             },
             {
               "fixture": "reduce-right-typeof-body",
@@ -2659,7 +2755,7 @@
           ]
         },
         "jinja": {
-          "pass": 326,
+          "pass": 325,
           "total": 347,
           "gaps": [
             {
@@ -2733,6 +2829,12 @@
             {
               "fixture": "preamble-cells",
               "issues": []
+            },
+            {
+              "fixture": "query-href-ternary",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2843"
+              ]
             },
             {
               "fixture": "reduce-right-typeof-body",
@@ -2765,7 +2867,7 @@
           ]
         },
         "minijinja": {
-          "pass": 326,
+          "pass": 325,
           "total": 347,
           "gaps": [
             {
@@ -2841,6 +2943,12 @@
               "issues": []
             },
             {
+              "fixture": "query-href-ternary",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2843"
+              ]
+            },
+            {
               "fixture": "reduce-right-typeof-body",
               "issues": []
             },
@@ -2871,7 +2979,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 326,
+          "pass": 325,
           "total": 347,
           "gaps": [
             {
@@ -2945,6 +3053,12 @@
               "issues": []
             },
             {
+              "fixture": "query-href-ternary",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2843"
+              ]
+            },
+            {
               "fixture": "reduce-right-typeof-body",
               "issues": []
             },
@@ -2975,7 +3089,7 @@
           ]
         },
         "twig": {
-          "pass": 326,
+          "pass": 325,
           "total": 347,
           "gaps": [
             {
@@ -3049,6 +3163,12 @@
             {
               "fixture": "preamble-cells",
               "issues": []
+            },
+            {
+              "fixture": "query-href-ternary",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2843"
+              ]
             },
             {
               "fixture": "reduce-right-typeof-body",
@@ -3081,7 +3201,7 @@
           ]
         },
         "xslate": {
-          "pass": 326,
+          "pass": 325,
           "total": 347,
           "gaps": [
             {
@@ -3155,6 +3275,12 @@
             {
               "fixture": "preamble-cells",
               "issues": []
+            },
+            {
+              "fixture": "query-href-ternary",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2843"
+              ]
             },
             {
               "fixture": "reduce-right-typeof-body",
@@ -3267,7 +3393,7 @@
           ]
         },
         "blade": {
-          "pass": 263,
+          "pass": 262,
           "total": 276,
           "gaps": [
             {
@@ -3303,6 +3429,12 @@
             {
               "fixture": "preamble-cells",
               "issues": []
+            },
+            {
+              "fixture": "query-href-ternary",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2843"
+              ]
             },
             {
               "fixture": "reduce-right-typeof-body",
@@ -3329,7 +3461,7 @@
           ]
         },
         "erb": {
-          "pass": 263,
+          "pass": 262,
           "total": 276,
           "gaps": [
             {
@@ -3365,6 +3497,12 @@
             {
               "fixture": "preamble-cells",
               "issues": []
+            },
+            {
+              "fixture": "query-href-ternary",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2843"
+              ]
             },
             {
               "fixture": "reduce-right-typeof-body",
@@ -3465,7 +3603,7 @@
           ]
         },
         "jinja": {
-          "pass": 263,
+          "pass": 262,
           "total": 276,
           "gaps": [
             {
@@ -3501,6 +3639,12 @@
             {
               "fixture": "preamble-cells",
               "issues": []
+            },
+            {
+              "fixture": "query-href-ternary",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2843"
+              ]
             },
             {
               "fixture": "reduce-right-typeof-body",
@@ -3527,7 +3671,7 @@
           ]
         },
         "minijinja": {
-          "pass": 263,
+          "pass": 262,
           "total": 276,
           "gaps": [
             {
@@ -3563,6 +3707,12 @@
             {
               "fixture": "preamble-cells",
               "issues": []
+            },
+            {
+              "fixture": "query-href-ternary",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2843"
+              ]
             },
             {
               "fixture": "reduce-right-typeof-body",
@@ -3589,7 +3739,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 263,
+          "pass": 262,
           "total": 276,
           "gaps": [
             {
@@ -3625,6 +3775,12 @@
             {
               "fixture": "preamble-cells",
               "issues": []
+            },
+            {
+              "fixture": "query-href-ternary",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2843"
+              ]
             },
             {
               "fixture": "reduce-right-typeof-body",
@@ -3651,7 +3807,7 @@
           ]
         },
         "twig": {
-          "pass": 263,
+          "pass": 262,
           "total": 276,
           "gaps": [
             {
@@ -3687,6 +3843,12 @@
             {
               "fixture": "preamble-cells",
               "issues": []
+            },
+            {
+              "fixture": "query-href-ternary",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2843"
+              ]
             },
             {
               "fixture": "reduce-right-typeof-body",
@@ -3713,7 +3875,7 @@
           ]
         },
         "xslate": {
-          "pass": 263,
+          "pass": 262,
           "total": 276,
           "gaps": [
             {
@@ -3749,6 +3911,12 @@
             {
               "fixture": "preamble-cells",
               "issues": []
+            },
+            {
+              "fixture": "query-href-ternary",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2843"
+              ]
             },
             {
               "fixture": "reduce-right-typeof-body",
@@ -4791,7 +4959,7 @@
           "total": 70
         },
         "blade": {
-          "pass": 66,
+          "pass": 65,
           "total": 70,
           "gaps": [
             {
@@ -4801,6 +4969,12 @@
             {
               "fixture": "preamble-cells",
               "issues": []
+            },
+            {
+              "fixture": "query-href-ternary",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2843"
+              ]
             },
             {
               "fixture": "static-array-from-props",
@@ -4815,7 +4989,7 @@
           ]
         },
         "erb": {
-          "pass": 66,
+          "pass": 65,
           "total": 70,
           "gaps": [
             {
@@ -4825,6 +4999,12 @@
             {
               "fixture": "preamble-cells",
               "issues": []
+            },
+            {
+              "fixture": "query-href-ternary",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2843"
+              ]
             },
             {
               "fixture": "static-array-from-props",
@@ -4869,7 +5049,7 @@
           ]
         },
         "jinja": {
-          "pass": 66,
+          "pass": 65,
           "total": 70,
           "gaps": [
             {
@@ -4879,6 +5059,12 @@
             {
               "fixture": "preamble-cells",
               "issues": []
+            },
+            {
+              "fixture": "query-href-ternary",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2843"
+              ]
             },
             {
               "fixture": "static-array-from-props",
@@ -4893,7 +5079,7 @@
           ]
         },
         "minijinja": {
-          "pass": 66,
+          "pass": 65,
           "total": 70,
           "gaps": [
             {
@@ -4903,6 +5089,12 @@
             {
               "fixture": "preamble-cells",
               "issues": []
+            },
+            {
+              "fixture": "query-href-ternary",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2843"
+              ]
             },
             {
               "fixture": "static-array-from-props",
@@ -4917,7 +5109,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 66,
+          "pass": 65,
           "total": 70,
           "gaps": [
             {
@@ -4927,6 +5119,12 @@
             {
               "fixture": "preamble-cells",
               "issues": []
+            },
+            {
+              "fixture": "query-href-ternary",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2843"
+              ]
             },
             {
               "fixture": "static-array-from-props",
@@ -4941,7 +5139,7 @@
           ]
         },
         "twig": {
-          "pass": 66,
+          "pass": 65,
           "total": 70,
           "gaps": [
             {
@@ -4951,6 +5149,12 @@
             {
               "fixture": "preamble-cells",
               "issues": []
+            },
+            {
+              "fixture": "query-href-ternary",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2843"
+              ]
             },
             {
               "fixture": "static-array-from-props",
@@ -4965,7 +5169,7 @@
           ]
         },
         "xslate": {
-          "pass": 66,
+          "pass": 65,
           "total": 70,
           "gaps": [
             {
@@ -4975,6 +5179,12 @@
             {
               "fixture": "preamble-cells",
               "issues": []
+            },
+            {
+              "fixture": "query-href-ternary",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2843"
+              ]
             },
             {
               "fixture": "static-array-from-props",
@@ -8490,7 +8700,7 @@
           "total": 193
         },
         "blade": {
-          "pass": 184,
+          "pass": 183,
           "total": 193,
           "gaps": [
             {
@@ -8520,6 +8730,12 @@
             {
               "fixture": "preamble-cells",
               "issues": []
+            },
+            {
+              "fixture": "query-href-ternary",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2843"
+              ]
             },
             {
               "fixture": "some-typeof-predicate",
@@ -8534,7 +8750,7 @@
           ]
         },
         "erb": {
-          "pass": 184,
+          "pass": 183,
           "total": 193,
           "gaps": [
             {
@@ -8564,6 +8780,12 @@
             {
               "fixture": "preamble-cells",
               "issues": []
+            },
+            {
+              "fixture": "query-href-ternary",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2843"
+              ]
             },
             {
               "fixture": "some-typeof-predicate",
@@ -8628,7 +8850,7 @@
           ]
         },
         "jinja": {
-          "pass": 184,
+          "pass": 183,
           "total": 193,
           "gaps": [
             {
@@ -8658,6 +8880,12 @@
             {
               "fixture": "preamble-cells",
               "issues": []
+            },
+            {
+              "fixture": "query-href-ternary",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2843"
+              ]
             },
             {
               "fixture": "some-typeof-predicate",
@@ -8672,7 +8900,7 @@
           ]
         },
         "minijinja": {
-          "pass": 184,
+          "pass": 183,
           "total": 193,
           "gaps": [
             {
@@ -8702,6 +8930,12 @@
             {
               "fixture": "preamble-cells",
               "issues": []
+            },
+            {
+              "fixture": "query-href-ternary",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2843"
+              ]
             },
             {
               "fixture": "some-typeof-predicate",
@@ -8716,7 +8950,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 184,
+          "pass": 183,
           "total": 193,
           "gaps": [
             {
@@ -8746,6 +8980,12 @@
             {
               "fixture": "preamble-cells",
               "issues": []
+            },
+            {
+              "fixture": "query-href-ternary",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2843"
+              ]
             },
             {
               "fixture": "some-typeof-predicate",
@@ -8760,7 +9000,7 @@
           ]
         },
         "twig": {
-          "pass": 184,
+          "pass": 183,
           "total": 193,
           "gaps": [
             {
@@ -8790,6 +9030,12 @@
             {
               "fixture": "preamble-cells",
               "issues": []
+            },
+            {
+              "fixture": "query-href-ternary",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2843"
+              ]
             },
             {
               "fixture": "some-typeof-predicate",
@@ -8804,7 +9050,7 @@
           ]
         },
         "xslate": {
-          "pass": 184,
+          "pass": 183,
           "total": 193,
           "gaps": [
             {
@@ -8834,6 +9080,12 @@
             {
               "fixture": "preamble-cells",
               "issues": []
+            },
+            {
+              "fixture": "query-href-ternary",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2843"
+              ]
             },
             {
               "fixture": "some-typeof-predicate",
@@ -9222,36 +9474,92 @@
           "total": 3
         },
         "blade": {
-          "pass": 3,
-          "total": 3
+          "pass": 2,
+          "total": 3,
+          "gaps": [
+            {
+              "fixture": "query-href-ternary",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2843"
+              ]
+            }
+          ]
         },
         "erb": {
-          "pass": 3,
-          "total": 3
+          "pass": 2,
+          "total": 3,
+          "gaps": [
+            {
+              "fixture": "query-href-ternary",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2843"
+              ]
+            }
+          ]
         },
         "go-template": {
           "pass": 3,
           "total": 3
         },
         "jinja": {
-          "pass": 3,
-          "total": 3
+          "pass": 2,
+          "total": 3,
+          "gaps": [
+            {
+              "fixture": "query-href-ternary",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2843"
+              ]
+            }
+          ]
         },
         "minijinja": {
-          "pass": 3,
-          "total": 3
+          "pass": 2,
+          "total": 3,
+          "gaps": [
+            {
+              "fixture": "query-href-ternary",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2843"
+              ]
+            }
+          ]
         },
         "mojolicious": {
-          "pass": 3,
-          "total": 3
+          "pass": 2,
+          "total": 3,
+          "gaps": [
+            {
+              "fixture": "query-href-ternary",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2843"
+              ]
+            }
+          ]
         },
         "twig": {
-          "pass": 3,
-          "total": 3
+          "pass": 2,
+          "total": 3,
+          "gaps": [
+            {
+              "fixture": "query-href-ternary",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2843"
+              ]
+            }
+          ]
         },
         "xslate": {
-          "pass": 3,
-          "total": 3
+          "pass": 2,
+          "total": 3,
+          "gaps": [
+            {
+              "fixture": "query-href-ternary",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2843"
+              ]
+            }
+          ]
         }
       },
       "source": {

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -1450,11 +1450,11 @@
       }
     },
     "call": {
-      "total": 244,
+      "total": 245,
       "cells": {
         "hono": {
-          "pass": 242,
-          "total": 244,
+          "pass": 243,
+          "total": 245,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1471,8 +1471,8 @@
           ]
         },
         "blade": {
-          "pass": 227,
-          "total": 244,
+          "pass": 228,
+          "total": 245,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -1557,8 +1557,8 @@
           ]
         },
         "erb": {
-          "pass": 228,
-          "total": 244,
+          "pass": 229,
+          "total": 245,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -1637,8 +1637,8 @@
           ]
         },
         "go-template": {
-          "pass": 226,
-          "total": 244,
+          "pass": 227,
+          "total": 245,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -1729,8 +1729,8 @@
           ]
         },
         "jinja": {
-          "pass": 227,
-          "total": 244,
+          "pass": 228,
+          "total": 245,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -1815,8 +1815,8 @@
           ]
         },
         "minijinja": {
-          "pass": 227,
-          "total": 244,
+          "pass": 228,
+          "total": 245,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -1901,8 +1901,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 228,
-          "total": 244,
+          "pass": 229,
+          "total": 245,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -1981,8 +1981,8 @@
           ]
         },
         "twig": {
-          "pass": 227,
-          "total": 244,
+          "pass": 228,
+          "total": 245,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -2067,8 +2067,8 @@
           ]
         },
         "xslate": {
-          "pass": 227,
-          "total": 244,
+          "pass": 228,
+          "total": 245,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -2166,15 +2166,15 @@
       }
     },
     "conditional": {
-      "total": 27,
+      "total": 28,
       "cells": {
         "hono": {
-          "pass": 27,
-          "total": 27
+          "pass": 28,
+          "total": 28
         },
         "blade": {
-          "pass": 25,
-          "total": 27,
+          "pass": 26,
+          "total": 28,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
@@ -2187,8 +2187,8 @@
           ]
         },
         "erb": {
-          "pass": 25,
-          "total": 27,
+          "pass": 26,
+          "total": 28,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
@@ -2201,8 +2201,8 @@
           ]
         },
         "go-template": {
-          "pass": 25,
-          "total": 27,
+          "pass": 26,
+          "total": 28,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
@@ -2215,8 +2215,8 @@
           ]
         },
         "jinja": {
-          "pass": 25,
-          "total": 27,
+          "pass": 26,
+          "total": 28,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
@@ -2229,8 +2229,8 @@
           ]
         },
         "minijinja": {
-          "pass": 25,
-          "total": 27,
+          "pass": 26,
+          "total": 28,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
@@ -2243,8 +2243,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 25,
-          "total": 27,
+          "pass": 26,
+          "total": 28,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
@@ -2257,8 +2257,8 @@
           ]
         },
         "twig": {
-          "pass": 25,
-          "total": 27,
+          "pass": 26,
+          "total": 28,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
@@ -2271,8 +2271,8 @@
           ]
         },
         "xslate": {
-          "pass": 25,
-          "total": 27,
+          "pass": 26,
+          "total": 28,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
@@ -2298,11 +2298,11 @@
       }
     },
     "identifier": {
-      "total": 346,
+      "total": 347,
       "cells": {
         "hono": {
-          "pass": 342,
-          "total": 346,
+          "pass": 343,
+          "total": 347,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2331,8 +2331,8 @@
           ]
         },
         "blade": {
-          "pass": 325,
-          "total": 346,
+          "pass": 326,
+          "total": 347,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -2437,8 +2437,8 @@
           ]
         },
         "erb": {
-          "pass": 326,
-          "total": 346,
+          "pass": 327,
+          "total": 347,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -2537,8 +2537,8 @@
           ]
         },
         "go-template": {
-          "pass": 322,
-          "total": 346,
+          "pass": 323,
+          "total": 347,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -2659,8 +2659,8 @@
           ]
         },
         "jinja": {
-          "pass": 325,
-          "total": 346,
+          "pass": 326,
+          "total": 347,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -2765,8 +2765,8 @@
           ]
         },
         "minijinja": {
-          "pass": 325,
-          "total": 346,
+          "pass": 326,
+          "total": 347,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -2871,8 +2871,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 325,
-          "total": 346,
+          "pass": 326,
+          "total": 347,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -2975,8 +2975,8 @@
           ]
         },
         "twig": {
-          "pass": 325,
-          "total": 346,
+          "pass": 326,
+          "total": 347,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -3081,8 +3081,8 @@
           ]
         },
         "xslate": {
-          "pass": 325,
-          "total": 346,
+          "pass": 326,
+          "total": 347,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -3252,11 +3252,11 @@
       }
     },
     "literal": {
-      "total": 275,
+      "total": 276,
       "cells": {
         "hono": {
-          "pass": 274,
-          "total": 275,
+          "pass": 275,
+          "total": 276,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -3267,8 +3267,8 @@
           ]
         },
         "blade": {
-          "pass": 262,
-          "total": 275,
+          "pass": 263,
+          "total": 276,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -3329,8 +3329,8 @@
           ]
         },
         "erb": {
-          "pass": 262,
-          "total": 275,
+          "pass": 263,
+          "total": 276,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -3391,8 +3391,8 @@
           ]
         },
         "go-template": {
-          "pass": 260,
-          "total": 275,
+          "pass": 261,
+          "total": 276,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -3465,8 +3465,8 @@
           ]
         },
         "jinja": {
-          "pass": 262,
-          "total": 275,
+          "pass": 263,
+          "total": 276,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -3527,8 +3527,8 @@
           ]
         },
         "minijinja": {
-          "pass": 262,
-          "total": 275,
+          "pass": 263,
+          "total": 276,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -3589,8 +3589,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 262,
-          "total": 275,
+          "pass": 263,
+          "total": 276,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -3651,8 +3651,8 @@
           ]
         },
         "twig": {
-          "pass": 262,
-          "total": 275,
+          "pass": 263,
+          "total": 276,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -3713,8 +3713,8 @@
           ]
         },
         "xslate": {
-          "pass": 262,
-          "total": 275,
+          "pass": 263,
+          "total": 276,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -4784,15 +4784,15 @@
       }
     },
     "object-literal": {
-      "total": 69,
+      "total": 70,
       "cells": {
         "hono": {
-          "pass": 69,
-          "total": 69
+          "pass": 70,
+          "total": 70
         },
         "blade": {
-          "pass": 65,
-          "total": 69,
+          "pass": 66,
+          "total": 70,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -4815,8 +4815,8 @@
           ]
         },
         "erb": {
-          "pass": 65,
-          "total": 69,
+          "pass": 66,
+          "total": 70,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -4839,8 +4839,8 @@
           ]
         },
         "go-template": {
-          "pass": 64,
-          "total": 69,
+          "pass": 65,
+          "total": 70,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -4869,8 +4869,8 @@
           ]
         },
         "jinja": {
-          "pass": 65,
-          "total": 69,
+          "pass": 66,
+          "total": 70,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -4893,8 +4893,8 @@
           ]
         },
         "minijinja": {
-          "pass": 65,
-          "total": 69,
+          "pass": 66,
+          "total": 70,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -4917,8 +4917,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 65,
-          "total": 69,
+          "pass": 66,
+          "total": 70,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -4941,8 +4941,8 @@
           ]
         },
         "twig": {
-          "pass": 65,
-          "total": 69,
+          "pass": 66,
+          "total": 70,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -4965,8 +4965,8 @@
           ]
         },
         "xslate": {
-          "pass": 65,
-          "total": 69,
+          "pass": 66,
+          "total": 70,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -8483,15 +8483,15 @@
       }
     },
     "literal:string": {
-      "total": 192,
+      "total": 193,
       "cells": {
         "hono": {
-          "pass": 192,
-          "total": 192
+          "pass": 193,
+          "total": 193
         },
         "blade": {
-          "pass": 183,
-          "total": 192,
+          "pass": 184,
+          "total": 193,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -8534,8 +8534,8 @@
           ]
         },
         "erb": {
-          "pass": 183,
-          "total": 192,
+          "pass": 184,
+          "total": 193,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -8578,8 +8578,8 @@
           ]
         },
         "go-template": {
-          "pass": 182,
-          "total": 192,
+          "pass": 183,
+          "total": 193,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -8628,8 +8628,8 @@
           ]
         },
         "jinja": {
-          "pass": 183,
-          "total": 192,
+          "pass": 184,
+          "total": 193,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -8672,8 +8672,8 @@
           ]
         },
         "minijinja": {
-          "pass": 183,
-          "total": 192,
+          "pass": 184,
+          "total": 193,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -8716,8 +8716,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 183,
-          "total": 192,
+          "pass": 184,
+          "total": 193,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -8760,8 +8760,8 @@
           ]
         },
         "twig": {
-          "pass": 183,
-          "total": 192,
+          "pass": 184,
+          "total": 193,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -8804,8 +8804,8 @@
           ]
         },
         "xslate": {
-          "pass": 183,
-          "total": 192,
+          "pass": 184,
+          "total": 193,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -9215,43 +9215,43 @@
       }
     },
     "lowering:queryHref": {
-      "total": 2,
+      "total": 3,
       "cells": {
         "hono": {
-          "pass": 2,
-          "total": 2
+          "pass": 3,
+          "total": 3
         },
         "blade": {
-          "pass": 2,
-          "total": 2
+          "pass": 3,
+          "total": 3
         },
         "erb": {
-          "pass": 2,
-          "total": 2
+          "pass": 3,
+          "total": 3
         },
         "go-template": {
-          "pass": 2,
-          "total": 2
+          "pass": 3,
+          "total": 3
         },
         "jinja": {
-          "pass": 2,
-          "total": 2
+          "pass": 3,
+          "total": 3
         },
         "minijinja": {
-          "pass": 2,
-          "total": 2
+          "pass": 3,
+          "total": 3
         },
         "mojolicious": {
-          "pass": 2,
-          "total": 2
+          "pass": 3,
+          "total": 3
         },
         "twig": {
-          "pass": 2,
-          "total": 2
+          "pass": 3,
+          "total": 3
         },
         "xslate": {
-          "pass": 2,
-          "total": 2
+          "pass": 3,
+          "total": 3
         }
       },
       "source": {

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -1450,11 +1450,11 @@
       }
     },
     "call": {
-      "total": 243,
+      "total": 244,
       "cells": {
         "hono": {
-          "pass": 241,
-          "total": 243,
+          "pass": 242,
+          "total": 244,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1471,8 +1471,8 @@
           ]
         },
         "blade": {
-          "pass": 226,
-          "total": 243,
+          "pass": 227,
+          "total": 244,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -1557,8 +1557,8 @@
           ]
         },
         "erb": {
-          "pass": 227,
-          "total": 243,
+          "pass": 228,
+          "total": 244,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -1637,8 +1637,8 @@
           ]
         },
         "go-template": {
-          "pass": 225,
-          "total": 243,
+          "pass": 226,
+          "total": 244,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -1729,8 +1729,8 @@
           ]
         },
         "jinja": {
-          "pass": 226,
-          "total": 243,
+          "pass": 227,
+          "total": 244,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -1815,8 +1815,8 @@
           ]
         },
         "minijinja": {
-          "pass": 226,
-          "total": 243,
+          "pass": 227,
+          "total": 244,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -1901,8 +1901,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 227,
-          "total": 243,
+          "pass": 228,
+          "total": 244,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -1981,8 +1981,8 @@
           ]
         },
         "twig": {
-          "pass": 226,
-          "total": 243,
+          "pass": 227,
+          "total": 244,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -2067,8 +2067,8 @@
           ]
         },
         "xslate": {
-          "pass": 226,
-          "total": 243,
+          "pass": 227,
+          "total": 244,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -2298,11 +2298,11 @@
       }
     },
     "identifier": {
-      "total": 345,
+      "total": 346,
       "cells": {
         "hono": {
-          "pass": 341,
-          "total": 345,
+          "pass": 342,
+          "total": 346,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2331,8 +2331,8 @@
           ]
         },
         "blade": {
-          "pass": 324,
-          "total": 345,
+          "pass": 325,
+          "total": 346,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -2437,8 +2437,8 @@
           ]
         },
         "erb": {
-          "pass": 325,
-          "total": 345,
+          "pass": 326,
+          "total": 346,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -2537,8 +2537,8 @@
           ]
         },
         "go-template": {
-          "pass": 321,
-          "total": 345,
+          "pass": 322,
+          "total": 346,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -2659,8 +2659,8 @@
           ]
         },
         "jinja": {
-          "pass": 324,
-          "total": 345,
+          "pass": 325,
+          "total": 346,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -2765,8 +2765,8 @@
           ]
         },
         "minijinja": {
-          "pass": 324,
-          "total": 345,
+          "pass": 325,
+          "total": 346,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -2871,8 +2871,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 324,
-          "total": 345,
+          "pass": 325,
+          "total": 346,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -2975,8 +2975,8 @@
           ]
         },
         "twig": {
-          "pass": 324,
-          "total": 345,
+          "pass": 325,
+          "total": 346,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -3081,8 +3081,8 @@
           ]
         },
         "xslate": {
-          "pass": 324,
-          "total": 345,
+          "pass": 325,
+          "total": 346,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -4784,15 +4784,15 @@
       }
     },
     "object-literal": {
-      "total": 68,
+      "total": 69,
       "cells": {
         "hono": {
-          "pass": 68,
-          "total": 68
+          "pass": 69,
+          "total": 69
         },
         "blade": {
-          "pass": 64,
-          "total": 68,
+          "pass": 65,
+          "total": 69,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -4815,8 +4815,8 @@
           ]
         },
         "erb": {
-          "pass": 64,
-          "total": 68,
+          "pass": 65,
+          "total": 69,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -4839,8 +4839,8 @@
           ]
         },
         "go-template": {
-          "pass": 63,
-          "total": 68,
+          "pass": 64,
+          "total": 69,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -4869,8 +4869,8 @@
           ]
         },
         "jinja": {
-          "pass": 64,
-          "total": 68,
+          "pass": 65,
+          "total": 69,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -4893,8 +4893,8 @@
           ]
         },
         "minijinja": {
-          "pass": 64,
-          "total": 68,
+          "pass": 65,
+          "total": 69,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -4917,8 +4917,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 64,
-          "total": 68,
+          "pass": 65,
+          "total": 69,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -4941,8 +4941,8 @@
           ]
         },
         "twig": {
-          "pass": 64,
-          "total": 68,
+          "pass": 65,
+          "total": 69,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -4965,8 +4965,8 @@
           ]
         },
         "xslate": {
-          "pass": 64,
-          "total": 68,
+          "pass": 65,
+          "total": 69,
           "gaps": [
             {
               "fixture": "aliased-loop-source",
@@ -9215,43 +9215,43 @@
       }
     },
     "lowering:queryHref": {
-      "total": 1,
+      "total": 2,
       "cells": {
         "hono": {
-          "pass": 1,
-          "total": 1
+          "pass": 2,
+          "total": 2
         },
         "blade": {
-          "pass": 1,
-          "total": 1
+          "pass": 2,
+          "total": 2
         },
         "erb": {
-          "pass": 1,
-          "total": 1
+          "pass": 2,
+          "total": 2
         },
         "go-template": {
-          "pass": 1,
-          "total": 1
+          "pass": 2,
+          "total": 2
         },
         "jinja": {
-          "pass": 1,
-          "total": 1
+          "pass": 2,
+          "total": 2
         },
         "minijinja": {
-          "pass": 1,
-          "total": 1
+          "pass": 2,
+          "total": 2
         },
         "mojolicious": {
-          "pass": 1,
-          "total": 1
+          "pass": 2,
+          "total": 2
         },
         "twig": {
-          "pass": 1,
-          "total": 1
+          "pass": 2,
+          "total": 2
         },
         "xslate": {
-          "pass": 1,
-          "total": 1
+          "pass": 2,
+          "total": 2
         }
       },
       "source": {
@@ -9260,9 +9260,9 @@
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/src/coverage-map.ts#L178"
       },
       "example": {
-        "fixture": "query-href",
-        "description": "queryHref(base, {…}) lowers to the query helper via the builtin plugin registry",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/query-href.ts"
+        "fixture": "query-href-src",
+        "description": "queryHref(base, {…}) lowers to the query helper in a non-href (src) attribute",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/query-href-src.ts"
       }
     },
     "lowering:toLocaleDateString": {


### PR DESCRIPTION
## Summary

`<a href={queryHref(base, {…})}>` on the Go adapter diverged from the JS reference (Hono) whenever `base` contained non-URL-safe or multibyte bytes, e.g. `日本語` rendered as `%e6%97%a5%e6%9c%ac%e8%aa%9e...` instead of passing through untouched. Root cause: `html/template` infers a URL context from the attribute name (`href`, `src`, `action`, `data-*`, …) and percent-encodes the whole pipeline result landing there; the reference only HTML-escapes. The `bf_query` runtime helper itself was already byte-faithful — the divergence was purely html/template's contextual auto-escaping bolted on top of the emitted attribute.

- Added a new `bf_attr(name, value) template.HTMLAttr` runtime helper (`packages/adapter-go-template/runtime/bf.go`) that emits a WHOLE `name="value"` attribute, HTML-escaping the value and nothing else — the same technique `bf_spread_attrs`/`bfHydrationAttrs` already use to bypass html/template's contextual auto-escaping (and `StyleObjectToCSS` uses for the analogous CSS-context case).
- Added `lowerRegisteredAttrCall` (`packages/adapter-go-template/src/adapter/expr/url-builder.ts`), which recognizes a `query` guard-list lowering node (the shape `queryHref` produces) landing in an attribute position — as a direct call OR inside a ternary branch (either side, recursing through right-folded chains) — and routes it through `bf_attr` instead of the generic `name="{{...}}"` emission. Wired into `elementAttrEmitter.emitExpression` in `go-template-adapter.ts`.
- The route is keyed on the neutral `helper === 'query'` fact, **not** the attribute name — so `src`, `title`, or any other attribute built from `queryHref` gets the same byte parity, not just `href` (Go's URL-context attribute table is an internal heuristic that shouldn't be re-implemented adapter-side).
- Confirmed against real Hono behavior: the reference adapter does no scheme filtering either (no `javascript:`/`data:` check) — it only HTML-escapes. Matching it exactly is the adapter contract, not a safety regression; a spread-props `href` already bypassed Go's scheme filter the same way before this change.

## Design

Reviewed and designed by an independent design pass (fable) before implementation: verified experimentally that `template.URL` does **not** fix the bug (it still percent-encodes; it only bypasses the scheme filter), and confirmed the whole-attribute `template.HTMLAttr` route matches Hono byte-for-byte (modulo the conformance harness's own HTML-entity-spelling normalization).

A follow-up round (pullfrog review) found the direct-call fix didn't cover a `queryHref` value reached through a ternary attribute branch with a real, non-`undefined` alternate (`cond ? queryHref(...) : '/fallback'`) — that shape already lowered both branches correctly via `bf_ternary`, but the whole pipeline was still wrapped in the plain `name="{{...}}"` form. `lowerRegisteredAttrCall` now also accepts a `conditional` node for this case.

## Test plan

- [x] `packages/adapter-go-template/runtime/bf_test.go`: `TestAttr` (unit) + `TestAttr_BypassesContextualURLEscaper` (end-to-end through a real `html/template` execution, asserting no percent-encoding / no `#ZgotmplZ`) + `TestScratchTernaryAttrBypass`-equivalent coverage for the ternary case
- [x] `packages/adapter-go-template/src/__tests__/query-href.test.ts`: shape pins — `href` and non-`href` (`title`) attributes route through `bf_attr`, text position unaffected, the ternary (non-undefined-alternate) shape routes through `bf_attr`, and the pre-existing `#2842` undefined-alternate gap is confirmed unaffected
- [x] `packages/adapter-go-template/src/__tests__/lowering-plugin.test.ts`: pin that a `helper-call` node (a different `LoweringNode` kind) is never routed through `bf_attr`
- [x] Removed the `query-href:gen:base:markup` / `query-href:gen:base:multibyte` `skipDataPoints` in `go-template-adapter.test.ts` — both now pass against the live Hono oracle
- [x] Added a declared `base-scheme-passthrough` data point to `packages/adapter-tests/fixtures/query-href.ts` pinning the no-scheme-filtering parity decision
- [x] Added `packages/adapter-tests/fixtures/query-href-src.ts` (queryHref in a `src` attribute, attribute-agnostic regression) and `query-href-ternary.ts` (queryHref in a ternary attribute branch, both branches), both registered in `fixtures/index.ts`
- [x] `query-href-ternary` compiles fine on Hono/Go but is refused (`BF101`) by all 7 other adapters (mojolicious/xslate/twig/erb/blade/jinja/minijinja) — a pre-existing, broader gap unrelated to this PR's escaping fix (their ternary-attribute lowering never consults the lowering registry for a branch). Filed as **#2843** and pinned per-adapter (with `unescapable` declarations, required by the escape-coverage floor test) so the shared conformance suite stays green.
- [x] Regenerated `expectedHtml`, `generated-data-points.json`, `coverage-map.json`, `ui/support-matrix.lock.json`, `ui/compat.lock.json` at each step — `git status` confirmed no unrelated drift each time
- [x] `packages/compat`'s full test suite (555 tests, including escape-coverage and both lock files' freshness tests) green
- [x] `bun test` green across all 9 adapters for `query-href`/`query-href-src`/`query-href-ternary`
- [x] `go test` green for the new `Attr` tests
- [x] `tsgo --emitDeclarationOnly` (type-check) clean
- [x] Full CI green (38/38 checks) — the one `fixture-hydrate` failure along the way was an unrelated `select`-component popover-positioning flake, confirmed by a clean re-run

## Out of scope (filed separately)

- **#2842** — `href={cond ? queryHref(base, {...}) : undefined}` (queryHref inside a ternary's `undefined`-alternate consequent) already emits invalid Go template syntax on `main`, independent of this bug (that path's consequent-only render doesn't consult the lowering registry at all). Confirmed unaffected by this PR's change.
- **#2843** — the 7 non-Go, non-Hono adapters refuse `queryHref` (or any lowering-registry call) inside a ternary attribute branch outright (`BF101`), a broader pre-existing gap surfaced while adding this PR's ternary fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P86NEtN4LGiyFYZWqESpQ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01P86NEtN4LGiyFYZWqESpQ6)_