### PR TITLE
Fix #2788: renamed children destructure now reaches SSR on Mojo and Go

### DIFF
--- a/.changeset/children-passthrough-renamed-2788.md
+++ b/.changeset/children-passthrough-renamed-2788.md
@@ -1,0 +1,7 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/go-template": patch
+"@barefootjs/mojolicious": patch
+---
+
+Fix #2788: a bare-props-form component (`function Foo(props: Props)`) whose body destructures a prop under a different local name (`const { children: kids } = props`) now reaches SSR correctly on Mojolicious and Go instead of dying/failing template execution. Added `resolveBodyDestructuredPropAliases` (`props-binding.ts`), which recognizes the analyzer's `props.<key>` member-read shape for such a destructure and seeds/routes the local name alongside the caller-facing key.

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -82,6 +82,7 @@ import {
   buildImportAliasMap,
   resolveGetterAliases,
   collectAliasableGetterNames,
+  resolveBodyDestructuredPropAliases,
 } from '@barefootjs/jsx'
 import { findInterpolationEnd } from '@barefootjs/jsx/scanner'
 import { BF_REGION, escapeHtml, resolveJsxChildrenProp } from '@barefootjs/shared'
@@ -476,6 +477,14 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       const getterNames = collectAliasableGetterNames(ir.metadata.signals ?? [], ir.metadata.memos ?? [])
       this.state.getterAliases = resolveGetterAliases(ir.metadata.localConstants ?? [], (n) => getterNames.has(n))
     }
+    // #2788: bare-props-form body destructure aliases (`const { children:
+    // kids } = props`) — same alias-resolution need as `getterAliases`
+    // above, different terminal set (a prop key here, a signal/memo
+    // getter there).
+    this.state.propDestructureAliases = resolveBodyDestructuredPropAliases(
+      ir.metadata.localConstants ?? [],
+      ir.metadata.propsObjectName,
+    )
     // #2208 fable review: every name a `.map()`/`.filter()` loop callback
     // binds as its item/index parameter anywhere in the component. Static
     // loop-source resolution (`getBakedStaticChildLoop` /
