### PR TITLE
Fix select idempotence oracle flake via pre-action scroll settle (#2745)

### DIFF
--- a/packages/adapter-tests/e2e/mutation-quarantine.ts
+++ b/packages/adapter-tests/e2e/mutation-quarantine.ts
@@ -117,7 +117,9 @@ const ENTRIES: readonly MutationQuarantineEntry[] = [
   // attribute (`top`/`--radix-select-content-available-height`) that
   // depends on viewport height at render time — confirmed flaky, not a
   // fragment-wrap regression, by rerunning in isolation (3/3 pass) vs. in
-  // the full parallel suite (1 failure observed).
+  // the full parallel suite (1 failure observed). Since root-caused (#2745)
+  // to Playwright's scroll-into-view racing the page's async `scroll`
+  // event and fixed in `oracle-core.ts`'s `settleScrollBeforeAction`.
 
   // --- G2c (open, #2731) ---------------------------------------------------
   { fixtureId: 'button', mutationId: 'fragment-wrap', oracle: 'three-point', reason: FRAGMENT_WRAP_CONDITIONAL_RETURN_BRANCH_SCOPE_ID, issue: 'https://github.com/piconic-ai/barefootjs/issues/2731' },

--- a/packages/adapter-tests/e2e/oracle-core.ts
+++ b/packages/adapter-tests/e2e/oracle-core.ts
@@ -14,7 +14,7 @@ import type { JSXFixture } from '../src/types'
 import { fixtureUrl } from './fixture-host'
 import { captureDomState, diffDomState, type DomStateSnapshot } from './dom-state'
 import { normalizeHTML, stripConditionalMarkersForCrossAdapter } from '../src/html-normalize'
-import { actionStepsOf, runStep } from './interaction-runner'
+import { actionStepsOf, runStep, type ActionStep } from './interaction-runner'
 
 /**
  * Canonicalize `bf-po` (portal-origin marker) the same way `normalizeHTML`
@@ -72,6 +72,40 @@ export async function captureCsrMount(page: Page, fixture: JSXFixture, baseUrl: 
 }
 
 /**
+ * Pin the scroll → frame → action ordering a real user always produces
+ * before `step` fires (#2745).
+ *
+ * Playwright scrolls an action's target into view itself, but it does so
+ * in the same task as the pointer event, so whether the page's `scroll`
+ * event (dispatched asynchronously, in the next rendering update) is
+ * delivered BEFORE or AFTER the action's own handlers run depends on
+ * whether a frame boundary happens to land in between — under CI load it
+ * sometimes does, locally it mostly doesn't. A component that tracks its
+ * anchor on scroll observes the two orderings as different DOM: `select`'s
+ * content panel re-reads `getBoundingClientRect` on every `scroll` event
+ * while open and stops listening the moment the item click closes it, so
+ * its final inline `top`/`--radix-select-content-available-height`
+ * differed between the two legs by exactly the scroll-into-view distance
+ * (the CSS-less host page grows past the viewport once a selected item's
+ * unsized indicator `<svg>` renders, so the second item click has to
+ * scroll). Nothing about the construction path is being compared there —
+ * only which side of a frame boundary the click fell on.
+ *
+ * The three waits each close one gap: zero-delay work the previous action
+ * deferred (e.g. `select`'s `setTimeout(0)` focus of the selected item,
+ * which scrolls) must run before we scroll, or it could scroll again
+ * after we do; then the target is scrolled into view explicitly; then one
+ * frame delivers that scroll's event so the page has observed it before
+ * the action. With the target already visible, Playwright's own
+ * scroll-into-view inside the action is a no-op and cannot re-race.
+ */
+async function settleScrollBeforeAction(page: Page, step: ActionStep, timeout: number): Promise<void> {
+  await page.evaluate(() => new Promise(r => setTimeout(r, 0)))
+  await page.locator(step.selector).first().scrollIntoViewIfNeeded({ timeout })
+  await waitOneFrame(page)
+}
+
+/**
  * Load `fixture` under `mode` (`'hydrate'` or `'csr-mount'`, both of
  * which boot the client JS on load — no `addScriptTag` two-step needed
  * here since idempotence only cares about the END state), replay every
@@ -91,7 +125,11 @@ export async function replayActionsAndCapture(
     // real divergence, not a flake — must fail fast enough for
     // `runQuarantined`'s plain `try`/`catch` to observe it, rather than
     // hang until Playwright's outer per-test timeout force-cancels the
-    // test outside any `catch`'s reach. See `runStep`'s docstring.
+    // test outside any `catch`'s reach. See `runStep`'s docstring. The
+    // settle's `scrollIntoViewIfNeeded` shares the bound and fails first
+    // on an absent selector, so a missing element still costs one 5s
+    // wait per leg, not two.
+    await settleScrollBeforeAction(page, step, 5_000)
     await runStep(page, step, { timeout: 5_000 })
   }
   return captureDomState(page)


### PR DESCRIPTION
## Summary

Fixes #2745 — `[idempotence] select: replayed actions agree between hydrated and csr-mount` failed intermittently in CI, never locally.

**Root cause:** Playwright scrolls an action's target into view in the same task as the pointer event, but the page's own `scroll` event is dispatched asynchronously on the next rendering update. Whether that event is delivered before or after the click's handlers run depends on which side of a frame boundary the click happens to fall on — under CI load it sometimes does, locally it mostly doesn't. `select`'s content panel re-measures its position (`top` / `--radix-select-content-available-height`) on every `scroll` event while open, and stops listening the moment an item click closes it. So its final inline style differed between the hydrated and csr-mount legs by exactly the scroll-into-view distance the second item click required (the CSS-less oracle host page grows past the viewport once a selected item's unsized indicator `<svg>` renders). This is not a correctness bug in `select`, and not fixable by simply widening a wait bound — confirmed by reproducing the failure locally (10/20 under `--repeat-each 20 --workers 4`) and by instrumenting both legs' scroll/focus/style timeline to trace the exact race.

**Fix:** in the harness, where the issue itself said a timing-cause fix belongs (`replayActionsAndCapture`, `packages/adapter-tests/e2e/oracle-core.ts`). A new `settleScrollBeforeAction` pins the scroll → frame → action ordering a real user always produces before each replayed step:
1. yield the previous action's deferred work (e.g. `select`'s `setTimeout(0)` re-focus of the selected item, which itself scrolls),
2. explicitly scroll the next step's target into view,
3. wait one animation frame so the resulting `scroll` event is delivered to the page.

With the target already visible, Playwright's own scroll-into-view inside the action becomes a no-op and can no longer race the page's async `scroll` event. `mutation-quarantine.ts`'s earlier note about this same symptom ("confirmed flaky ... by rerunning in isolation vs. in the full parallel suite") is updated to point at the root cause and this fix.

Sibling overlay components (`dropdown-menu`/`menubar`/`context-menu`) share the "auto-focus an item on open" pattern but have no analogous defect to fix — the cause is harness/browser event ordering, not component code, and `dropdown-menu`'s own idempotence test already passes reliably.

## Test plan

- [x] `select` idempotence: 10/20 failing → 40/40 passing under `--repeat-each --workers 4` load
- [x] Full `oracle.playwright.ts`: 127 passed, 3 pre-existing exclusions unaffected, 0 failed
- [x] Mutation suite idempotence tests: 59/60 (the one remaining failure, `command × fragment-wrap`, reproduces on unmodified `main` too — pre-existing #2827 bimodality, unrelated to this change)
- [x] `select` fixture snapshots (`__snapshots__/select.*`) regenerated and confirmed no diff — this change doesn't touch component/compiler output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UweUhTx4g6TrAgugdzPzXL

---
_Generated by [Claude Code](https://claude.ai/code/session_01UweUhTx4g6TrAgugdzPzXL)_