@@ -4857,12 +4866,14 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    * rebinds. Outside any loop the root *is* the dot, so we emit `.Field`.
    */
   private rootFieldRef(name: string): string {
-    // #2813: `name` may be a bare local-const alias of a signal/memo
-    // getter (`const items__alias = items`) — resolve it to the getter's
-    // own name FIRST, so the emitted field matches what the getter itself
-    // seeds (`.Items`) instead of registering a second, never-seeded field
-    // under the alias (`.Items__alias`).
-    const resolved = this.state.getterAliases.get(name) ?? name
+    // #2813 / #2788: `name` may be a bare local-const alias of a
+    // signal/memo getter (`const items__alias = items`) or a bare-props-
+    // form body destructure's renamed prop (`const { children: kids } =
+    // props`) — resolve it to the ALIASED entity's own name FIRST, so the
+    // emitted field matches what that entity itself seeds (`.Items`,
+    // `.Children`) instead of registering a second, never-populated field
+    // under the local alias (`.Items__alias`, `.Kids`).
+    const resolved = this.state.getterAliases.get(name) ?? this.state.propDestructureAliases.get(name) ?? name
     this.state.templateReadRootFields.add(resolved)
     const prefix = this.inLoop ? '$.' : '.'
     return `${prefix}${capitalizeFieldName(resolved)}`

--- a/packages/adapter-go-template/src/adapter/lib/compile-state.ts
+++ b/packages/adapter-go-template/src/adapter/lib/compile-state.ts
@@ -99,6 +99,18 @@ export class CompileState {
   getterAliases: Map<string, string> = new Map()
 
   /**
+   * Local names that are BODY-level destructured aliases of a prop key
+   * for a bare-props-form component (`const { children: kids } =
+   * props`), #2788 — the SSR-side twin of `aliased-destructured-prop`'s
+   * PARAMETER-destructuring case (`{ n: count }`, already handled via
+   * `ParamInfo.sourceName`/`capitalizeFieldName(p.name)`). `rootFieldRef`
+   * resolves a name through this map too, so `kids` reads the same
+   * `.Children` field the prop itself seeds instead of a phantom,
+   * never-populated `.Kids`.
+   */
+  propDestructureAliases: Map<string, string> = new Map()
+
+  /**
    * Every name a `.map()`/`.filter()` loop callback binds as its item/index
    * parameter anywhere in the component (#2208 fable review). Consulted by
    * static loop-source resolution (`getBakedStaticChildLoop`) so a const

--- a/packages/adapter-go-template/src/render-divergences.ts
+++ b/packages/adapter-go-template/src/render-divergences.ts
@@ -37,7 +37,4 @@
 
 import type { RenderDivergences } from '@barefootjs/jsx'
 
-export const renderDivergences: RenderDivergences = {
-  'children-passthrough-renamed':
-    'A `children` prop destructured under a different name (`const { children: kids } = props`) does not reach the SSR template on Go, tracked as https://github.com/piconic-ai/barefootjs/issues/2788. The same fixture also fails on Mojolicious, where the mechanism IS isolated: the `.html.ep` interpolates the LOCAL alias (`$kids`) while the stash defines only the caller-facing `children`, so the Perl render dies inside `Mojo::Template::process`. Go\'s own failure mode has NOT been read — `go` is not reachable from the local test process (the conformance case prints "go command not found" and skips), so this entry is declared from the CI failure on #2787 alone, not from a local reproduction. Whoever graduates this should read Go\'s actual output first rather than assume it shares Mojo\'s mechanism. Same alias family as `aliased-destructured-prop` (`{ n: count }`), whose Go half graduated in #2525 — worth checking whether the reserved `children` slot bypasses that fix or never had it. `children-passthrough-renamed` asserts the CORRECT (Hono-generated) output, so deleting this entry is the graduation.',
-}
+export const renderDivergences: RenderDivergences = {}

--- a/packages/adapter-mojolicious/src/render-divergences.ts
+++ b/packages/adapter-mojolicious/src/render-divergences.ts
@@ -15,17 +15,4 @@ import type { RenderDivergences } from '@barefootjs/jsx'
 // at value position and the runtime evaluator's `object-literal` case
 // now merges it, so the seed classifies `derived` and SSRs identically
 // to Hono.
-// https://github.com/piconic-ai/barefootjs/issues/2788 — a renamed
-// `children` destructure (`const { children: kids } = props`) interpolates
-// the LOCAL alias into the `.html.ep`, and the stash only carries the
-// caller-facing `children`, so Perl dies inside `Mojo::Template::process`
-// at render time rather than at build. Seven adapters resolve the alias;
-// only Mojo does not. Same family as `aliased-destructured-prop`'s
-// `{ n: count }` shape, one level in — the reserved children slot.
-// Delete this entry when #2788 is fixed: `children-passthrough-renamed`
-// already asserts the correct (Hono-generated) output, so it becomes the
-// regression test the moment the skip comes off.
-export const renderDivergences: RenderDivergences = {
-  'children-passthrough-renamed':
-    'A renamed `children` destructure emits the local alias as a template variable; the stash defines only `children`, so the Perl render dies (#2788).',
-}
+export const renderDivergences: RenderDivergences = {}

--- a/packages/adapter-mojolicious/src/test-render.ts
+++ b/packages/adapter-mojolicious/src/test-render.ts
@@ -548,6 +548,21 @@ function buildChildDefaultsPerl(ir: ComponentIR): string {
       `${memo.name} => ${value !== undefined && value !== null ? toPerlLiteral(value) : 'undef'}`,
     )
   }
+  // #2788: `extractSsrDefaults` can seed an entry under a name that is
+  // none of `propsParams` / `signals` / `memos` above — a bare-props-form
+  // component's body-level RENAMED destructure (`const { children: kids }
+  // = props`) seeds `kids` alongside the caller-facing `children`
+  // (`ssr-defaults.ts`). Real production hands `$entry->{ssrDefaults}`
+  // straight through to `_derive_stash_from_defaults`, which iterates
+  // every key it contains — so any leftover entry here must be added too,
+  // or this harness's hand-built stash literal would silently omit a key
+  // production's manifest-driven path already provides, mismeasuring
+  // this conformance case's real behavior.
+  for (const name of Object.keys(ssrDefaults)) {
+    if (declared.has(name)) continue
+    declared.add(name)
+    entries.push(`${name} => ${ssrDefaultEntryToPerl(ssrDefaults[name])}`)
+  }
   return `{${entries.join(', ')}}`
 }
 

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -11,8 +11,8 @@ export type { CompileResult, CompileOptions, CompileOptionsWithAdapter, FileOutp
 // SSR template-variable defaults (manifest seeds for stash-based adapters)
 export { extractSsrDefaults, deriveStashFromDefaults } from './ssr-defaults.ts'
 
-// Shared props-destructure binding + alias-map helpers (#2524)
-export { propsDestructureBinding, buildPropAliasMap, isIdentifierName } from './props-binding.ts'
+// Shared props-destructure binding + alias-map helpers (#2524, #2788)
+export { propsDestructureBinding, buildPropAliasMap, isIdentifierName, resolveBodyDestructuredPropAliases } from './props-binding.ts'
 export type { SsrDefault } from './ssr-defaults.ts'
 
 // Bare local-const alias-hop resolution for a signal/memo getter name

--- a/packages/jsx/src/props-binding.ts
+++ b/packages/jsx/src/props-binding.ts
@@ -1,5 +1,5 @@
 import ts from 'typescript'
-import type { ParamInfo } from './types.ts'
+import type { ConstantInfo, ParamInfo } from './types.ts'
 
 /**
  * Authoritative IdentifierName classification for a destructure-pattern
@@ -67,6 +67,42 @@ export function buildPropAliasMap(params: readonly ParamInfo[]): Map<string, str
     }
   }
   return map
+}
+
+/**
+ * Local-name → caller-facing-key map for a BARE-PROPS-form component
+ * (`function Foo(props: Props)`) whose BODY destructures a prop under a
+ * different local name (`const { children: kids } = props`) — the
+ * body-level twin of `buildPropAliasMap` above, which only sees
+ * PARAMETER-destructuring aliases (`{ n: count }`, tracked via
+ * `ParamInfo.sourceName`). For the bare-props form, `propsParams` comes
+ * from the TYPE annotation (`extractPropsFromTypeMembers`) and has no
+ * notion of a body-level rename at all — but the analyzer already
+ * resolves such a destructuring statement into an ordinary
+ * `localConstants` entry whose `parsed` is a plain `props.<key>` member
+ * read (`const { children: kids } = props` → a `kids` local const valued
+ * `props.children`). Recognizing that shape here is enough to answer
+ * "what caller-facing prop key does this local alias" without a second,
+ * dedicated AST walk of the destructuring pattern itself (#2788).
+ *
+ * Returns an empty map for a parameter-destructuring component
+ * (`propsObjectName === null`) — that shape's aliasing is already fully
+ * covered by `buildPropAliasMap`.
+ */
+export function resolveBodyDestructuredPropAliases(
+  localConstants: readonly ConstantInfo[],
+  propsObjectName: string | null,
+): Map<string, string> {
+  const aliases = new Map<string, string>()
+  if (propsObjectName === null) return aliases
+  for (const c of localConstants) {
+    if (c.isModule) continue
+    const m = c.parsed
+    if (m?.kind === 'member' && !m.computed && m.object.kind === 'identifier' && m.object.name === propsObjectName) {
+      aliases.set(c.name, m.property)
+    }
+  }
+  return aliases
 }
 
 /**

--- a/packages/jsx/src/ssr-defaults.ts
+++ b/packages/jsx/src/ssr-defaults.ts
@@ -32,6 +32,7 @@
 import ts from 'typescript'
 import { extractFreeIdentifiersFromNode } from './analyzer.ts'
 import { resolveGetterAliases, collectAliasableGetterNames } from './ir-to-client-js/csr-substitute.ts'
+import { resolveBodyDestructuredPropAliases } from './props-binding.ts'
 import type { IRMetadata } from './types.ts'
 
 /**
@@ -330,6 +331,29 @@ export function extractSsrDefaults(metadata: IRMetadata): Record<string, SsrDefa
       if (alias in out) continue
       out[alias] = out[origin]
     }
+  }
+
+  // #2788: a bare-props-form component (`function Foo(props: Props)`)
+  // whose BODY destructures a prop under a different local name
+  // (`const { children: kids } = props`) has no `ParamInfo.sourceName` to
+  // key off above — `propsParams` here comes from the TYPE annotation
+  // (`extractPropsFromTypeMembers`), which has no notion of a body-level
+  // rename. `resolveBodyDestructuredPropAliases` recognizes such a
+  // destructuring statement's `localConstants` shape; seeding the LOCAL
+  // name too (alongside the caller-facing key already seeded above) is
+  // enough to fix what a template-stash adapter's compiled output
+  // actually reads (`v[:kids]` / `$kids`). Without this, a stash-based
+  // adapter reading the renamed local sees an undefined/nil value instead
+  // of the prop — fatal under Perl strict mode (Mojolicious), a
+  // nonexistent Go struct field, or (on an adapter whose runtime
+  // tolerates a missing key) a silent wrong render the moment a caller
+  // actually supplies a value. Parameter-destructuring aliases (`{ n:
+  // count }`) need no such entry — `sourceName`/`name` already handle
+  // that shape via `callerPropName` above.
+  for (const [local, callerKey] of resolveBodyDestructuredPropAliases(metadata.localConstants ?? [], metadata.propsObjectName)) {
+    if (local in out) continue
+    const origin = out[callerKey]
+    if (origin) out[local] = origin
   }
 
   // Bare-props-arg safety net: the prop block above covers every prop

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1816,16 +1816,6 @@
     "note": "Render-conformance section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. This answers, per fixture and per adapter, whether the construct WORKS — not just whether it compiles. A construct works either as written (✓) or with a documented `/* @client */` comment (✓†, a verified, supported escape — most refusals have one). Fixtures absent from the table below work on every adapter — most as written, some via that documented escape; the headline says how many of each. Listed fixtures need attention somewhere: a bare diagnostic code is still-open debt with no escape yet, a code led by ✗ owes no escape at all (by design), and ≠ means the fixture compiles clean but its rendered output diverges from the reference.",
     "totalFixtures": 375,
     "fixtures": {
-      "children-passthrough-renamed": {
-        "go-template": {
-          "kind": "render",
-          "reason": "A `children` prop destructured under a different name (`const { children: kids } = props`) does not reach the SSR template on Go, tracked as https://github.com/piconic-ai/barefootjs/issues/2788. The same fixture also fails on Mojolicious, where the mechanism IS isolated: the `.html.ep` interpolates the LOCAL alias (`$kids`) while the stash defines only the caller-facing `children`, so the Perl render dies inside `Mojo::Template::process`. Go's own failure mode has NOT been read — `go` is not reachable from the local test process (the conformance case prints \"go command not found\" and skips), so this entry is declared from the CI failure on #2787 alone, not from a local reproduction. Whoever graduates this should read Go's actual output first rather than assume it shares Mojo's mechanism. Same alias family as `aliased-destructured-prop` (`{ n: count }`), whose Go half graduated in #2525 — worth checking whether the reserved `children` slot bypasses that fix or never had it. `children-passthrough-renamed` asserts the CORRECT (Hono-generated) output, so deleting this entry is the graduation."
-        },
-        "mojolicious": {
-          "kind": "render",
-          "reason": "A renamed `children` destructure emits the local alias as a template variable; the stash defines only `children`, so the Perl render dies (#2788)."
-        }
-      },
       "date-method-uncatalogued": {
         "blade": {
           "kind": "refusal",
@@ -3654,10 +3644,6 @@
       }
     },
     "docs": {
-      "children-passthrough-renamed": {
-        "description": "A renamed children destructure renders nothing when the caller passes no children",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/children-passthrough-renamed.ts"
-      },
       "date-method-uncatalogued": {
         "description": "Method call on a Date-typed prop refuses with BF021 (no catalogued lowering)",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/date-method-uncatalogued.ts"

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -2465,13 +2465,9 @@
           ]
         },
         "go-template": {
-          "pass": 327,
+          "pass": 328,
           "total": 350,
           "gaps": [
-            {
-              "fixture": "children-passthrough-renamed",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -2787,13 +2783,9 @@
           ]
         },
         "mojolicious": {
-          "pass": 330,
+          "pass": 331,
           "total": 350,
           "gaps": [
-            {
-              "fixture": "children-passthrough-renamed",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -4021,13 +4013,9 @@
           ]
         },
         "go-template": {
-          "pass": 175,
+          "pass": 176,
           "total": 197,
           "gaps": [
-            {
-              "fixture": "children-passthrough-renamed",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -4325,13 +4313,9 @@
           ]
         },
         "mojolicious": {
-          "pass": 178,
+          "pass": 179,
           "total": 197,
           "gaps": [
-            {
-              "fixture": "children-passthrough-renamed",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -1026,15 +1026,15 @@
       }
     },
     "binary": {
-      "total": 94,
+      "total": 97,
       "cells": {
         "hono": {
-          "pass": 94,
-          "total": 94
+          "pass": 97,
+          "total": 97
         },
         "blade": {
-          "pass": 85,
-          "total": 94,
+          "pass": 88,
+          "total": 97,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1081,8 +1081,8 @@
           ]
         },
         "erb": {
-          "pass": 86,
-          "total": 94,
+          "pass": 89,
+          "total": 97,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1123,8 +1123,8 @@
           ]
         },
         "go-template": {
-          "pass": 85,
-          "total": 94,
+          "pass": 88,
+          "total": 97,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1171,8 +1171,8 @@
           ]
         },
         "jinja": {
-          "pass": 85,
-          "total": 94,
+          "pass": 88,
+          "total": 97,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1219,8 +1219,8 @@
           ]
         },
         "minijinja": {
-          "pass": 85,
-          "total": 94,
+          "pass": 88,
+          "total": 97,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1267,8 +1267,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 86,
-          "total": 94,
+          "pass": 89,
+          "total": 97,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1309,8 +1309,8 @@
           ]
         },
         "twig": {
-          "pass": 85,
-          "total": 94,
+          "pass": 88,
+          "total": 97,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1357,8 +1357,8 @@
           ]
         },
         "xslate": {
-          "pass": 85,
-          "total": 94,
+          "pass": 88,
+          "total": 97,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1418,11 +1418,11 @@
       }
     },
     "call": {
-      "total": 248,
+      "total": 251,
       "cells": {
         "hono": {
-          "pass": 246,
-          "total": 248,
+          "pass": 249,
+          "total": 251,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1439,8 +1439,8 @@
           ]
         },
         "blade": {
-          "pass": 232,
-          "total": 248,
+          "pass": 235,
+          "total": 251,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1521,8 +1521,8 @@
           ]
         },
         "erb": {
-          "pass": 233,
-          "total": 248,
+          "pass": 236,
+          "total": 251,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1597,8 +1597,8 @@
           ]
         },
         "go-template": {
-          "pass": 231,
-          "total": 248,
+          "pass": 234,
+          "total": 251,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1685,8 +1685,8 @@
           ]
         },
         "jinja": {
-          "pass": 232,
-          "total": 248,
+          "pass": 235,
+          "total": 251,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1767,8 +1767,8 @@
           ]
         },
         "minijinja": {
-          "pass": 232,
-          "total": 248,
+          "pass": 235,
+          "total": 251,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1849,8 +1849,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 233,
-          "total": 248,
+          "pass": 236,
+          "total": 251,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1925,8 +1925,8 @@
           ]
         },
         "twig": {
-          "pass": 232,
-          "total": 248,
+          "pass": 235,
+          "total": 251,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2007,8 +2007,8 @@
           ]
         },
         "xslate": {
-          "pass": 232,
-          "total": 248,
+          "pass": 235,
+          "total": 251,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2234,11 +2234,11 @@
       }
     },
     "identifier": {
-      "total": 350,
+      "total": 353,
       "cells": {
         "hono": {
-          "pass": 346,
-          "total": 350,
+          "pass": 349,
+          "total": 353,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2267,8 +2267,8 @@
           ]
         },
         "blade": {
-          "pass": 330,
-          "total": 350,
+          "pass": 333,
+          "total": 353,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2369,8 +2369,8 @@
           ]
         },
         "erb": {
-          "pass": 331,
-          "total": 350,
+          "pass": 334,
+          "total": 353,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2465,8 +2465,8 @@
           ]
         },
         "go-template": {
-          "pass": 328,
-          "total": 350,
+          "pass": 331,
+          "total": 353,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2579,8 +2579,8 @@
           ]
         },
         "jinja": {
-          "pass": 330,
-          "total": 350,
+          "pass": 333,
+          "total": 353,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2681,8 +2681,8 @@
           ]
         },
         "minijinja": {
-          "pass": 330,
-          "total": 350,
+          "pass": 333,
+          "total": 353,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2783,8 +2783,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 331,
-          "total": 350,
+          "pass": 334,
+          "total": 353,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2879,8 +2879,8 @@
           ]
         },
         "twig": {
-          "pass": 330,
-          "total": 350,
+          "pass": 333,
+          "total": 353,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2981,8 +2981,8 @@
           ]
         },
         "xslate": {
-          "pass": 330,
-          "total": 350,
+          "pass": 333,
+          "total": 353,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3148,11 +3148,11 @@
       }
     },
     "literal": {
-      "total": 277,
+      "total": 280,
       "cells": {
         "hono": {
-          "pass": 276,
-          "total": 277,
+          "pass": 279,
+          "total": 280,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -3163,8 +3163,8 @@
           ]
         },
         "blade": {
-          "pass": 265,
-          "total": 277,
+          "pass": 268,
+          "total": 280,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3221,8 +3221,8 @@
           ]
         },
         "erb": {
-          "pass": 265,
-          "total": 277,
+          "pass": 268,
+          "total": 280,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3279,8 +3279,8 @@
           ]
         },
         "go-template": {
-          "pass": 263,
-          "total": 277,
+          "pass": 266,
+          "total": 280,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3349,8 +3349,8 @@
           ]
         },
         "jinja": {
-          "pass": 265,
-          "total": 277,
+          "pass": 268,
+          "total": 280,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3407,8 +3407,8 @@
           ]
         },
         "minijinja": {
-          "pass": 265,
-          "total": 277,
+          "pass": 268,
+          "total": 280,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3465,8 +3465,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 265,
-          "total": 277,
+          "pass": 268,
+          "total": 280,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3523,8 +3523,8 @@
           ]
         },
         "twig": {
-          "pass": 265,
-          "total": 277,
+          "pass": 268,
+          "total": 280,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3581,8 +3581,8 @@
           ]
         },
         "xslate": {
-          "pass": 265,
-          "total": 277,
+          "pass": 268,
+          "total": 280,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3652,15 +3652,15 @@
       }
     },
     "logical": {
-      "total": 47,
+      "total": 49,
       "cells": {
         "hono": {
-          "pass": 47,
-          "total": 47
+          "pass": 49,
+          "total": 49
         },
         "blade": {
-          "pass": 45,
-          "total": 47,
+          "pass": 47,
+          "total": 49,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -3675,8 +3675,8 @@
           ]
         },
         "erb": {
-          "pass": 45,
-          "total": 47,
+          "pass": 47,
+          "total": 49,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -3691,8 +3691,8 @@
           ]
         },
         "go-template": {
-          "pass": 45,
-          "total": 47,
+          "pass": 47,
+          "total": 49,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -3707,8 +3707,8 @@
           ]
         },
         "jinja": {
-          "pass": 45,
-          "total": 47,
+          "pass": 47,
+          "total": 49,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -3723,8 +3723,8 @@
           ]
         },
         "minijinja": {
-          "pass": 45,
-          "total": 47,
+          "pass": 47,
+          "total": 49,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -3739,8 +3739,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 45,
-          "total": 47,
+          "pass": 47,
+          "total": 49,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -3755,8 +3755,8 @@
           ]
         },
         "twig": {
-          "pass": 45,
-          "total": 47,
+          "pass": 47,
+          "total": 49,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -3771,8 +3771,8 @@
           ]
         },
         "xslate": {
-          "pass": 45,
-          "total": 47,
+          "pass": 47,
+          "total": 49,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -4940,15 +4940,15 @@
       }
     },
     "unary": {
-      "total": 24,
+      "total": 26,
       "cells": {
         "hono": {
-          "pass": 24,
-          "total": 24
+          "pass": 26,
+          "total": 26
         },
         "blade": {
-          "pass": 22,
-          "total": 24,
+          "pass": 24,
+          "total": 26,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -4963,8 +4963,8 @@
           ]
         },
         "erb": {
-          "pass": 23,
-          "total": 24,
+          "pass": 25,
+          "total": 26,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4973,8 +4973,8 @@
           ]
         },
         "go-template": {
-          "pass": 22,
-          "total": 24,
+          "pass": 24,
+          "total": 26,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -4989,8 +4989,8 @@
           ]
         },
         "jinja": {
-          "pass": 22,
-          "total": 24,
+          "pass": 24,
+          "total": 26,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -5005,8 +5005,8 @@
           ]
         },
         "minijinja": {
-          "pass": 22,
-          "total": 24,
+          "pass": 24,
+          "total": 26,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -5021,8 +5021,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 23,
-          "total": 24,
+          "pass": 25,
+          "total": 26,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -5031,8 +5031,8 @@
           ]
         },
         "twig": {
-          "pass": 22,
-          "total": 24,
+          "pass": 24,
+          "total": 26,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -5047,8 +5047,8 @@
           ]
         },
         "xslate": {
-          "pass": 22,
-          "total": 24,
+          "pass": 24,
+          "total": 26,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -7348,15 +7348,15 @@
       }
     },
     "binary:===": {
-      "total": 49,
+      "total": 52,
       "cells": {
         "hono": {
-          "pass": 49,
-          "total": 49
+          "pass": 52,
+          "total": 52
         },
         "blade": {
-          "pass": 41,
-          "total": 49,
+          "pass": 44,
+          "total": 52,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7397,8 +7397,8 @@
           ]
         },
         "erb": {
-          "pass": 42,
-          "total": 49,
+          "pass": 45,
+          "total": 52,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7433,8 +7433,8 @@
           ]
         },
         "go-template": {
-          "pass": 41,
-          "total": 49,
+          "pass": 44,
+          "total": 52,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7475,8 +7475,8 @@
           ]
         },
         "jinja": {
-          "pass": 41,
-          "total": 49,
+          "pass": 44,
+          "total": 52,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7517,8 +7517,8 @@
           ]
         },
         "minijinja": {
-          "pass": 41,
-          "total": 49,
+          "pass": 44,
+          "total": 52,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7559,8 +7559,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 42,
-          "total": 49,
+          "pass": 45,
+          "total": 52,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7595,8 +7595,8 @@
           ]
         },
         "twig": {
-          "pass": 41,
-          "total": 49,
+          "pass": 44,
+          "total": 52,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7637,8 +7637,8 @@
           ]
         },
         "xslate": {
-          "pass": 41,
-          "total": 49,
+          "pass": 44,
+          "total": 52,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8015,15 +8015,15 @@
       }
     },
     "literal:number": {
-      "total": 116,
+      "total": 118,
       "cells": {
         "hono": {
-          "pass": 116,
-          "total": 116
+          "pass": 118,
+          "total": 118
         },
         "blade": {
-          "pass": 111,
-          "total": 116,
+          "pass": 113,
+          "total": 118,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8048,8 +8048,8 @@
           ]
         },
         "erb": {
-          "pass": 111,
-          "total": 116,
+          "pass": 113,
+          "total": 118,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8074,8 +8074,8 @@
           ]
         },
         "go-template": {
-          "pass": 111,
-          "total": 116,
+          "pass": 113,
+          "total": 118,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8100,8 +8100,8 @@
           ]
         },
         "jinja": {
-          "pass": 111,
-          "total": 116,
+          "pass": 113,
+          "total": 118,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8126,8 +8126,8 @@
           ]
         },
         "minijinja": {
-          "pass": 111,
-          "total": 116,
+          "pass": 113,
+          "total": 118,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8152,8 +8152,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 111,
-          "total": 116,
+          "pass": 113,
+          "total": 118,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8178,8 +8178,8 @@
           ]
         },
         "twig": {
-          "pass": 111,
-          "total": 116,
+          "pass": 113,
+          "total": 118,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8204,8 +8204,8 @@
           ]
         },
         "xslate": {
-          "pass": 111,
-          "total": 116,
+          "pass": 113,
+          "total": 118,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8243,15 +8243,15 @@
       }
     },
     "literal:string": {
-      "total": 194,
+      "total": 197,
       "cells": {
         "hono": {
-          "pass": 194,
-          "total": 194
+          "pass": 197,
+          "total": 197
         },
         "blade": {
-          "pass": 186,
-          "total": 194,
+          "pass": 189,
+          "total": 197,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8290,8 +8290,8 @@
           ]
         },
         "erb": {
-          "pass": 186,
-          "total": 194,
+          "pass": 189,
+          "total": 197,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8330,8 +8330,8 @@
           ]
         },
         "go-template": {
-          "pass": 185,
-          "total": 194,
+          "pass": 188,
+          "total": 197,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8376,8 +8376,8 @@
           ]
         },
         "jinja": {
-          "pass": 186,
-          "total": 194,
+          "pass": 189,
+          "total": 197,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8416,8 +8416,8 @@
           ]
         },
         "minijinja": {
-          "pass": 186,
-          "total": 194,
+          "pass": 189,
+          "total": 197,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8456,8 +8456,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 186,
-          "total": 194,
+          "pass": 189,
+          "total": 197,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8496,8 +8496,8 @@
           ]
         },
         "twig": {
-          "pass": 186,
-          "total": 194,
+          "pass": 189,
+          "total": 197,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8536,8 +8536,8 @@
           ]
         },
         "xslate": {
-          "pass": 186,
-          "total": 194,
+          "pass": 189,
+          "total": 197,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8789,43 +8789,43 @@
       }
     },
     "logical:||": {
-      "total": 14,
+      "total": 16,
       "cells": {
         "hono": {
-          "pass": 14,
-          "total": 14
+          "pass": 16,
+          "total": 16
         },
         "blade": {
-          "pass": 14,
-          "total": 14
+          "pass": 16,
+          "total": 16
         },
         "erb": {
-          "pass": 14,
-          "total": 14
+          "pass": 16,
+          "total": 16
         },
         "go-template": {
-          "pass": 14,
-          "total": 14
+          "pass": 16,
+          "total": 16
         },
         "jinja": {
-          "pass": 14,
-          "total": 14
+          "pass": 16,
+          "total": 16
         },
         "minijinja": {
-          "pass": 14,
-          "total": 14
+          "pass": 16,
+          "total": 16
         },
         "mojolicious": {
-          "pass": 14,
-          "total": 14
+          "pass": 16,
+          "total": 16
         },
         "twig": {
-          "pass": 14,
-          "total": 14
+          "pass": 16,
+          "total": 16
         },
         "xslate": {
-          "pass": 14,
-          "total": 14
+          "pass": 16,
+          "total": 16
         }
       },
       "source": {
@@ -9557,15 +9557,15 @@
       }
     },
     "unary:!": {
-      "total": 16,
+      "total": 18,
       "cells": {
         "hono": {
-          "pass": 16,
-          "total": 16
+          "pass": 18,
+          "total": 18
         },
         "blade": {
-          "pass": 14,
-          "total": 16,
+          "pass": 16,
+          "total": 18,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -9580,8 +9580,8 @@
           ]
         },
         "erb": {
-          "pass": 15,
-          "total": 16,
+          "pass": 17,
+          "total": 18,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -9590,8 +9590,8 @@
           ]
         },
         "go-template": {
-          "pass": 14,
-          "total": 16,
+          "pass": 16,
+          "total": 18,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -9606,8 +9606,8 @@
           ]
         },
         "jinja": {
-          "pass": 14,
-          "total": 16,
+          "pass": 16,
+          "total": 18,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -9622,8 +9622,8 @@
           ]
         },
         "minijinja": {
-          "pass": 14,
-          "total": 16,
+          "pass": 16,
+          "total": 18,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -9638,8 +9638,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 15,
-          "total": 16,
+          "pass": 17,
+          "total": 18,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -9648,8 +9648,8 @@
           ]
         },
         "twig": {
-          "pass": 14,
-          "total": 16,
+          "pass": 16,
+          "total": 18,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -9664,8 +9664,8 @@
           ]
         },
         "xslate": {
-          "pass": 14,
-          "total": 16,
+          "pass": 16,
+          "total": 18,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -1026,15 +1026,15 @@
       }
     },
     "binary": {
-      "total": 97,
+      "total": 94,
       "cells": {
         "hono": {
-          "pass": 97,
-          "total": 97
+          "pass": 94,
+          "total": 94
         },
         "blade": {
-          "pass": 88,
-          "total": 97,
+          "pass": 85,
+          "total": 94,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1081,8 +1081,8 @@
           ]
         },
         "erb": {
-          "pass": 89,
-          "total": 97,
+          "pass": 86,
+          "total": 94,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1123,8 +1123,8 @@
           ]
         },
         "go-template": {
-          "pass": 88,
-          "total": 97,
+          "pass": 85,
+          "total": 94,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1171,8 +1171,8 @@
           ]
         },
         "jinja": {
-          "pass": 88,
-          "total": 97,
+          "pass": 85,
+          "total": 94,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1219,8 +1219,8 @@
           ]
         },
         "minijinja": {
-          "pass": 88,
-          "total": 97,
+          "pass": 85,
+          "total": 94,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1267,8 +1267,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 89,
-          "total": 97,
+          "pass": 86,
+          "total": 94,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1309,8 +1309,8 @@
           ]
         },
         "twig": {
-          "pass": 88,
-          "total": 97,
+          "pass": 85,
+          "total": 94,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1357,8 +1357,8 @@
           ]
         },
         "xslate": {
-          "pass": 88,
-          "total": 97,
+          "pass": 85,
+          "total": 94,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1418,11 +1418,11 @@
       }
     },
     "call": {
-      "total": 251,
+      "total": 248,
       "cells": {
         "hono": {
-          "pass": 249,
-          "total": 251,
+          "pass": 246,
+          "total": 248,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1439,8 +1439,8 @@
           ]
         },
         "blade": {
-          "pass": 235,
-          "total": 251,
+          "pass": 232,
+          "total": 248,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1521,8 +1521,8 @@
           ]
         },
         "erb": {
-          "pass": 236,
-          "total": 251,
+          "pass": 233,
+          "total": 248,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1597,8 +1597,8 @@
           ]
         },
         "go-template": {
-          "pass": 234,
-          "total": 251,
+          "pass": 231,
+          "total": 248,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1685,8 +1685,8 @@
           ]
         },
         "jinja": {
-          "pass": 235,
-          "total": 251,
+          "pass": 232,
+          "total": 248,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1767,8 +1767,8 @@
           ]
         },
         "minijinja": {
-          "pass": 235,
-          "total": 251,
+          "pass": 232,
+          "total": 248,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1849,8 +1849,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 236,
-          "total": 251,
+          "pass": 233,
+          "total": 248,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1925,8 +1925,8 @@
           ]
         },
         "twig": {
-          "pass": 235,
-          "total": 251,
+          "pass": 232,
+          "total": 248,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2007,8 +2007,8 @@
           ]
         },
         "xslate": {
-          "pass": 235,
-          "total": 251,
+          "pass": 232,
+          "total": 248,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2234,11 +2234,11 @@
       }
     },
     "identifier": {
-      "total": 353,
+      "total": 350,
       "cells": {
         "hono": {
-          "pass": 349,
-          "total": 353,
+          "pass": 346,
+          "total": 350,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2267,8 +2267,8 @@
           ]
         },
         "blade": {
-          "pass": 333,
-          "total": 353,
+          "pass": 330,
+          "total": 350,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2369,8 +2369,8 @@
           ]
         },
         "erb": {
-          "pass": 334,
-          "total": 353,
+          "pass": 331,
+          "total": 350,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2465,8 +2465,8 @@
           ]
         },
         "go-template": {
-          "pass": 330,
-          "total": 353,
+          "pass": 327,
+          "total": 350,
           "gaps": [
             {
               "fixture": "children-passthrough-renamed",
@@ -2583,8 +2583,8 @@
           ]
         },
         "jinja": {
-          "pass": 333,
-          "total": 353,
+          "pass": 330,
+          "total": 350,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2685,8 +2685,8 @@
           ]
         },
         "minijinja": {
-          "pass": 333,
-          "total": 353,
+          "pass": 330,
+          "total": 350,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2787,8 +2787,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 333,
-          "total": 353,
+          "pass": 330,
+          "total": 350,
           "gaps": [
             {
               "fixture": "children-passthrough-renamed",
@@ -2887,8 +2887,8 @@
           ]
         },
         "twig": {
-          "pass": 333,
-          "total": 353,
+          "pass": 330,
+          "total": 350,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2989,8 +2989,8 @@
           ]
         },
         "xslate": {
-          "pass": 333,
-          "total": 353,
+          "pass": 330,
+          "total": 350,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3156,11 +3156,11 @@
       }
     },
     "literal": {
-      "total": 280,
+      "total": 277,
       "cells": {
         "hono": {
-          "pass": 279,
-          "total": 280,
+          "pass": 276,
+          "total": 277,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -3171,8 +3171,8 @@
           ]
         },
         "blade": {
-          "pass": 268,
-          "total": 280,
+          "pass": 265,
+          "total": 277,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3229,8 +3229,8 @@
           ]
         },
         "erb": {
-          "pass": 268,
-          "total": 280,
+          "pass": 265,
+          "total": 277,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3287,8 +3287,8 @@
           ]
         },
         "go-template": {
-          "pass": 266,
-          "total": 280,
+          "pass": 263,
+          "total": 277,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3357,8 +3357,8 @@
           ]
         },
         "jinja": {
-          "pass": 268,
-          "total": 280,
+          "pass": 265,
+          "total": 277,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3415,8 +3415,8 @@
           ]
         },
         "minijinja": {
-          "pass": 268,
-          "total": 280,
+          "pass": 265,
+          "total": 277,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3473,8 +3473,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 268,
-          "total": 280,
+          "pass": 265,
+          "total": 277,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3531,8 +3531,8 @@
           ]
         },
         "twig": {
-          "pass": 268,
-          "total": 280,
+          "pass": 265,
+          "total": 277,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3589,8 +3589,8 @@
           ]
         },
         "xslate": {
-          "pass": 268,
-          "total": 280,
+          "pass": 265,
+          "total": 277,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3660,15 +3660,15 @@
       }
     },
     "logical": {
-      "total": 49,
+      "total": 47,
       "cells": {
         "hono": {
-          "pass": 49,
-          "total": 49
+          "pass": 47,
+          "total": 47
         },
         "blade": {
-          "pass": 47,
-          "total": 49,
+          "pass": 45,
+          "total": 47,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -3683,8 +3683,8 @@
           ]
         },
         "erb": {
-          "pass": 47,
-          "total": 49,
+          "pass": 45,
+          "total": 47,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -3699,8 +3699,8 @@
           ]
         },
         "go-template": {
-          "pass": 47,
-          "total": 49,
+          "pass": 45,
+          "total": 47,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -3715,8 +3715,8 @@
           ]
         },
         "jinja": {
-          "pass": 47,
-          "total": 49,
+          "pass": 45,
+          "total": 47,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -3731,8 +3731,8 @@
           ]
         },
         "minijinja": {
-          "pass": 47,
-          "total": 49,
+          "pass": 45,
+          "total": 47,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -3747,8 +3747,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 47,
-          "total": 49,
+          "pass": 45,
+          "total": 47,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -3763,8 +3763,8 @@
           ]
         },
         "twig": {
-          "pass": 47,
-          "total": 49,
+          "pass": 45,
+          "total": 47,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -3779,8 +3779,8 @@
           ]
         },
         "xslate": {
-          "pass": 47,
-          "total": 49,
+          "pass": 45,
+          "total": 47,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -4956,15 +4956,15 @@
       }
     },
     "unary": {
-      "total": 26,
+      "total": 24,
       "cells": {
         "hono": {
-          "pass": 26,
-          "total": 26
+          "pass": 24,
+          "total": 24
         },
         "blade": {
-          "pass": 24,
-          "total": 26,
+          "pass": 22,
+          "total": 24,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -4979,8 +4979,8 @@
           ]
         },
         "erb": {
-          "pass": 25,
-          "total": 26,
+          "pass": 23,
+          "total": 24,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4989,8 +4989,8 @@
           ]
         },
         "go-template": {
-          "pass": 24,
-          "total": 26,
+          "pass": 22,
+          "total": 24,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -5005,8 +5005,8 @@
           ]
         },
         "jinja": {
-          "pass": 24,
-          "total": 26,
+          "pass": 22,
+          "total": 24,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -5021,8 +5021,8 @@
           ]
         },
         "minijinja": {
-          "pass": 24,
-          "total": 26,
+          "pass": 22,
+          "total": 24,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -5037,8 +5037,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 25,
-          "total": 26,
+          "pass": 23,
+          "total": 24,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -5047,8 +5047,8 @@
           ]
         },
         "twig": {
-          "pass": 24,
-          "total": 26,
+          "pass": 22,
+          "total": 24,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -5063,8 +5063,8 @@
           ]
         },
         "xslate": {
-          "pass": 24,
-          "total": 26,
+          "pass": 22,
+          "total": 24,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -7364,15 +7364,15 @@
       }
     },
     "binary:===": {
-      "total": 52,
+      "total": 49,
       "cells": {
         "hono": {
-          "pass": 52,
-          "total": 52
+          "pass": 49,
+          "total": 49
         },
         "blade": {
-          "pass": 44,
-          "total": 52,
+          "pass": 41,
+          "total": 49,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7413,8 +7413,8 @@
           ]
         },
         "erb": {
-          "pass": 45,
-          "total": 52,
+          "pass": 42,
+          "total": 49,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7449,8 +7449,8 @@
           ]
         },
         "go-template": {
-          "pass": 44,
-          "total": 52,
+          "pass": 41,
+          "total": 49,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7491,8 +7491,8 @@
           ]
         },
         "jinja": {
-          "pass": 44,
-          "total": 52,
+          "pass": 41,
+          "total": 49,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7533,8 +7533,8 @@
           ]
         },
         "minijinja": {
-          "pass": 44,
-          "total": 52,
+          "pass": 41,
+          "total": 49,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7575,8 +7575,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 45,
-          "total": 52,
+          "pass": 42,
+          "total": 49,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7611,8 +7611,8 @@
           ]
         },
         "twig": {
-          "pass": 44,
-          "total": 52,
+          "pass": 41,
+          "total": 49,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7653,8 +7653,8 @@
           ]
         },
         "xslate": {
-          "pass": 44,
-          "total": 52,
+          "pass": 41,
+          "total": 49,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8031,15 +8031,15 @@
       }
     },
     "literal:number": {
-      "total": 118,
+      "total": 116,
       "cells": {
         "hono": {
-          "pass": 118,
-          "total": 118
+          "pass": 116,
+          "total": 116
         },
         "blade": {
-          "pass": 113,
-          "total": 118,
+          "pass": 111,
+          "total": 116,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8064,8 +8064,8 @@
           ]
         },
         "erb": {
-          "pass": 113,
-          "total": 118,
+          "pass": 111,
+          "total": 116,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8090,8 +8090,8 @@
           ]
         },
         "go-template": {
-          "pass": 113,
-          "total": 118,
+          "pass": 111,
+          "total": 116,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8116,8 +8116,8 @@
           ]
         },
         "jinja": {
-          "pass": 113,
-          "total": 118,
+          "pass": 111,
+          "total": 116,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8142,8 +8142,8 @@
           ]
         },
         "minijinja": {
-          "pass": 113,
-          "total": 118,
+          "pass": 111,
+          "total": 116,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8168,8 +8168,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 113,
-          "total": 118,
+          "pass": 111,
+          "total": 116,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8194,8 +8194,8 @@
           ]
         },
         "twig": {
-          "pass": 113,
-          "total": 118,
+          "pass": 111,
+          "total": 116,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8220,8 +8220,8 @@
           ]
         },
         "xslate": {
-          "pass": 113,
-          "total": 118,
+          "pass": 111,
+          "total": 116,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8259,15 +8259,15 @@
       }
     },
     "literal:string": {
-      "total": 197,
+      "total": 194,
       "cells": {
         "hono": {
-          "pass": 197,
-          "total": 197
+          "pass": 194,
+          "total": 194
         },
         "blade": {
-          "pass": 189,
-          "total": 197,
+          "pass": 186,
+          "total": 194,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8306,8 +8306,8 @@
           ]
         },
         "erb": {
-          "pass": 189,
-          "total": 197,
+          "pass": 186,
+          "total": 194,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8346,8 +8346,8 @@
           ]
         },
         "go-template": {
-          "pass": 188,
-          "total": 197,
+          "pass": 185,
+          "total": 194,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8392,8 +8392,8 @@
           ]
         },
         "jinja": {
-          "pass": 189,
-          "total": 197,
+          "pass": 186,
+          "total": 194,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8432,8 +8432,8 @@
           ]
         },
         "minijinja": {
-          "pass": 189,
-          "total": 197,
+          "pass": 186,
+          "total": 194,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8472,8 +8472,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 189,
-          "total": 197,
+          "pass": 186,
+          "total": 194,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8512,8 +8512,8 @@
           ]
         },
         "twig": {
-          "pass": 189,
-          "total": 197,
+          "pass": 186,
+          "total": 194,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8552,8 +8552,8 @@
           ]
         },
         "xslate": {
-          "pass": 189,
-          "total": 197,
+          "pass": 186,
+          "total": 194,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8805,43 +8805,43 @@
       }
     },
     "logical:||": {
-      "total": 16,
+      "total": 14,
       "cells": {
         "hono": {
-          "pass": 16,
-          "total": 16
+          "pass": 14,
+          "total": 14
         },
         "blade": {
-          "pass": 16,
-          "total": 16
+          "pass": 14,
+          "total": 14
         },
         "erb": {
-          "pass": 16,
-          "total": 16
+          "pass": 14,
+          "total": 14
         },
         "go-template": {
-          "pass": 16,
-          "total": 16
+          "pass": 14,
+          "total": 14
         },
         "jinja": {
-          "pass": 16,
-          "total": 16
+          "pass": 14,
+          "total": 14
         },
         "minijinja": {
-          "pass": 16,
-          "total": 16
+          "pass": 14,
+          "total": 14
         },
         "mojolicious": {
-          "pass": 16,
-          "total": 16
+          "pass": 14,
+          "total": 14
         },
         "twig": {
-          "pass": 16,
-          "total": 16
+          "pass": 14,
+          "total": 14
         },
         "xslate": {
-          "pass": 16,
-          "total": 16
+          "pass": 14,
+          "total": 14
         }
       },
       "source": {
@@ -9573,15 +9573,15 @@
       }
     },
     "unary:!": {
-      "total": 18,
+      "total": 16,
       "cells": {
         "hono": {
-          "pass": 18,
-          "total": 18
+          "pass": 16,
+          "total": 16
         },
         "blade": {
-          "pass": 16,
-          "total": 18,
+          "pass": 14,
+          "total": 16,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -9596,8 +9596,8 @@
           ]
         },
         "erb": {
-          "pass": 17,
-          "total": 18,
+          "pass": 15,
+          "total": 16,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -9606,8 +9606,8 @@
           ]
         },
         "go-template": {
-          "pass": 16,
-          "total": 18,
+          "pass": 14,
+          "total": 16,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -9622,8 +9622,8 @@
           ]
         },
         "jinja": {
-          "pass": 16,
-          "total": 18,
+          "pass": 14,
+          "total": 16,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -9638,8 +9638,8 @@
           ]
         },
         "minijinja": {
-          "pass": 16,
-          "total": 18,
+          "pass": 14,
+          "total": 16,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -9654,8 +9654,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 17,
-          "total": 18,
+          "pass": 15,
+          "total": 16,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -9664,8 +9664,8 @@
           ]
         },
         "twig": {
-          "pass": 16,
-          "total": 18,
+          "pass": 14,
+          "total": 16,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",
@@ -9680,8 +9680,8 @@
           ]
         },
         "xslate": {
-          "pass": 16,
-          "total": 18,
+          "pass": 14,
+          "total": 16,
           "gaps": [
             {
               "fixture": "filter-nested-callback-predicate",


### PR DESCRIPTION
## Summary

Stacked on #2854 (base is that branch, not `main`).

A component using the bare-props form (`function Foo(props: Props)`) whose body destructures a prop under a different local name (`const { children: kids } = props`) compiled clean and died at SSR:

- Mojolicious: Perl strict-mode `Global symbol "$kids" requires explicit package name`.
- Go: template execution failure, `can't evaluate field Kids`.

**Root cause:** `propsParams` for the bare-props form comes from the TYPE annotation (`extractPropsFromTypeMembers`), which has no notion of a body-level rename — unlike parameter destructuring (`{ n: count }`), which already carries `ParamInfo.sourceName`. The analyzer already resolves such a destructuring statement into an ordinary `localConstants` entry whose `parsed` value is a plain `props.<key>` member read; recognizing that shape is enough to answer the alias question without a second AST walk of the destructuring pattern itself.

Added `resolveBodyDestructuredPropAliases` (`props-binding.ts`, exported alongside the existing `buildPropAliasMap`) and wired it into:

- `ssr-defaults.ts`: seeds the stash under the local name too, alongside the caller-facing key.
- `go-template-adapter.ts`: `rootFieldRef` also resolves through this alias map before capitalizing into a struct field.

Not children-specific — the same gap affects **any** renamed body-level prop destructure on any template-stash adapter, but the other seven already-passing adapters mask it for a no-children-passed test case (a wrong stash lookup and a genuinely absent value both render as "nothing").

Also fixes `buildChildDefaultsPerl` (`adapter-mojolicious/test-render.ts`), which had the same hand-enumeration gap fixed for root-level components in #2854's PR, this time for CHILD components — `children-passthrough-renamed`'s `Panel` is a child of `Page`.

## Real-interpreter verification

- Perl `Mojolicious` (already installed for #2854).
- Go 1.25.6 (already installed for #2854).

Deleted the `children-passthrough-renamed` `render-divergences.ts` pin on both Mojolicious and Go.

## Test plan

- [x] `children-passthrough-renamed` passes against real Mojolicious (Perl) and Go 1.25.
- [x] Regression-checked an unrelated already-passing adapter (ERB) for the same fixture — still passes.
- [x] Regenerated `coverage-map.json` (no change — no new fixture here), `ui/support-matrix.lock.json`, `ui/compat.lock.json` — `git status` clean after regeneration.
- [x] `biome check` clean on touched files.
- [x] Full-stack drift check (coverage-map + expected-html + support-matrix) on this branch's tip (all three PRs combined) — zero diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ARqsMtqFeHTNdnxirGcQVd

---
_Generated by [Claude Code](https://claude.ai/code/session_01ARqsMtqFeHTNdnxirGcQVd)_