### PR TITLE
fix(jsx): dedup reactive attribute writes against their previous value

### DIFF
--- a/.changeset/attr-dedup-guard-2869.md
+++ b/.changeset/attr-dedup-guard-2869.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Fix eager reactive-attribute writes rewriting the DOM unconditionally on every `createEffect` rerun, regardless of which binding in that effect actually changed. This mattered most for a keyed `.map()` row's fused row effect, where a sibling binding's legitimate change reran the whole effect and rewrote every attribute in it — including one wrapped in `untrack()`, which only suppresses dependency registration, not re-execution of the surrounding effect. Every eager reactive-attribute write is now guarded against its previous value (`Object.is`), matching the guard the lazy row graph already had.

--- a/docs/core/reactivity/untrack.md
+++ b/docs/core/reactivity/untrack.md
@@ -67,3 +67,43 @@ createEffect(() => {
   setResult(a + b)
 })
 ```
+
+
+## What `untrack` Does Not Do
+
+`untrack` only stops the wrapped read from **registering a dependency**. It does not stop the surrounding effect from **re-running** — and when the effect re-runs for any other reason, the code inside `untrack` runs again too.
+
+This matters because BarefootJS groups several bindings into one effect for performance: every reactive attribute on one element shares an effect, and a keyed `.map()` row's attributes and text share a single row effect. When one binding in that group changes, the whole effect re-runs, and every expression in it — untracked or not — is evaluated again.
+
+```tsx
+'use client'
+import { createSignal, untrack } from '@barefootjs/client'
+
+function renderPreview(id: number): string {
+  return `<p>Preview for item ${id}</p>`
+}
+
+export function Gallery() {
+  const [items, setItems] = createSignal([{ id: 1, label: 'First' }, { id: 2, label: 'Second' }])
+  const rename = () => setItems(items().map(item => ({ id: item.id, label: item.label + '!' })))
+  return (
+    <div>
+      <button onClick={rename}>Rename all</button>
+      <ul>
+        {items().map(item => (
+          <li key={item.id} title={item.label} data-preview={untrack(() => renderPreview(item.id))}>
+            {item.label}
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+```
+
+Clicking "Rename all" changes `title` on every row, so every row effect re-runs and `renderPreview` is called again for each row even though it is wrapped in `untrack`. Two guarantees hold regardless:
+
+- The untracked read still does not subscribe: a signal read only inside `untrack` never triggers the effect on its own.
+- A DOM write is skipped when the binding's new value is the same as the last one it computed (compared with `Object.is`). `data-preview` above is recomputed on every run but not rewritten, so an attribute whose write is expensive to apply — `srcdoc` on an `<iframe>`, which reloads the frame on every assignment — stays untouched until its value actually changes.
+
+If the **computation** itself is what you need to avoid repeating, `untrack` is the wrong tool: put it in a `createMemo` so it only re-runs when its own inputs change.

--- a/packages/adapter-tests/fixtures/__snapshots__/accordion.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/accordion.client.js
@@ -39,11 +39,16 @@ export function initCheckIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -144,11 +149,16 @@ export function initChevronDownIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -249,11 +259,16 @@ export function initChevronUpIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -354,11 +369,16 @@ export function initChevronLeftIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -459,11 +479,16 @@ export function initChevronRightIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -564,11 +589,16 @@ export function initXIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -669,11 +699,16 @@ export function initPlusIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -774,11 +809,16 @@ export function initMinusIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -879,11 +919,16 @@ export function initSunIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -984,11 +1029,16 @@ export function initMoonIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1089,11 +1139,16 @@ export function initMonitorIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1194,11 +1249,16 @@ export function initCopyIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1299,11 +1359,16 @@ export function initClipboardIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1404,11 +1469,16 @@ export function initClipboardCheckIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1509,11 +1579,16 @@ export function initMenuIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1614,11 +1689,16 @@ export function initArrowLeftIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1719,11 +1799,16 @@ export function initArrowRightIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1824,11 +1909,16 @@ export function initArrowUpDownIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1906,11 +1996,16 @@ export function initEllipsisIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1944,11 +2039,16 @@ export function initGitHubIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","class","aria-hidden"])
 
@@ -1982,11 +2082,16 @@ export function initSettingsIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2020,11 +2125,16 @@ export function initGlobeIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2058,11 +2168,16 @@ export function initLogOutIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2096,11 +2211,16 @@ export function initCircleHelpIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2134,11 +2254,16 @@ export function initSearchIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2172,11 +2297,16 @@ export function initCircleCheckIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2210,11 +2340,16 @@ export function initCircleXIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2248,11 +2383,16 @@ export function initTriangleAlertIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2286,11 +2426,16 @@ export function initInfoIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2324,11 +2469,16 @@ export function initCalendarIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2362,11 +2512,16 @@ export function initGripVerticalIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2423,11 +2578,16 @@ export function initLoaderCircleIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2505,11 +2665,16 @@ export function initPanelLeftIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2576,77 +2741,180 @@ export function initIcon(__scope, _p = {}) {
   const [_s1, _s0] = $(__scope, 's1', 's0')
   const [_s11, _s10, _s9, _s8, _s7, _s6, _s5, _s4, _s3, _s2] = $c(__scope, 's11', 's10', 's9', 's8', 's7', 's6', 's5', 's4', 's3', 's2')
 
+  { const __l = []
   createEffect(() => {
     if (_s1) {
-      { const __v = sizeMap[(_p.size ?? 'md')]; if (__v != null) _s1.setAttribute('width', String(__v)); else _s1.removeAttribute('width') }
-      { const __v = sizeMap[(_p.size ?? 'md')]; if (__v != null) _s1.setAttribute('height', String(__v)); else _s1.removeAttribute('height') }
-      { const __v = (buttLinecapIcons).includes(_p.name) ? 'butt' : 'round'; if (__v != null) _s1.setAttribute('stroke-linecap', String(__v)); else _s1.removeAttribute('stroke-linecap') }
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s1.setAttribute('class', String(__v)); else _s1.removeAttribute('class') }
+      { const __x = sizeMap[(_p.size ?? 'md')]
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('width', String(__v)); else _s1.removeAttribute('width') }
+      }
+      __l[0] = __x }
+      { const __x = sizeMap[(_p.size ?? 'md')]
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('height', String(__v)); else _s1.removeAttribute('height') }
+      }
+      __l[1] = __x }
+      { const __x = (buttLinecapIcons).includes(_p.name) ? 'butt' : 'round'
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('stroke-linecap', String(__v)); else _s1.removeAttribute('stroke-linecap') }
+      }
+      __l[2] = __x }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(3 in __l) || !Object.is(__l[3], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('class', String(__v)); else _s1.removeAttribute('class') }
+      }
+      __l[3] = __x }
     }
-  })
+  }) }
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `${({"check": "M20 6 9 17l-5-5", "chevron-down": "m6 9 6 6 6-6", "chevron-up": "m18 15-6-6-6 6", "chevron-left": "m15 18-6-6 6-6", "chevron-right": "m9 18 6-6-6-6", "x": "M18 6 6 18M6 6l12 12", "plus": "M5 12h14M12 5v14", "minus": "M5 12h14", "sun": "M12 16a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41", "moon": "M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z", "monitor": "M20 3H4a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2zM8 21h8M12 17v4", "copy": "M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2M8 8h12a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V10a2 2 0 0 1 2-2z", "clipboard": "M9 2h6a1 1 0 0 1 1 1v1H8V3a1 1 0 0 1 1-1zM16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2", "clipboard-check": "M9 2h6a1 1 0 0 1 1 1v1H8V3a1 1 0 0 1 1-1zM16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2M9 14l2 2 4-4", "menu": "M4 6h16M4 12h16M4 18h16", "arrow-left": "m12 19-7-7 7-7M19 12H5", "arrow-right": "M5 12h14m-7-7 7 7-7 7", "ellipsis": "M5 12h.01M12 12h.01M19 12h.01", "arrow-up-down": "m21 16-4 4-4-4M17 20V4M3 8l4-4 4 4M7 4v16", "panel-left": "M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4M3 3h12v18H3zM9 3v18", "loader-circle": "M21 12a9 9 0 1 1-6.219-8.56"})[_p.name]}`; if (__v != null) _s0.setAttribute('d', String(__v)); else _s0.removeAttribute('d') }
+      { const __x = `${({"check": "M20 6 9 17l-5-5", "chevron-down": "m6 9 6 6 6-6", "chevron-up": "m18 15-6-6-6 6", "chevron-left": "m15 18-6-6 6-6", "chevron-right": "m9 18 6-6-6-6", "x": "M18 6 6 18M6 6l12 12", "plus": "M5 12h14M12 5v14", "minus": "M5 12h14", "sun": "M12 16a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41", "moon": "M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z", "monitor": "M20 3H4a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2zM8 21h8M12 17v4", "copy": "M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2M8 8h12a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V10a2 2 0 0 1 2-2z", "clipboard": "M9 2h6a1 1 0 0 1 1 1v1H8V3a1 1 0 0 1 1-1zM16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2", "clipboard-check": "M9 2h6a1 1 0 0 1 1 1v1H8V3a1 1 0 0 1 1-1zM16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2M9 14l2 2 4-4", "menu": "M4 6h16M4 12h16M4 18h16", "arrow-left": "m12 19-7-7 7-7M19 12H5", "arrow-right": "M5 12h14m-7-7 7 7-7 7", "ellipsis": "M5 12h.01M12 12h.01M19 12h.01", "arrow-up-down": "m21 16-4 4-4-4M17 20V4M3 8l4-4 4 4M7 4v16", "panel-left": "M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4M3 3h12v18H3zM9 3v18", "loader-circle": "M21 12a9 9 0 1 1-6.219-8.56"})[_p.name]}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('d', String(__v)); else _s0.removeAttribute('d') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s1) applyRestAttrs(_s1, _p, ["name","size","className","xmlns","width","height","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     const [__GitHubIcon_s11El] = $c(__scope, 's11')
     if (__GitHubIcon_s11El) {
-      { const __v = size; if (__v != null) __GitHubIcon_s11El.setAttribute('size', String(__v)); else __GitHubIcon_s11El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __GitHubIcon_s11El.setAttribute('class', String(__v)); else __GitHubIcon_s11El.removeAttribute('class') }
+      { const __x = size
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) __GitHubIcon_s11El.setAttribute('size', String(__v)); else __GitHubIcon_s11El.removeAttribute('size') }
+      }
+      __l[0] = __x }
+      { const __x = className
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) __GitHubIcon_s11El.setAttribute('class', String(__v)); else __GitHubIcon_s11El.removeAttribute('class') }
+      }
+      __l[1] = __x }
     }
     const [__SearchIcon_s10El] = $c(__scope, 's10')
     if (__SearchIcon_s10El) {
-      { const __v = size; if (__v != null) __SearchIcon_s10El.setAttribute('size', String(__v)); else __SearchIcon_s10El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __SearchIcon_s10El.setAttribute('class', String(__v)); else __SearchIcon_s10El.removeAttribute('class') }
+      { const __x = size
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        { const __v = __x; if (__v != null) __SearchIcon_s10El.setAttribute('size', String(__v)); else __SearchIcon_s10El.removeAttribute('size') }
+      }
+      __l[2] = __x }
+      { const __x = className
+      if (!(3 in __l) || !Object.is(__l[3], __x)) {
+        { const __v = __x; if (__v != null) __SearchIcon_s10El.setAttribute('class', String(__v)); else __SearchIcon_s10El.removeAttribute('class') }
+      }
+      __l[3] = __x }
     }
     const [__SettingsIcon_s9El] = $c(__scope, 's9')
     if (__SettingsIcon_s9El) {
-      { const __v = size; if (__v != null) __SettingsIcon_s9El.setAttribute('size', String(__v)); else __SettingsIcon_s9El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __SettingsIcon_s9El.setAttribute('class', String(__v)); else __SettingsIcon_s9El.removeAttribute('class') }
+      { const __x = size
+      if (!(4 in __l) || !Object.is(__l[4], __x)) {
+        { const __v = __x; if (__v != null) __SettingsIcon_s9El.setAttribute('size', String(__v)); else __SettingsIcon_s9El.removeAttribute('size') }
+      }
+      __l[4] = __x }
+      { const __x = className
+      if (!(5 in __l) || !Object.is(__l[5], __x)) {
+        { const __v = __x; if (__v != null) __SettingsIcon_s9El.setAttribute('class', String(__v)); else __SettingsIcon_s9El.removeAttribute('class') }
+      }
+      __l[5] = __x }
     }
     const [__GlobeIcon_s8El] = $c(__scope, 's8')
     if (__GlobeIcon_s8El) {
-      { const __v = size; if (__v != null) __GlobeIcon_s8El.setAttribute('size', String(__v)); else __GlobeIcon_s8El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __GlobeIcon_s8El.setAttribute('class', String(__v)); else __GlobeIcon_s8El.removeAttribute('class') }
+      { const __x = size
+      if (!(6 in __l) || !Object.is(__l[6], __x)) {
+        { const __v = __x; if (__v != null) __GlobeIcon_s8El.setAttribute('size', String(__v)); else __GlobeIcon_s8El.removeAttribute('size') }
+      }
+      __l[6] = __x }
+      { const __x = className
+      if (!(7 in __l) || !Object.is(__l[7], __x)) {
+        { const __v = __x; if (__v != null) __GlobeIcon_s8El.setAttribute('class', String(__v)); else __GlobeIcon_s8El.removeAttribute('class') }
+      }
+      __l[7] = __x }
     }
     const [__LogOutIcon_s7El] = $c(__scope, 's7')
     if (__LogOutIcon_s7El) {
-      { const __v = size; if (__v != null) __LogOutIcon_s7El.setAttribute('size', String(__v)); else __LogOutIcon_s7El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __LogOutIcon_s7El.setAttribute('class', String(__v)); else __LogOutIcon_s7El.removeAttribute('class') }
+      { const __x = size
+      if (!(8 in __l) || !Object.is(__l[8], __x)) {
+        { const __v = __x; if (__v != null) __LogOutIcon_s7El.setAttribute('size', String(__v)); else __LogOutIcon_s7El.removeAttribute('size') }
+      }
+      __l[8] = __x }
+      { const __x = className
+      if (!(9 in __l) || !Object.is(__l[9], __x)) {
+        { const __v = __x; if (__v != null) __LogOutIcon_s7El.setAttribute('class', String(__v)); else __LogOutIcon_s7El.removeAttribute('class') }
+      }
+      __l[9] = __x }
     }
     const [__CircleHelpIcon_s6El] = $c(__scope, 's6')
     if (__CircleHelpIcon_s6El) {
-      { const __v = size; if (__v != null) __CircleHelpIcon_s6El.setAttribute('size', String(__v)); else __CircleHelpIcon_s6El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __CircleHelpIcon_s6El.setAttribute('class', String(__v)); else __CircleHelpIcon_s6El.removeAttribute('class') }
+      { const __x = size
+      if (!(10 in __l) || !Object.is(__l[10], __x)) {
+        { const __v = __x; if (__v != null) __CircleHelpIcon_s6El.setAttribute('size', String(__v)); else __CircleHelpIcon_s6El.removeAttribute('size') }
+      }
+      __l[10] = __x }
+      { const __x = className
+      if (!(11 in __l) || !Object.is(__l[11], __x)) {
+        { const __v = __x; if (__v != null) __CircleHelpIcon_s6El.setAttribute('class', String(__v)); else __CircleHelpIcon_s6El.removeAttribute('class') }
+      }
+      __l[11] = __x }
     }
     const [__CalendarIcon_s5El] = $c(__scope, 's5')
     if (__CalendarIcon_s5El) {
-      { const __v = size; if (__v != null) __CalendarIcon_s5El.setAttribute('size', String(__v)); else __CalendarIcon_s5El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __CalendarIcon_s5El.setAttribute('class', String(__v)); else __CalendarIcon_s5El.removeAttribute('class') }
+      { const __x = size
+      if (!(12 in __l) || !Object.is(__l[12], __x)) {
+        { const __v = __x; if (__v != null) __CalendarIcon_s5El.setAttribute('size', String(__v)); else __CalendarIcon_s5El.removeAttribute('size') }
+      }
+      __l[12] = __x }
+      { const __x = className
+      if (!(13 in __l) || !Object.is(__l[13], __x)) {
+        { const __v = __x; if (__v != null) __CalendarIcon_s5El.setAttribute('class', String(__v)); else __CalendarIcon_s5El.removeAttribute('class') }
+      }
+      __l[13] = __x }
     }
     const [__GripVerticalIcon_s4El] = $c(__scope, 's4')
     if (__GripVerticalIcon_s4El) {
-      { const __v = size; if (__v != null) __GripVerticalIcon_s4El.setAttribute('size', String(__v)); else __GripVerticalIcon_s4El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __GripVerticalIcon_s4El.setAttribute('class', String(__v)); else __GripVerticalIcon_s4El.removeAttribute('class') }
+      { const __x = size
+      if (!(14 in __l) || !Object.is(__l[14], __x)) {
+        { const __v = __x; if (__v != null) __GripVerticalIcon_s4El.setAttribute('size', String(__v)); else __GripVerticalIcon_s4El.removeAttribute('size') }
+      }
+      __l[14] = __x }
+      { const __x = className
+      if (!(15 in __l) || !Object.is(__l[15], __x)) {
+        { const __v = __x; if (__v != null) __GripVerticalIcon_s4El.setAttribute('class', String(__v)); else __GripVerticalIcon_s4El.removeAttribute('class') }
+      }
+      __l[15] = __x }
     }
     const [__LoaderCircleIcon_s3El] = $c(__scope, 's3')
     if (__LoaderCircleIcon_s3El) {
-      { const __v = size; if (__v != null) __LoaderCircleIcon_s3El.setAttribute('size', String(__v)); else __LoaderCircleIcon_s3El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __LoaderCircleIcon_s3El.setAttribute('class', String(__v)); else __LoaderCircleIcon_s3El.removeAttribute('class') }
+      { const __x = size
+      if (!(16 in __l) || !Object.is(__l[16], __x)) {
+        { const __v = __x; if (__v != null) __LoaderCircleIcon_s3El.setAttribute('size', String(__v)); else __LoaderCircleIcon_s3El.removeAttribute('size') }
+      }
+      __l[16] = __x }
+      { const __x = className
+      if (!(17 in __l) || !Object.is(__l[17], __x)) {
+        { const __v = __x; if (__v != null) __LoaderCircleIcon_s3El.setAttribute('class', String(__v)); else __LoaderCircleIcon_s3El.removeAttribute('class') }
+      }
+      __l[17] = __x }
     }
     const [__PanelLeftIcon_s2El] = $c(__scope, 's2')
     if (__PanelLeftIcon_s2El) {
-      { const __v = size; if (__v != null) __PanelLeftIcon_s2El.setAttribute('size', String(__v)); else __PanelLeftIcon_s2El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __PanelLeftIcon_s2El.setAttribute('class', String(__v)); else __PanelLeftIcon_s2El.removeAttribute('class') }
+      { const __x = size
+      if (!(18 in __l) || !Object.is(__l[18], __x)) {
+        { const __v = __x; if (__v != null) __PanelLeftIcon_s2El.setAttribute('size', String(__v)); else __PanelLeftIcon_s2El.removeAttribute('size') }
+      }
+      __l[18] = __x }
+      { const __x = className
+      if (!(19 in __l) || !Object.is(__l[19], __x)) {
+        { const __v = __x; if (__v != null) __PanelLeftIcon_s2El.setAttribute('class', String(__v)); else __PanelLeftIcon_s2El.removeAttribute('class') }
+      }
+      __l[19] = __x }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('GitHubIcon', _s11, forwardProps(_p, { get size() { return size }, get className() { return className } }, ["size","className"]))
@@ -2691,11 +2959,16 @@ export function initAccordion(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `${accordionClasses} ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `${accordionClasses} ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot","class"])
 
@@ -2713,14 +2986,31 @@ export function initAccordionItem(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = _p.id; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
-      { const __v = `${_p.open ? 'open' : 'closed'}`; if (__v != null) _s0.setAttribute('data-state', String(__v)); else _s0.removeAttribute('data-state') }
-      { const __v = _p.value; if (__v != null) _s0.setAttribute('data-value', String(__v)); else _s0.removeAttribute('data-value') }
-      { const __v = `${accordionItemClasses} ${_p.className ?? ''}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = _p.id
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
+      }
+      __l[0] = __x }
+      { const __x = `${_p.open ? 'open' : 'closed'}`
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('data-state', String(__v)); else _s0.removeAttribute('data-state') }
+      }
+      __l[1] = __x }
+      { const __x = _p.value
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('data-value', String(__v)); else _s0.removeAttribute('data-value') }
+      }
+      __l[2] = __x }
+      { const __x = `${accordionItemClasses} ${_p.className ?? ''}`
+      if (!(3 in __l) || !Object.is(__l[3], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[3] = __x }
     }
-  })
+  }) }
 
 
   // Provide context for child components
@@ -2808,15 +3098,32 @@ export function initAccordionTrigger(__scope, _p = {}) {
   const [_s2, _s1] = $(__scope, 's2', 's1')
   const [_s0] = $c(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s1) {
-      { const __v = _p.id; if (__v != null) _s1.setAttribute('id', String(__v)); else _s1.removeAttribute('id') }
-      { const __v = `flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left text-sm font-medium transition-all outline-none hover:underline disabled:pointer-events-none disabled:opacity-50 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] ${className}`; if (__v != null) _s1.setAttribute('class', String(__v)); else _s1.removeAttribute('class') }
-      _s1.disabled = !!(_p.disabled)
-      if (_p.disabled) _s1.setAttribute('aria-disabled', 'true')
-      else _s1.removeAttribute('aria-disabled')
+      { const __x = _p.id
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('id', String(__v)); else _s1.removeAttribute('id') }
+      }
+      __l[0] = __x }
+      { const __x = `flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left text-sm font-medium transition-all outline-none hover:underline disabled:pointer-events-none disabled:opacity-50 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] ${className}`
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('class', String(__v)); else _s1.removeAttribute('class') }
+      }
+      __l[1] = __x }
+      { const __x = _p.disabled
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        _s1.disabled = !!(__x)
+      }
+      __l[2] = __x }
+      { const __x = _p.disabled
+      if (!(3 in __l) || !Object.is(__l[3], __x)) {
+        if (__x) _s1.setAttribute('aria-disabled', 'true')
+        else _s1.removeAttribute('aria-disabled')
+      }
+      __l[3] = __x }
     }
-  })
+  }) }
 
   if (_s2) (handleMount)(_s2)
   if (_s1) (handleMount)(_s1)
@@ -2849,17 +3156,27 @@ export function initAccordionContent(__scope, _p = {}) {
 
   const [_s1, _s0] = $(__scope, 's1', 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s1) {
-      { const __v = _p.id; if (__v != null) _s1.setAttribute('id', String(__v)); else _s1.removeAttribute('id') }
+      { const __x = _p.id
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('id', String(__v)); else _s1.removeAttribute('id') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `pt-0 pb-4 ${className()}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `pt-0 pb-4 ${className()}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s1) (handleMount)(_s1)
 }
@@ -2876,20 +3193,33 @@ export function initAccordionSingleOpenDemo(__scope, _p = {}) {
 
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     const [__AccordionItem_s2El] = $c(__scope, 's2')
     if (__AccordionItem_s2El) {
-      __AccordionItem_s2El.open = !!(openItem() === 'item-1')
+      { const __x = openItem() === 'item-1'
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        __AccordionItem_s2El.open = !!(__x)
+      }
+      __l[0] = __x }
     }
     const [__AccordionItem_s5El] = $c(__scope, 's5')
     if (__AccordionItem_s5El) {
-      __AccordionItem_s5El.open = !!(openItem() === 'item-2')
+      { const __x = openItem() === 'item-2'
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        __AccordionItem_s5El.open = !!(__x)
+      }
+      __l[1] = __x }
     }
     const [__AccordionItem_s8El] = $c(__scope, 's8')
     if (__AccordionItem_s8El) {
-      __AccordionItem_s8El.open = !!(openItem() === 'item-3')
+      { const __x = openItem() === 'item-3'
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        __AccordionItem_s8El.open = !!(__x)
+      }
+      __l[2] = __x }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('Accordion', __scope, {})
@@ -2927,16 +3257,25 @@ export function initAccordionAsChildDemo(__scope, _p = {}) {
 
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     const [__AccordionItem_s2El] = $c(__scope, 's2')
     if (__AccordionItem_s2El) {
-      __AccordionItem_s2El.open = !!(openItem() === 'custom')
+      { const __x = openItem() === 'custom'
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        __AccordionItem_s2El.open = !!(__x)
+      }
+      __l[0] = __x }
     }
     const [__AccordionItem_s5El] = $c(__scope, 's5')
     if (__AccordionItem_s5El) {
-      __AccordionItem_s5El.open = !!(openItem() === 'standard')
+      { const __x = openItem() === 'standard'
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        __AccordionItem_s5El.open = !!(__x)
+      }
+      __l[1] = __x }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('Accordion', _s6, {})
@@ -2975,20 +3314,33 @@ export function initAccordionMultipleOpenDemo(__scope, _p = {}) {
   })
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     const [__AccordionItem_s2El] = $c(__scope, 's2')
     if (__AccordionItem_s2El) {
-      __AccordionItem_s2El.open = !!(item1Open())
+      { const __x = item1Open()
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        __AccordionItem_s2El.open = !!(__x)
+      }
+      __l[0] = __x }
     }
     const [__AccordionItem_s5El] = $c(__scope, 's5')
     if (__AccordionItem_s5El) {
-      __AccordionItem_s5El.open = !!(item2Open())
+      { const __x = item2Open()
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        __AccordionItem_s5El.open = !!(__x)
+      }
+      __l[1] = __x }
     }
     const [__AccordionItem_s8El] = $c(__scope, 's8')
     if (__AccordionItem_s8El) {
-      __AccordionItem_s8El.open = !!(item3Open())
+      { const __x = item3Open()
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        __AccordionItem_s8El.open = !!(__x)
+      }
+      __l[2] = __x }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('Accordion', __scope, {})

--- a/packages/adapter-tests/fixtures/__snapshots__/ai-chat.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/ai-chat.client.js
@@ -44,19 +44,33 @@ export function initAIChatInteractive(__scope, _p = {}) {
 
   const [_s6, _s7, _s2, _s5] = $(__scope, 's6', 's7', 's2', 's5')
 
+  { const __l = []
   createEffect(() => {
     if (_s6) {
-      const __val = String(input())
-      if ('value' in _s6) { if (_s6.value !== __val) _s6.value = __val } else { _s6.setAttribute('value', __val) }
-      _s6.disabled = !!(isStreaming())
+      { const __x = input()
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        const __val = String(__x)
+        if ('value' in _s6) { if (_s6.value !== __val) _s6.value = __val } else { _s6.setAttribute('value', __val) }
+      }
+      __l[0] = __x }
+      { const __x = isStreaming()
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        _s6.disabled = !!(__x)
+      }
+      __l[1] = __x }
     }
-  })
+  }) }
 
+  { const __l = []
   createEffect(() => {
     if (_s7) {
-      _s7.disabled = !!(isStreaming())
+      { const __x = isStreaming()
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        _s7.disabled = !!(__x)
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   insert(__scope, 's2', () => isStreaming(), {
     template: () => { const __slots = []; return { html: `<div bf-c="s2" class="chat-msg chat-assistant"><div class="chat-bubble"><p bf="s4"><!--bf:s3-->${__bfSlot(streamingText(), __slots)}<!--/--><span class="streaming-cursor">▌</span></p></div></div>`, slots: __slots } },
@@ -92,9 +106,9 @@ export function initAIChatInteractive(__scope, _p = {}) {
       const __l = __e.last = []
       { const __t = __r[0]
       if (__t) {
-        const __x = `chat-msg chat-${msg().role}`
+        { const __x = `chat-msg chat-${msg().role}`
         { const __v = __x; if (__v != null) __t.setAttribute('class', String(__v)); else __t.removeAttribute('class') }
-        __l[0] = __x
+        __l[0] = __x }
       } }
       { const __x = msg().content
       __r[1]('s0', textOrNode(__x))
@@ -107,11 +121,11 @@ export function initAIChatInteractive(__scope, _p = {}) {
       const __l = __e.last ?? (__e.last = [])
       { const __t = 0 in __r ? __r[0] : (__r[0] = qsa(__e.primaryEl, '[bf="s1"]'))
       if (__t) {
-        const __x = `chat-msg chat-${msg().role}`
+        { const __x = `chat-msg chat-${msg().role}`
         if (!(0 in __l) || !Object.is(__l[0], __x)) {
           { const __v = __x; if (__v != null) __t.setAttribute('class', String(__v)); else __t.removeAttribute('class') }
         }
-        __l[0] = __x
+        __l[0] = __x }
       } }
       const __d = __r[1] ?? (__r[1] = lazySlots(__e.primaryEl, __lzs_l0))
       { const __x = msg().content

--- a/packages/adapter-tests/fixtures/__snapshots__/branch-root-prop-attr.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/branch-root-prop-attr.client.js
@@ -11,17 +11,27 @@ export function initVariantTag(__scope, _p = {}) {
 
   const [_s1, _s0] = $(__scope, 's1', 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s1) {
-      { const __v = `${({"a": "cls-a", "b": "cls-b"})[(_p.variant ?? 'a')]}`; if (__v != null) _s1.setAttribute('class', String(__v)); else _s1.removeAttribute('class') }
+      { const __x = `${({"a": "cls-a", "b": "cls-b"})[(_p.variant ?? 'a')]}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('class', String(__v)); else _s1.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `${({"a": "cls-a", "b": "cls-b"})[(_p.variant ?? 'a')]}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `${({"a": "cls-a", "b": "cls-b"})[(_p.variant ?? 'a')]}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
 }
 
@@ -46,12 +56,17 @@ export function initBranchRootPropAttr(__scope, _p = {}) {
   })
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     const [__VariantTag_s0El] = $c(__scope, 's0')
     if (__VariantTag_s0El) {
-      { const __v = variant(); if (__v != null) __VariantTag_s0El.setAttribute('variant', String(__v)); else __VariantTag_s0El.removeAttribute('variant') }
+      { const __x = variant()
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) __VariantTag_s0El.setAttribute('variant', String(__v)); else __VariantTag_s0El.removeAttribute('variant') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('VariantTag', _s0, { get variant() { return variant() } })

--- a/packages/adapter-tests/fixtures/__snapshots__/button.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/button.client.js
@@ -15,12 +15,17 @@ export function initSlot(__scope, _p = {}) {
 
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     const [__Tag_s0El] = $c(__scope, 's0')
     if (__Tag_s0El) {
-      { const __v = ([className, (((children.props).className) || '')].filter(Boolean).join(' ')); if (__v != null) __Tag_s0El.setAttribute('class', String(__v)); else __Tag_s0El.removeAttribute('class') }
+      { const __x = ([className, (((children.props).className) || '')].filter(Boolean).join(' '))
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) __Tag_s0El.setAttribute('class', String(__v)); else __Tag_s0El.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('Tag', _s0, forwardProps(_p, { get className() { return ([className, (((children.props).className) || '')].filter(Boolean).join(' ')) } }, ["className"]))
@@ -57,22 +62,32 @@ export function initButton(__scope, _p = {}) {
   const [_s0] = $(__scope, 's0')
   const [_s1] = $c(__scope, 's1')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*="size-"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-[invalid]:ring-destructive/20 dark:aria-[invalid]:ring-destructive/40 aria-[invalid]:border-destructive touch-action-manipulation ${({"default": "bg-primary text-primary-foreground hover:bg-primary/90", "destructive": "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60", "outline": "border border-input bg-background text-foreground shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:hover:bg-input/50", "secondary": "bg-secondary text-secondary-foreground hover:bg-secondary/80", "ghost": "text-foreground hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50", "link": "text-foreground underline-offset-4 hover:underline hover:text-primary"})[(_p.variant ?? 'default')]} ${({"default": "h-9 px-4 py-2 has-[>svg]:px-3", "sm": "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5", "lg": "h-10 rounded-md px-6 has-[>svg]:px-4", "icon": "size-9", "icon-sm": "size-8", "icon-lg": "size-10"})[(_p.size ?? 'default')]} ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*="size-"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-[invalid]:ring-destructive/20 dark:aria-[invalid]:ring-destructive/40 aria-[invalid]:border-destructive touch-action-manipulation ${({"default": "bg-primary text-primary-foreground hover:bg-primary/90", "destructive": "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60", "outline": "border border-input bg-background text-foreground shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:hover:bg-input/50", "secondary": "bg-secondary text-secondary-foreground hover:bg-secondary/80", "ghost": "text-foreground hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50", "link": "text-foreground underline-offset-4 hover:underline hover:text-primary"})[(_p.variant ?? 'default')]} ${({"default": "h-9 px-4 py-2 has-[>svg]:px-3", "sm": "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5", "lg": "h-10 rounded-md px-6 has-[>svg]:px-4", "icon": "size-9", "icon-sm": "size-8", "icon-lg": "size-10"})[(_p.size ?? 'default')]} ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["className","variant","size","asChild","children","class"])
 
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     const [__Slot_s1El] = $c(__scope, 's1')
     if (__Slot_s1El) {
-      { const __v = `inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*="size-"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-[invalid]:ring-destructive/20 dark:aria-[invalid]:ring-destructive/40 aria-[invalid]:border-destructive touch-action-manipulation ${({"default": "bg-primary text-primary-foreground hover:bg-primary/90", "destructive": "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60", "outline": "border border-input bg-background text-foreground shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:hover:bg-input/50", "secondary": "bg-secondary text-secondary-foreground hover:bg-secondary/80", "ghost": "text-foreground hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50", "link": "text-foreground underline-offset-4 hover:underline hover:text-primary"})[variant]} ${({"default": "h-9 px-4 py-2 has-[>svg]:px-3", "sm": "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5", "lg": "h-10 rounded-md px-6 has-[>svg]:px-4", "icon": "size-9", "icon-sm": "size-8", "icon-lg": "size-10"})[size]} ${className}`; if (__v != null) __Slot_s1El.setAttribute('class', String(__v)); else __Slot_s1El.removeAttribute('class') }
+      { const __x = `inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*="size-"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-[invalid]:ring-destructive/20 dark:aria-[invalid]:ring-destructive/40 aria-[invalid]:border-destructive touch-action-manipulation ${({"default": "bg-primary text-primary-foreground hover:bg-primary/90", "destructive": "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60", "outline": "border border-input bg-background text-foreground shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:hover:bg-input/50", "secondary": "bg-secondary text-secondary-foreground hover:bg-secondary/80", "ghost": "text-foreground hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50", "link": "text-foreground underline-offset-4 hover:underline hover:text-primary"})[variant]} ${({"default": "h-9 px-4 py-2 has-[>svg]:px-3", "sm": "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5", "lg": "h-10 rounded-md px-6 has-[>svg]:px-4", "icon": "size-9", "icon-sm": "size-8", "icon-lg": "size-10"})[size]} ${className}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) __Slot_s1El.setAttribute('class', String(__v)); else __Slot_s1El.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('Slot', _s1, forwardProps(_p, { get className() { return `inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*="size-"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-[invalid]:ring-destructive/20 dark:aria-[invalid]:ring-destructive/40 aria-[invalid]:border-destructive touch-action-manipulation ${({"default": "bg-primary text-primary-foreground hover:bg-primary/90", "destructive": "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60", "outline": "border border-input bg-background text-foreground shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:hover:bg-input/50", "secondary": "bg-secondary text-secondary-foreground hover:bg-secondary/80", "ghost": "text-foreground hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50", "link": "text-foreground underline-offset-4 hover:underline hover:text-primary"})[variant]} ${({"default": "h-9 px-4 py-2 has-[>svg]:px-3", "sm": "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5", "lg": "h-10 rounded-md px-6 has-[>svg]:px-4", "icon": "size-9", "icon-sm": "size-8", "icon-lg": "size-10"})[size]} ${className}` } }, ["className"]))

--- a/packages/adapter-tests/fixtures/__snapshots__/carousel.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/carousel.client.js
@@ -39,11 +39,16 @@ export function initCheckIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -144,11 +149,16 @@ export function initChevronDownIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -249,11 +259,16 @@ export function initChevronUpIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -354,11 +369,16 @@ export function initChevronLeftIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -459,11 +479,16 @@ export function initChevronRightIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -564,11 +589,16 @@ export function initXIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -669,11 +699,16 @@ export function initPlusIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -774,11 +809,16 @@ export function initMinusIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -879,11 +919,16 @@ export function initSunIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -984,11 +1029,16 @@ export function initMoonIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1089,11 +1139,16 @@ export function initMonitorIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1194,11 +1249,16 @@ export function initCopyIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1299,11 +1359,16 @@ export function initClipboardIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1404,11 +1469,16 @@ export function initClipboardCheckIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1509,11 +1579,16 @@ export function initMenuIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1614,11 +1689,16 @@ export function initArrowLeftIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1719,11 +1799,16 @@ export function initArrowRightIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1824,11 +1909,16 @@ export function initArrowUpDownIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1906,11 +1996,16 @@ export function initEllipsisIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1944,11 +2039,16 @@ export function initGitHubIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","class","aria-hidden"])
 
@@ -1982,11 +2082,16 @@ export function initSettingsIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2020,11 +2125,16 @@ export function initGlobeIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2058,11 +2168,16 @@ export function initLogOutIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2096,11 +2211,16 @@ export function initCircleHelpIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2134,11 +2254,16 @@ export function initSearchIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2172,11 +2297,16 @@ export function initCircleCheckIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2210,11 +2340,16 @@ export function initCircleXIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2248,11 +2383,16 @@ export function initTriangleAlertIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2286,11 +2426,16 @@ export function initInfoIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2324,11 +2469,16 @@ export function initCalendarIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2362,11 +2512,16 @@ export function initGripVerticalIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2423,11 +2578,16 @@ export function initLoaderCircleIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2505,11 +2665,16 @@ export function initPanelLeftIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2576,77 +2741,180 @@ export function initIcon(__scope, _p = {}) {
   const [_s1, _s0] = $(__scope, 's1', 's0')
   const [_s11, _s10, _s9, _s8, _s7, _s6, _s5, _s4, _s3, _s2] = $c(__scope, 's11', 's10', 's9', 's8', 's7', 's6', 's5', 's4', 's3', 's2')
 
+  { const __l = []
   createEffect(() => {
     if (_s1) {
-      { const __v = sizeMap[(_p.size ?? 'md')]; if (__v != null) _s1.setAttribute('width', String(__v)); else _s1.removeAttribute('width') }
-      { const __v = sizeMap[(_p.size ?? 'md')]; if (__v != null) _s1.setAttribute('height', String(__v)); else _s1.removeAttribute('height') }
-      { const __v = (buttLinecapIcons).includes(_p.name) ? 'butt' : 'round'; if (__v != null) _s1.setAttribute('stroke-linecap', String(__v)); else _s1.removeAttribute('stroke-linecap') }
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s1.setAttribute('class', String(__v)); else _s1.removeAttribute('class') }
+      { const __x = sizeMap[(_p.size ?? 'md')]
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('width', String(__v)); else _s1.removeAttribute('width') }
+      }
+      __l[0] = __x }
+      { const __x = sizeMap[(_p.size ?? 'md')]
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('height', String(__v)); else _s1.removeAttribute('height') }
+      }
+      __l[1] = __x }
+      { const __x = (buttLinecapIcons).includes(_p.name) ? 'butt' : 'round'
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('stroke-linecap', String(__v)); else _s1.removeAttribute('stroke-linecap') }
+      }
+      __l[2] = __x }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(3 in __l) || !Object.is(__l[3], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('class', String(__v)); else _s1.removeAttribute('class') }
+      }
+      __l[3] = __x }
     }
-  })
+  }) }
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `${({"check": "M20 6 9 17l-5-5", "chevron-down": "m6 9 6 6 6-6", "chevron-up": "m18 15-6-6-6 6", "chevron-left": "m15 18-6-6 6-6", "chevron-right": "m9 18 6-6-6-6", "x": "M18 6 6 18M6 6l12 12", "plus": "M5 12h14M12 5v14", "minus": "M5 12h14", "sun": "M12 16a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41", "moon": "M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z", "monitor": "M20 3H4a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2zM8 21h8M12 17v4", "copy": "M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2M8 8h12a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V10a2 2 0 0 1 2-2z", "clipboard": "M9 2h6a1 1 0 0 1 1 1v1H8V3a1 1 0 0 1 1-1zM16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2", "clipboard-check": "M9 2h6a1 1 0 0 1 1 1v1H8V3a1 1 0 0 1 1-1zM16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2M9 14l2 2 4-4", "menu": "M4 6h16M4 12h16M4 18h16", "arrow-left": "m12 19-7-7 7-7M19 12H5", "arrow-right": "M5 12h14m-7-7 7 7-7 7", "ellipsis": "M5 12h.01M12 12h.01M19 12h.01", "arrow-up-down": "m21 16-4 4-4-4M17 20V4M3 8l4-4 4 4M7 4v16", "panel-left": "M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4M3 3h12v18H3zM9 3v18", "loader-circle": "M21 12a9 9 0 1 1-6.219-8.56"})[_p.name]}`; if (__v != null) _s0.setAttribute('d', String(__v)); else _s0.removeAttribute('d') }
+      { const __x = `${({"check": "M20 6 9 17l-5-5", "chevron-down": "m6 9 6 6 6-6", "chevron-up": "m18 15-6-6-6 6", "chevron-left": "m15 18-6-6 6-6", "chevron-right": "m9 18 6-6-6-6", "x": "M18 6 6 18M6 6l12 12", "plus": "M5 12h14M12 5v14", "minus": "M5 12h14", "sun": "M12 16a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41", "moon": "M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z", "monitor": "M20 3H4a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2zM8 21h8M12 17v4", "copy": "M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2M8 8h12a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V10a2 2 0 0 1 2-2z", "clipboard": "M9 2h6a1 1 0 0 1 1 1v1H8V3a1 1 0 0 1 1-1zM16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2", "clipboard-check": "M9 2h6a1 1 0 0 1 1 1v1H8V3a1 1 0 0 1 1-1zM16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2M9 14l2 2 4-4", "menu": "M4 6h16M4 12h16M4 18h16", "arrow-left": "m12 19-7-7 7-7M19 12H5", "arrow-right": "M5 12h14m-7-7 7 7-7 7", "ellipsis": "M5 12h.01M12 12h.01M19 12h.01", "arrow-up-down": "m21 16-4 4-4-4M17 20V4M3 8l4-4 4 4M7 4v16", "panel-left": "M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4M3 3h12v18H3zM9 3v18", "loader-circle": "M21 12a9 9 0 1 1-6.219-8.56"})[_p.name]}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('d', String(__v)); else _s0.removeAttribute('d') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s1) applyRestAttrs(_s1, _p, ["name","size","className","xmlns","width","height","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     const [__GitHubIcon_s11El] = $c(__scope, 's11')
     if (__GitHubIcon_s11El) {
-      { const __v = size; if (__v != null) __GitHubIcon_s11El.setAttribute('size', String(__v)); else __GitHubIcon_s11El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __GitHubIcon_s11El.setAttribute('class', String(__v)); else __GitHubIcon_s11El.removeAttribute('class') }
+      { const __x = size
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) __GitHubIcon_s11El.setAttribute('size', String(__v)); else __GitHubIcon_s11El.removeAttribute('size') }
+      }
+      __l[0] = __x }
+      { const __x = className
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) __GitHubIcon_s11El.setAttribute('class', String(__v)); else __GitHubIcon_s11El.removeAttribute('class') }
+      }
+      __l[1] = __x }
     }
     const [__SearchIcon_s10El] = $c(__scope, 's10')
     if (__SearchIcon_s10El) {
-      { const __v = size; if (__v != null) __SearchIcon_s10El.setAttribute('size', String(__v)); else __SearchIcon_s10El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __SearchIcon_s10El.setAttribute('class', String(__v)); else __SearchIcon_s10El.removeAttribute('class') }
+      { const __x = size
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        { const __v = __x; if (__v != null) __SearchIcon_s10El.setAttribute('size', String(__v)); else __SearchIcon_s10El.removeAttribute('size') }
+      }
+      __l[2] = __x }
+      { const __x = className
+      if (!(3 in __l) || !Object.is(__l[3], __x)) {
+        { const __v = __x; if (__v != null) __SearchIcon_s10El.setAttribute('class', String(__v)); else __SearchIcon_s10El.removeAttribute('class') }
+      }
+      __l[3] = __x }
     }
     const [__SettingsIcon_s9El] = $c(__scope, 's9')
     if (__SettingsIcon_s9El) {
-      { const __v = size; if (__v != null) __SettingsIcon_s9El.setAttribute('size', String(__v)); else __SettingsIcon_s9El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __SettingsIcon_s9El.setAttribute('class', String(__v)); else __SettingsIcon_s9El.removeAttribute('class') }
+      { const __x = size
+      if (!(4 in __l) || !Object.is(__l[4], __x)) {
+        { const __v = __x; if (__v != null) __SettingsIcon_s9El.setAttribute('size', String(__v)); else __SettingsIcon_s9El.removeAttribute('size') }
+      }
+      __l[4] = __x }
+      { const __x = className
+      if (!(5 in __l) || !Object.is(__l[5], __x)) {
+        { const __v = __x; if (__v != null) __SettingsIcon_s9El.setAttribute('class', String(__v)); else __SettingsIcon_s9El.removeAttribute('class') }
+      }
+      __l[5] = __x }
     }
     const [__GlobeIcon_s8El] = $c(__scope, 's8')
     if (__GlobeIcon_s8El) {
-      { const __v = size; if (__v != null) __GlobeIcon_s8El.setAttribute('size', String(__v)); else __GlobeIcon_s8El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __GlobeIcon_s8El.setAttribute('class', String(__v)); else __GlobeIcon_s8El.removeAttribute('class') }
+      { const __x = size
+      if (!(6 in __l) || !Object.is(__l[6], __x)) {
+        { const __v = __x; if (__v != null) __GlobeIcon_s8El.setAttribute('size', String(__v)); else __GlobeIcon_s8El.removeAttribute('size') }
+      }
+      __l[6] = __x }
+      { const __x = className
+      if (!(7 in __l) || !Object.is(__l[7], __x)) {
+        { const __v = __x; if (__v != null) __GlobeIcon_s8El.setAttribute('class', String(__v)); else __GlobeIcon_s8El.removeAttribute('class') }
+      }
+      __l[7] = __x }
     }
     const [__LogOutIcon_s7El] = $c(__scope, 's7')
     if (__LogOutIcon_s7El) {
-      { const __v = size; if (__v != null) __LogOutIcon_s7El.setAttribute('size', String(__v)); else __LogOutIcon_s7El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __LogOutIcon_s7El.setAttribute('class', String(__v)); else __LogOutIcon_s7El.removeAttribute('class') }
+      { const __x = size
+      if (!(8 in __l) || !Object.is(__l[8], __x)) {
+        { const __v = __x; if (__v != null) __LogOutIcon_s7El.setAttribute('size', String(__v)); else __LogOutIcon_s7El.removeAttribute('size') }
+      }
+      __l[8] = __x }
+      { const __x = className
+      if (!(9 in __l) || !Object.is(__l[9], __x)) {
+        { const __v = __x; if (__v != null) __LogOutIcon_s7El.setAttribute('class', String(__v)); else __LogOutIcon_s7El.removeAttribute('class') }
+      }
+      __l[9] = __x }
     }
     const [__CircleHelpIcon_s6El] = $c(__scope, 's6')
     if (__CircleHelpIcon_s6El) {
-      { const __v = size; if (__v != null) __CircleHelpIcon_s6El.setAttribute('size', String(__v)); else __CircleHelpIcon_s6El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __CircleHelpIcon_s6El.setAttribute('class', String(__v)); else __CircleHelpIcon_s6El.removeAttribute('class') }
+      { const __x = size
+      if (!(10 in __l) || !Object.is(__l[10], __x)) {
+        { const __v = __x; if (__v != null) __CircleHelpIcon_s6El.setAttribute('size', String(__v)); else __CircleHelpIcon_s6El.removeAttribute('size') }
+      }
+      __l[10] = __x }
+      { const __x = className
+      if (!(11 in __l) || !Object.is(__l[11], __x)) {
+        { const __v = __x; if (__v != null) __CircleHelpIcon_s6El.setAttribute('class', String(__v)); else __CircleHelpIcon_s6El.removeAttribute('class') }
+      }
+      __l[11] = __x }
     }
     const [__CalendarIcon_s5El] = $c(__scope, 's5')
     if (__CalendarIcon_s5El) {
-      { const __v = size; if (__v != null) __CalendarIcon_s5El.setAttribute('size', String(__v)); else __CalendarIcon_s5El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __CalendarIcon_s5El.setAttribute('class', String(__v)); else __CalendarIcon_s5El.removeAttribute('class') }
+      { const __x = size
+      if (!(12 in __l) || !Object.is(__l[12], __x)) {
+        { const __v = __x; if (__v != null) __CalendarIcon_s5El.setAttribute('size', String(__v)); else __CalendarIcon_s5El.removeAttribute('size') }
+      }
+      __l[12] = __x }
+      { const __x = className
+      if (!(13 in __l) || !Object.is(__l[13], __x)) {
+        { const __v = __x; if (__v != null) __CalendarIcon_s5El.setAttribute('class', String(__v)); else __CalendarIcon_s5El.removeAttribute('class') }
+      }
+      __l[13] = __x }
     }
     const [__GripVerticalIcon_s4El] = $c(__scope, 's4')
     if (__GripVerticalIcon_s4El) {
-      { const __v = size; if (__v != null) __GripVerticalIcon_s4El.setAttribute('size', String(__v)); else __GripVerticalIcon_s4El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __GripVerticalIcon_s4El.setAttribute('class', String(__v)); else __GripVerticalIcon_s4El.removeAttribute('class') }
+      { const __x = size
+      if (!(14 in __l) || !Object.is(__l[14], __x)) {
+        { const __v = __x; if (__v != null) __GripVerticalIcon_s4El.setAttribute('size', String(__v)); else __GripVerticalIcon_s4El.removeAttribute('size') }
+      }
+      __l[14] = __x }
+      { const __x = className
+      if (!(15 in __l) || !Object.is(__l[15], __x)) {
+        { const __v = __x; if (__v != null) __GripVerticalIcon_s4El.setAttribute('class', String(__v)); else __GripVerticalIcon_s4El.removeAttribute('class') }
+      }
+      __l[15] = __x }
     }
     const [__LoaderCircleIcon_s3El] = $c(__scope, 's3')
     if (__LoaderCircleIcon_s3El) {
-      { const __v = size; if (__v != null) __LoaderCircleIcon_s3El.setAttribute('size', String(__v)); else __LoaderCircleIcon_s3El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __LoaderCircleIcon_s3El.setAttribute('class', String(__v)); else __LoaderCircleIcon_s3El.removeAttribute('class') }
+      { const __x = size
+      if (!(16 in __l) || !Object.is(__l[16], __x)) {
+        { const __v = __x; if (__v != null) __LoaderCircleIcon_s3El.setAttribute('size', String(__v)); else __LoaderCircleIcon_s3El.removeAttribute('size') }
+      }
+      __l[16] = __x }
+      { const __x = className
+      if (!(17 in __l) || !Object.is(__l[17], __x)) {
+        { const __v = __x; if (__v != null) __LoaderCircleIcon_s3El.setAttribute('class', String(__v)); else __LoaderCircleIcon_s3El.removeAttribute('class') }
+      }
+      __l[17] = __x }
     }
     const [__PanelLeftIcon_s2El] = $c(__scope, 's2')
     if (__PanelLeftIcon_s2El) {
-      { const __v = size; if (__v != null) __PanelLeftIcon_s2El.setAttribute('size', String(__v)); else __PanelLeftIcon_s2El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __PanelLeftIcon_s2El.setAttribute('class', String(__v)); else __PanelLeftIcon_s2El.removeAttribute('class') }
+      { const __x = size
+      if (!(18 in __l) || !Object.is(__l[18], __x)) {
+        { const __v = __x; if (__v != null) __PanelLeftIcon_s2El.setAttribute('size', String(__v)); else __PanelLeftIcon_s2El.removeAttribute('size') }
+      }
+      __l[18] = __x }
+      { const __x = className
+      if (!(19 in __l) || !Object.is(__l[19], __x)) {
+        { const __v = __x; if (__v != null) __PanelLeftIcon_s2El.setAttribute('class', String(__v)); else __PanelLeftIcon_s2El.removeAttribute('class') }
+      }
+      __l[19] = __x }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('GitHubIcon', _s11, forwardProps(_p, { get size() { return size }, get className() { return className } }, ["size","className"]))
@@ -2710,13 +2978,26 @@ export function initCarousel(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `${carouselClasses} ${_p.className ?? ''}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
-      { const __v = orientation(); if (__v != null) _s0.setAttribute('data-orientation', String(__v)); else _s0.removeAttribute('data-orientation') }
-      { const __v = _p.opts ? JSON.stringify(_p.opts) : undefined; if (__v != null) _s0.setAttribute('data-opts', String(__v)); else _s0.removeAttribute('data-opts') }
+      { const __x = `${carouselClasses} ${_p.className ?? ''}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
+      { const __x = orientation()
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('data-orientation', String(__v)); else _s0.removeAttribute('data-orientation') }
+      }
+      __l[1] = __x }
+      { const __x = _p.opts ? JSON.stringify(_p.opts) : undefined
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('data-opts', String(__v)); else _s0.removeAttribute('data-opts') }
+      }
+      __l[2] = __x }
     }
-  })
+  }) }
 
   if (_s0) (handleMount)(_s0)
 
@@ -2783,11 +3064,16 @@ export function initCarouselContent(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `${directionClasses()} ${_p.className ?? ''}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `${directionClasses()} ${_p.className ?? ''}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) (handleMount)(_s0)
 }
@@ -2803,11 +3089,16 @@ export function initCarouselItem(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `${carouselItemClasses} ${paddingClass()} ${_p.className ?? ''}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `${carouselItemClasses} ${paddingClass()} ${_p.className ?? ''}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
 }
 
@@ -2841,11 +3132,16 @@ export function initCarouselPrevious(__scope, _p = {}) {
   const [_s1] = $(__scope, 's1')
   const [_s0] = $c(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s1) {
-      { const __v = `${carouselButtonBaseClasses} ${positionClasses()} ${_p.className ?? ''}`; if (__v != null) _s1.setAttribute('class', String(__v)); else _s1.removeAttribute('class') }
+      { const __x = `${carouselButtonBaseClasses} ${positionClasses()} ${_p.className ?? ''}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('class', String(__v)); else _s1.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s1) (handleMount)(_s1)
 
@@ -2883,11 +3179,16 @@ export function initCarouselNext(__scope, _p = {}) {
   const [_s1] = $(__scope, 's1')
   const [_s0] = $c(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s1) {
-      { const __v = `${carouselButtonBaseClasses} ${positionClasses()} ${_p.className ?? ''}`; if (__v != null) _s1.setAttribute('class', String(__v)); else _s1.removeAttribute('class') }
+      { const __x = `${carouselButtonBaseClasses} ${positionClasses()} ${_p.className ?? ''}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('class', String(__v)); else _s1.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s1) (handleMount)(_s1)
 

--- a/packages/adapter-tests/fixtures/__snapshots__/checkbox-native-shared.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/checkbox-native-shared.client.js
@@ -9,11 +9,16 @@ export function initCheckboxNative(__scope, _p = {}) {
 
   const [_s0, _s1] = $(__scope, 's0', 's1')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      _s0.checked = !!(subscribed())
+      { const __x = subscribed()
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        _s0.checked = !!(__x)
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   insert(__scope, 's1', () => subscribed(), {
     template: () => { const __slots = []; return { html: `<!--bf-cond-start:s1-->${__bfSlot('Subscribed', __slots)}<!--bf-cond-end:s1-->`, slots: __slots } },

--- a/packages/adapter-tests/fixtures/__snapshots__/checkbox.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/checkbox.client.js
@@ -39,11 +39,16 @@ export function initCheckIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -144,11 +149,16 @@ export function initChevronDownIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -249,11 +259,16 @@ export function initChevronUpIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -354,11 +369,16 @@ export function initChevronLeftIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -459,11 +479,16 @@ export function initChevronRightIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -564,11 +589,16 @@ export function initXIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -669,11 +699,16 @@ export function initPlusIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -774,11 +809,16 @@ export function initMinusIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -879,11 +919,16 @@ export function initSunIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -984,11 +1029,16 @@ export function initMoonIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1089,11 +1139,16 @@ export function initMonitorIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1194,11 +1249,16 @@ export function initCopyIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1299,11 +1359,16 @@ export function initClipboardIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1404,11 +1469,16 @@ export function initClipboardCheckIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1509,11 +1579,16 @@ export function initMenuIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1614,11 +1689,16 @@ export function initArrowLeftIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1719,11 +1799,16 @@ export function initArrowRightIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1824,11 +1909,16 @@ export function initArrowUpDownIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1906,11 +1996,16 @@ export function initEllipsisIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1944,11 +2039,16 @@ export function initGitHubIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","class","aria-hidden"])
 
@@ -1982,11 +2082,16 @@ export function initSettingsIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2020,11 +2125,16 @@ export function initGlobeIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2058,11 +2168,16 @@ export function initLogOutIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2096,11 +2211,16 @@ export function initCircleHelpIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2134,11 +2254,16 @@ export function initSearchIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2172,11 +2297,16 @@ export function initCircleCheckIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2210,11 +2340,16 @@ export function initCircleXIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2248,11 +2383,16 @@ export function initTriangleAlertIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2286,11 +2426,16 @@ export function initInfoIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2324,11 +2469,16 @@ export function initCalendarIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2362,11 +2512,16 @@ export function initGripVerticalIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2423,11 +2578,16 @@ export function initLoaderCircleIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2505,11 +2665,16 @@ export function initPanelLeftIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2576,77 +2741,180 @@ export function initIcon(__scope, _p = {}) {
   const [_s1, _s0] = $(__scope, 's1', 's0')
   const [_s11, _s10, _s9, _s8, _s7, _s6, _s5, _s4, _s3, _s2] = $c(__scope, 's11', 's10', 's9', 's8', 's7', 's6', 's5', 's4', 's3', 's2')
 
+  { const __l = []
   createEffect(() => {
     if (_s1) {
-      { const __v = sizeMap[(_p.size ?? 'md')]; if (__v != null) _s1.setAttribute('width', String(__v)); else _s1.removeAttribute('width') }
-      { const __v = sizeMap[(_p.size ?? 'md')]; if (__v != null) _s1.setAttribute('height', String(__v)); else _s1.removeAttribute('height') }
-      { const __v = (buttLinecapIcons).includes(_p.name) ? 'butt' : 'round'; if (__v != null) _s1.setAttribute('stroke-linecap', String(__v)); else _s1.removeAttribute('stroke-linecap') }
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s1.setAttribute('class', String(__v)); else _s1.removeAttribute('class') }
+      { const __x = sizeMap[(_p.size ?? 'md')]
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('width', String(__v)); else _s1.removeAttribute('width') }
+      }
+      __l[0] = __x }
+      { const __x = sizeMap[(_p.size ?? 'md')]
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('height', String(__v)); else _s1.removeAttribute('height') }
+      }
+      __l[1] = __x }
+      { const __x = (buttLinecapIcons).includes(_p.name) ? 'butt' : 'round'
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('stroke-linecap', String(__v)); else _s1.removeAttribute('stroke-linecap') }
+      }
+      __l[2] = __x }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(3 in __l) || !Object.is(__l[3], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('class', String(__v)); else _s1.removeAttribute('class') }
+      }
+      __l[3] = __x }
     }
-  })
+  }) }
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `${({"check": "M20 6 9 17l-5-5", "chevron-down": "m6 9 6 6 6-6", "chevron-up": "m18 15-6-6-6 6", "chevron-left": "m15 18-6-6 6-6", "chevron-right": "m9 18 6-6-6-6", "x": "M18 6 6 18M6 6l12 12", "plus": "M5 12h14M12 5v14", "minus": "M5 12h14", "sun": "M12 16a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41", "moon": "M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z", "monitor": "M20 3H4a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2zM8 21h8M12 17v4", "copy": "M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2M8 8h12a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V10a2 2 0 0 1 2-2z", "clipboard": "M9 2h6a1 1 0 0 1 1 1v1H8V3a1 1 0 0 1 1-1zM16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2", "clipboard-check": "M9 2h6a1 1 0 0 1 1 1v1H8V3a1 1 0 0 1 1-1zM16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2M9 14l2 2 4-4", "menu": "M4 6h16M4 12h16M4 18h16", "arrow-left": "m12 19-7-7 7-7M19 12H5", "arrow-right": "M5 12h14m-7-7 7 7-7 7", "ellipsis": "M5 12h.01M12 12h.01M19 12h.01", "arrow-up-down": "m21 16-4 4-4-4M17 20V4M3 8l4-4 4 4M7 4v16", "panel-left": "M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4M3 3h12v18H3zM9 3v18", "loader-circle": "M21 12a9 9 0 1 1-6.219-8.56"})[_p.name]}`; if (__v != null) _s0.setAttribute('d', String(__v)); else _s0.removeAttribute('d') }
+      { const __x = `${({"check": "M20 6 9 17l-5-5", "chevron-down": "m6 9 6 6 6-6", "chevron-up": "m18 15-6-6-6 6", "chevron-left": "m15 18-6-6 6-6", "chevron-right": "m9 18 6-6-6-6", "x": "M18 6 6 18M6 6l12 12", "plus": "M5 12h14M12 5v14", "minus": "M5 12h14", "sun": "M12 16a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41", "moon": "M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z", "monitor": "M20 3H4a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2zM8 21h8M12 17v4", "copy": "M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2M8 8h12a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V10a2 2 0 0 1 2-2z", "clipboard": "M9 2h6a1 1 0 0 1 1 1v1H8V3a1 1 0 0 1 1-1zM16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2", "clipboard-check": "M9 2h6a1 1 0 0 1 1 1v1H8V3a1 1 0 0 1 1-1zM16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2M9 14l2 2 4-4", "menu": "M4 6h16M4 12h16M4 18h16", "arrow-left": "m12 19-7-7 7-7M19 12H5", "arrow-right": "M5 12h14m-7-7 7 7-7 7", "ellipsis": "M5 12h.01M12 12h.01M19 12h.01", "arrow-up-down": "m21 16-4 4-4-4M17 20V4M3 8l4-4 4 4M7 4v16", "panel-left": "M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4M3 3h12v18H3zM9 3v18", "loader-circle": "M21 12a9 9 0 1 1-6.219-8.56"})[_p.name]}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('d', String(__v)); else _s0.removeAttribute('d') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s1) applyRestAttrs(_s1, _p, ["name","size","className","xmlns","width","height","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     const [__GitHubIcon_s11El] = $c(__scope, 's11')
     if (__GitHubIcon_s11El) {
-      { const __v = size; if (__v != null) __GitHubIcon_s11El.setAttribute('size', String(__v)); else __GitHubIcon_s11El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __GitHubIcon_s11El.setAttribute('class', String(__v)); else __GitHubIcon_s11El.removeAttribute('class') }
+      { const __x = size
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) __GitHubIcon_s11El.setAttribute('size', String(__v)); else __GitHubIcon_s11El.removeAttribute('size') }
+      }
+      __l[0] = __x }
+      { const __x = className
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) __GitHubIcon_s11El.setAttribute('class', String(__v)); else __GitHubIcon_s11El.removeAttribute('class') }
+      }
+      __l[1] = __x }
     }
     const [__SearchIcon_s10El] = $c(__scope, 's10')
     if (__SearchIcon_s10El) {
-      { const __v = size; if (__v != null) __SearchIcon_s10El.setAttribute('size', String(__v)); else __SearchIcon_s10El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __SearchIcon_s10El.setAttribute('class', String(__v)); else __SearchIcon_s10El.removeAttribute('class') }
+      { const __x = size
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        { const __v = __x; if (__v != null) __SearchIcon_s10El.setAttribute('size', String(__v)); else __SearchIcon_s10El.removeAttribute('size') }
+      }
+      __l[2] = __x }
+      { const __x = className
+      if (!(3 in __l) || !Object.is(__l[3], __x)) {
+        { const __v = __x; if (__v != null) __SearchIcon_s10El.setAttribute('class', String(__v)); else __SearchIcon_s10El.removeAttribute('class') }
+      }
+      __l[3] = __x }
     }
     const [__SettingsIcon_s9El] = $c(__scope, 's9')
     if (__SettingsIcon_s9El) {
-      { const __v = size; if (__v != null) __SettingsIcon_s9El.setAttribute('size', String(__v)); else __SettingsIcon_s9El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __SettingsIcon_s9El.setAttribute('class', String(__v)); else __SettingsIcon_s9El.removeAttribute('class') }
+      { const __x = size
+      if (!(4 in __l) || !Object.is(__l[4], __x)) {
+        { const __v = __x; if (__v != null) __SettingsIcon_s9El.setAttribute('size', String(__v)); else __SettingsIcon_s9El.removeAttribute('size') }
+      }
+      __l[4] = __x }
+      { const __x = className
+      if (!(5 in __l) || !Object.is(__l[5], __x)) {
+        { const __v = __x; if (__v != null) __SettingsIcon_s9El.setAttribute('class', String(__v)); else __SettingsIcon_s9El.removeAttribute('class') }
+      }
+      __l[5] = __x }
     }
     const [__GlobeIcon_s8El] = $c(__scope, 's8')
     if (__GlobeIcon_s8El) {
-      { const __v = size; if (__v != null) __GlobeIcon_s8El.setAttribute('size', String(__v)); else __GlobeIcon_s8El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __GlobeIcon_s8El.setAttribute('class', String(__v)); else __GlobeIcon_s8El.removeAttribute('class') }
+      { const __x = size
+      if (!(6 in __l) || !Object.is(__l[6], __x)) {
+        { const __v = __x; if (__v != null) __GlobeIcon_s8El.setAttribute('size', String(__v)); else __GlobeIcon_s8El.removeAttribute('size') }
+      }
+      __l[6] = __x }
+      { const __x = className
+      if (!(7 in __l) || !Object.is(__l[7], __x)) {
+        { const __v = __x; if (__v != null) __GlobeIcon_s8El.setAttribute('class', String(__v)); else __GlobeIcon_s8El.removeAttribute('class') }
+      }
+      __l[7] = __x }
     }
     const [__LogOutIcon_s7El] = $c(__scope, 's7')
     if (__LogOutIcon_s7El) {
-      { const __v = size; if (__v != null) __LogOutIcon_s7El.setAttribute('size', String(__v)); else __LogOutIcon_s7El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __LogOutIcon_s7El.setAttribute('class', String(__v)); else __LogOutIcon_s7El.removeAttribute('class') }
+      { const __x = size
+      if (!(8 in __l) || !Object.is(__l[8], __x)) {
+        { const __v = __x; if (__v != null) __LogOutIcon_s7El.setAttribute('size', String(__v)); else __LogOutIcon_s7El.removeAttribute('size') }
+      }
+      __l[8] = __x }
+      { const __x = className
+      if (!(9 in __l) || !Object.is(__l[9], __x)) {
+        { const __v = __x; if (__v != null) __LogOutIcon_s7El.setAttribute('class', String(__v)); else __LogOutIcon_s7El.removeAttribute('class') }
+      }
+      __l[9] = __x }
     }
     const [__CircleHelpIcon_s6El] = $c(__scope, 's6')
     if (__CircleHelpIcon_s6El) {
-      { const __v = size; if (__v != null) __CircleHelpIcon_s6El.setAttribute('size', String(__v)); else __CircleHelpIcon_s6El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __CircleHelpIcon_s6El.setAttribute('class', String(__v)); else __CircleHelpIcon_s6El.removeAttribute('class') }
+      { const __x = size
+      if (!(10 in __l) || !Object.is(__l[10], __x)) {
+        { const __v = __x; if (__v != null) __CircleHelpIcon_s6El.setAttribute('size', String(__v)); else __CircleHelpIcon_s6El.removeAttribute('size') }
+      }
+      __l[10] = __x }
+      { const __x = className
+      if (!(11 in __l) || !Object.is(__l[11], __x)) {
+        { const __v = __x; if (__v != null) __CircleHelpIcon_s6El.setAttribute('class', String(__v)); else __CircleHelpIcon_s6El.removeAttribute('class') }
+      }
+      __l[11] = __x }
     }
     const [__CalendarIcon_s5El] = $c(__scope, 's5')
     if (__CalendarIcon_s5El) {
-      { const __v = size; if (__v != null) __CalendarIcon_s5El.setAttribute('size', String(__v)); else __CalendarIcon_s5El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __CalendarIcon_s5El.setAttribute('class', String(__v)); else __CalendarIcon_s5El.removeAttribute('class') }
+      { const __x = size
+      if (!(12 in __l) || !Object.is(__l[12], __x)) {
+        { const __v = __x; if (__v != null) __CalendarIcon_s5El.setAttribute('size', String(__v)); else __CalendarIcon_s5El.removeAttribute('size') }
+      }
+      __l[12] = __x }
+      { const __x = className
+      if (!(13 in __l) || !Object.is(__l[13], __x)) {
+        { const __v = __x; if (__v != null) __CalendarIcon_s5El.setAttribute('class', String(__v)); else __CalendarIcon_s5El.removeAttribute('class') }
+      }
+      __l[13] = __x }
     }
     const [__GripVerticalIcon_s4El] = $c(__scope, 's4')
     if (__GripVerticalIcon_s4El) {
-      { const __v = size; if (__v != null) __GripVerticalIcon_s4El.setAttribute('size', String(__v)); else __GripVerticalIcon_s4El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __GripVerticalIcon_s4El.setAttribute('class', String(__v)); else __GripVerticalIcon_s4El.removeAttribute('class') }
+      { const __x = size
+      if (!(14 in __l) || !Object.is(__l[14], __x)) {
+        { const __v = __x; if (__v != null) __GripVerticalIcon_s4El.setAttribute('size', String(__v)); else __GripVerticalIcon_s4El.removeAttribute('size') }
+      }
+      __l[14] = __x }
+      { const __x = className
+      if (!(15 in __l) || !Object.is(__l[15], __x)) {
+        { const __v = __x; if (__v != null) __GripVerticalIcon_s4El.setAttribute('class', String(__v)); else __GripVerticalIcon_s4El.removeAttribute('class') }
+      }
+      __l[15] = __x }
     }
     const [__LoaderCircleIcon_s3El] = $c(__scope, 's3')
     if (__LoaderCircleIcon_s3El) {
-      { const __v = size; if (__v != null) __LoaderCircleIcon_s3El.setAttribute('size', String(__v)); else __LoaderCircleIcon_s3El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __LoaderCircleIcon_s3El.setAttribute('class', String(__v)); else __LoaderCircleIcon_s3El.removeAttribute('class') }
+      { const __x = size
+      if (!(16 in __l) || !Object.is(__l[16], __x)) {
+        { const __v = __x; if (__v != null) __LoaderCircleIcon_s3El.setAttribute('size', String(__v)); else __LoaderCircleIcon_s3El.removeAttribute('size') }
+      }
+      __l[16] = __x }
+      { const __x = className
+      if (!(17 in __l) || !Object.is(__l[17], __x)) {
+        { const __v = __x; if (__v != null) __LoaderCircleIcon_s3El.setAttribute('class', String(__v)); else __LoaderCircleIcon_s3El.removeAttribute('class') }
+      }
+      __l[17] = __x }
     }
     const [__PanelLeftIcon_s2El] = $c(__scope, 's2')
     if (__PanelLeftIcon_s2El) {
-      { const __v = size; if (__v != null) __PanelLeftIcon_s2El.setAttribute('size', String(__v)); else __PanelLeftIcon_s2El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __PanelLeftIcon_s2El.setAttribute('class', String(__v)); else __PanelLeftIcon_s2El.removeAttribute('class') }
+      { const __x = size
+      if (!(18 in __l) || !Object.is(__l[18], __x)) {
+        { const __v = __x; if (__v != null) __PanelLeftIcon_s2El.setAttribute('size', String(__v)); else __PanelLeftIcon_s2El.removeAttribute('size') }
+      }
+      __l[18] = __x }
+      { const __x = className
+      if (!(19 in __l) || !Object.is(__l[19], __x)) {
+        { const __v = __x; if (__v != null) __PanelLeftIcon_s2El.setAttribute('class', String(__v)); else __PanelLeftIcon_s2El.removeAttribute('class') }
+      }
+      __l[19] = __x }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('GitHubIcon', _s11, forwardProps(_p, { get size() { return size }, get className() { return className } }, ["size","className"]))
@@ -2725,17 +2993,42 @@ export function initCheckbox(__scope, _p = {}) {
   const [_s2, _s0] = $(__scope, 's2', 's0')
   const [_s1] = $c(__scope, 's1')
 
+  { const __l = []
   createEffect(() => {
     if (_s2) {
-      { const __v = `${isChecked() ? 'checked' : 'unchecked'}`; if (__v != null) _s2.setAttribute('data-state', String(__v)); else _s2.removeAttribute('data-state') }
-      { const __v = _p.id; if (__v != null) _s2.setAttribute('id', String(__v)); else _s2.removeAttribute('id') }
-      { const __v = isChecked(); if (__v != null) _s2.setAttribute('aria-checked', String(__v)); else _s2.removeAttribute('aria-checked') }
-      if (_p.error) _s2.setAttribute('aria-invalid', 'true')
-      else _s2.removeAttribute('aria-invalid')
-      _s2.disabled = !!(_p.disabled ?? false)
-      { const __v = classes(); if (__v != null) _s2.setAttribute('class', String(__v)); else _s2.removeAttribute('class') }
+      { const __x = `${isChecked() ? 'checked' : 'unchecked'}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s2.setAttribute('data-state', String(__v)); else _s2.removeAttribute('data-state') }
+      }
+      __l[0] = __x }
+      { const __x = _p.id
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s2.setAttribute('id', String(__v)); else _s2.removeAttribute('id') }
+      }
+      __l[1] = __x }
+      { const __x = isChecked()
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        { const __v = __x; if (__v != null) _s2.setAttribute('aria-checked', String(__v)); else _s2.removeAttribute('aria-checked') }
+      }
+      __l[2] = __x }
+      { const __x = _p.error
+      if (!(3 in __l) || !Object.is(__l[3], __x)) {
+        if (__x) _s2.setAttribute('aria-invalid', 'true')
+        else _s2.removeAttribute('aria-invalid')
+      }
+      __l[3] = __x }
+      { const __x = _p.disabled ?? false
+      if (!(4 in __l) || !Object.is(__l[4], __x)) {
+        _s2.disabled = !!(__x)
+      }
+      __l[4] = __x }
+      { const __x = classes()
+      if (!(5 in __l) || !Object.is(__l[5], __x)) {
+        { const __v = __x; if (__v != null) _s2.setAttribute('class', String(__v)); else _s2.removeAttribute('class') }
+      }
+      __l[5] = __x }
     }
-  })
+  }) }
 
   insert(__scope, 's0', () => isChecked(), {
     template: () => { const __slots = []; return { html: `<!--bf-cond-start:s0-->${renderChild('CheckIcon', {"data-slot": "checkbox-indicator", className: "size-3.5 text-current"}, undefined, 's1')}<!--bf-cond-end:s0-->`, slots: __slots } },

--- a/packages/adapter-tests/fixtures/__snapshots__/combobox.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/combobox.client.js
@@ -39,11 +39,16 @@ export function initCheckIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -144,11 +149,16 @@ export function initChevronDownIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -249,11 +259,16 @@ export function initChevronUpIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -354,11 +369,16 @@ export function initChevronLeftIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -459,11 +479,16 @@ export function initChevronRightIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -564,11 +589,16 @@ export function initXIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -669,11 +699,16 @@ export function initPlusIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -774,11 +809,16 @@ export function initMinusIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -879,11 +919,16 @@ export function initSunIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -984,11 +1029,16 @@ export function initMoonIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1089,11 +1139,16 @@ export function initMonitorIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1194,11 +1249,16 @@ export function initCopyIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1299,11 +1359,16 @@ export function initClipboardIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1404,11 +1469,16 @@ export function initClipboardCheckIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1509,11 +1579,16 @@ export function initMenuIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1614,11 +1689,16 @@ export function initArrowLeftIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1719,11 +1799,16 @@ export function initArrowRightIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1824,11 +1909,16 @@ export function initArrowUpDownIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1906,11 +1996,16 @@ export function initEllipsisIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1944,11 +2039,16 @@ export function initGitHubIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","class","aria-hidden"])
 
@@ -1982,11 +2082,16 @@ export function initSettingsIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2020,11 +2125,16 @@ export function initGlobeIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2058,11 +2168,16 @@ export function initLogOutIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2096,11 +2211,16 @@ export function initCircleHelpIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2134,11 +2254,16 @@ export function initSearchIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2172,11 +2297,16 @@ export function initCircleCheckIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2210,11 +2340,16 @@ export function initCircleXIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2248,11 +2383,16 @@ export function initTriangleAlertIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2286,11 +2426,16 @@ export function initInfoIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2324,11 +2469,16 @@ export function initCalendarIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2362,11 +2512,16 @@ export function initGripVerticalIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2423,11 +2578,16 @@ export function initLoaderCircleIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2505,11 +2665,16 @@ export function initPanelLeftIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2576,77 +2741,180 @@ export function initIcon(__scope, _p = {}) {
   const [_s1, _s0] = $(__scope, 's1', 's0')
   const [_s11, _s10, _s9, _s8, _s7, _s6, _s5, _s4, _s3, _s2] = $c(__scope, 's11', 's10', 's9', 's8', 's7', 's6', 's5', 's4', 's3', 's2')
 
+  { const __l = []
   createEffect(() => {
     if (_s1) {
-      { const __v = sizeMap[(_p.size ?? 'md')]; if (__v != null) _s1.setAttribute('width', String(__v)); else _s1.removeAttribute('width') }
-      { const __v = sizeMap[(_p.size ?? 'md')]; if (__v != null) _s1.setAttribute('height', String(__v)); else _s1.removeAttribute('height') }
-      { const __v = (buttLinecapIcons).includes(_p.name) ? 'butt' : 'round'; if (__v != null) _s1.setAttribute('stroke-linecap', String(__v)); else _s1.removeAttribute('stroke-linecap') }
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s1.setAttribute('class', String(__v)); else _s1.removeAttribute('class') }
+      { const __x = sizeMap[(_p.size ?? 'md')]
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('width', String(__v)); else _s1.removeAttribute('width') }
+      }
+      __l[0] = __x }
+      { const __x = sizeMap[(_p.size ?? 'md')]
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('height', String(__v)); else _s1.removeAttribute('height') }
+      }
+      __l[1] = __x }
+      { const __x = (buttLinecapIcons).includes(_p.name) ? 'butt' : 'round'
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('stroke-linecap', String(__v)); else _s1.removeAttribute('stroke-linecap') }
+      }
+      __l[2] = __x }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(3 in __l) || !Object.is(__l[3], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('class', String(__v)); else _s1.removeAttribute('class') }
+      }
+      __l[3] = __x }
     }
-  })
+  }) }
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `${({"check": "M20 6 9 17l-5-5", "chevron-down": "m6 9 6 6 6-6", "chevron-up": "m18 15-6-6-6 6", "chevron-left": "m15 18-6-6 6-6", "chevron-right": "m9 18 6-6-6-6", "x": "M18 6 6 18M6 6l12 12", "plus": "M5 12h14M12 5v14", "minus": "M5 12h14", "sun": "M12 16a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41", "moon": "M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z", "monitor": "M20 3H4a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2zM8 21h8M12 17v4", "copy": "M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2M8 8h12a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V10a2 2 0 0 1 2-2z", "clipboard": "M9 2h6a1 1 0 0 1 1 1v1H8V3a1 1 0 0 1 1-1zM16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2", "clipboard-check": "M9 2h6a1 1 0 0 1 1 1v1H8V3a1 1 0 0 1 1-1zM16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2M9 14l2 2 4-4", "menu": "M4 6h16M4 12h16M4 18h16", "arrow-left": "m12 19-7-7 7-7M19 12H5", "arrow-right": "M5 12h14m-7-7 7 7-7 7", "ellipsis": "M5 12h.01M12 12h.01M19 12h.01", "arrow-up-down": "m21 16-4 4-4-4M17 20V4M3 8l4-4 4 4M7 4v16", "panel-left": "M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4M3 3h12v18H3zM9 3v18", "loader-circle": "M21 12a9 9 0 1 1-6.219-8.56"})[_p.name]}`; if (__v != null) _s0.setAttribute('d', String(__v)); else _s0.removeAttribute('d') }
+      { const __x = `${({"check": "M20 6 9 17l-5-5", "chevron-down": "m6 9 6 6 6-6", "chevron-up": "m18 15-6-6-6 6", "chevron-left": "m15 18-6-6 6-6", "chevron-right": "m9 18 6-6-6-6", "x": "M18 6 6 18M6 6l12 12", "plus": "M5 12h14M12 5v14", "minus": "M5 12h14", "sun": "M12 16a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41", "moon": "M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z", "monitor": "M20 3H4a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2zM8 21h8M12 17v4", "copy": "M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2M8 8h12a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V10a2 2 0 0 1 2-2z", "clipboard": "M9 2h6a1 1 0 0 1 1 1v1H8V3a1 1 0 0 1 1-1zM16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2", "clipboard-check": "M9 2h6a1 1 0 0 1 1 1v1H8V3a1 1 0 0 1 1-1zM16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2M9 14l2 2 4-4", "menu": "M4 6h16M4 12h16M4 18h16", "arrow-left": "m12 19-7-7 7-7M19 12H5", "arrow-right": "M5 12h14m-7-7 7 7-7 7", "ellipsis": "M5 12h.01M12 12h.01M19 12h.01", "arrow-up-down": "m21 16-4 4-4-4M17 20V4M3 8l4-4 4 4M7 4v16", "panel-left": "M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4M3 3h12v18H3zM9 3v18", "loader-circle": "M21 12a9 9 0 1 1-6.219-8.56"})[_p.name]}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('d', String(__v)); else _s0.removeAttribute('d') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s1) applyRestAttrs(_s1, _p, ["name","size","className","xmlns","width","height","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     const [__GitHubIcon_s11El] = $c(__scope, 's11')
     if (__GitHubIcon_s11El) {
-      { const __v = size; if (__v != null) __GitHubIcon_s11El.setAttribute('size', String(__v)); else __GitHubIcon_s11El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __GitHubIcon_s11El.setAttribute('class', String(__v)); else __GitHubIcon_s11El.removeAttribute('class') }
+      { const __x = size
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) __GitHubIcon_s11El.setAttribute('size', String(__v)); else __GitHubIcon_s11El.removeAttribute('size') }
+      }
+      __l[0] = __x }
+      { const __x = className
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) __GitHubIcon_s11El.setAttribute('class', String(__v)); else __GitHubIcon_s11El.removeAttribute('class') }
+      }
+      __l[1] = __x }
     }
     const [__SearchIcon_s10El] = $c(__scope, 's10')
     if (__SearchIcon_s10El) {
-      { const __v = size; if (__v != null) __SearchIcon_s10El.setAttribute('size', String(__v)); else __SearchIcon_s10El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __SearchIcon_s10El.setAttribute('class', String(__v)); else __SearchIcon_s10El.removeAttribute('class') }
+      { const __x = size
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        { const __v = __x; if (__v != null) __SearchIcon_s10El.setAttribute('size', String(__v)); else __SearchIcon_s10El.removeAttribute('size') }
+      }
+      __l[2] = __x }
+      { const __x = className
+      if (!(3 in __l) || !Object.is(__l[3], __x)) {
+        { const __v = __x; if (__v != null) __SearchIcon_s10El.setAttribute('class', String(__v)); else __SearchIcon_s10El.removeAttribute('class') }
+      }
+      __l[3] = __x }
     }
     const [__SettingsIcon_s9El] = $c(__scope, 's9')
     if (__SettingsIcon_s9El) {
-      { const __v = size; if (__v != null) __SettingsIcon_s9El.setAttribute('size', String(__v)); else __SettingsIcon_s9El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __SettingsIcon_s9El.setAttribute('class', String(__v)); else __SettingsIcon_s9El.removeAttribute('class') }
+      { const __x = size
+      if (!(4 in __l) || !Object.is(__l[4], __x)) {
+        { const __v = __x; if (__v != null) __SettingsIcon_s9El.setAttribute('size', String(__v)); else __SettingsIcon_s9El.removeAttribute('size') }
+      }
+      __l[4] = __x }
+      { const __x = className
+      if (!(5 in __l) || !Object.is(__l[5], __x)) {
+        { const __v = __x; if (__v != null) __SettingsIcon_s9El.setAttribute('class', String(__v)); else __SettingsIcon_s9El.removeAttribute('class') }
+      }
+      __l[5] = __x }
     }
     const [__GlobeIcon_s8El] = $c(__scope, 's8')
     if (__GlobeIcon_s8El) {
-      { const __v = size; if (__v != null) __GlobeIcon_s8El.setAttribute('size', String(__v)); else __GlobeIcon_s8El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __GlobeIcon_s8El.setAttribute('class', String(__v)); else __GlobeIcon_s8El.removeAttribute('class') }
+      { const __x = size
+      if (!(6 in __l) || !Object.is(__l[6], __x)) {
+        { const __v = __x; if (__v != null) __GlobeIcon_s8El.setAttribute('size', String(__v)); else __GlobeIcon_s8El.removeAttribute('size') }
+      }
+      __l[6] = __x }
+      { const __x = className
+      if (!(7 in __l) || !Object.is(__l[7], __x)) {
+        { const __v = __x; if (__v != null) __GlobeIcon_s8El.setAttribute('class', String(__v)); else __GlobeIcon_s8El.removeAttribute('class') }
+      }
+      __l[7] = __x }
     }
     const [__LogOutIcon_s7El] = $c(__scope, 's7')
     if (__LogOutIcon_s7El) {
-      { const __v = size; if (__v != null) __LogOutIcon_s7El.setAttribute('size', String(__v)); else __LogOutIcon_s7El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __LogOutIcon_s7El.setAttribute('class', String(__v)); else __LogOutIcon_s7El.removeAttribute('class') }
+      { const __x = size
+      if (!(8 in __l) || !Object.is(__l[8], __x)) {
+        { const __v = __x; if (__v != null) __LogOutIcon_s7El.setAttribute('size', String(__v)); else __LogOutIcon_s7El.removeAttribute('size') }
+      }
+      __l[8] = __x }
+      { const __x = className
+      if (!(9 in __l) || !Object.is(__l[9], __x)) {
+        { const __v = __x; if (__v != null) __LogOutIcon_s7El.setAttribute('class', String(__v)); else __LogOutIcon_s7El.removeAttribute('class') }
+      }
+      __l[9] = __x }
     }
     const [__CircleHelpIcon_s6El] = $c(__scope, 's6')
     if (__CircleHelpIcon_s6El) {
-      { const __v = size; if (__v != null) __CircleHelpIcon_s6El.setAttribute('size', String(__v)); else __CircleHelpIcon_s6El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __CircleHelpIcon_s6El.setAttribute('class', String(__v)); else __CircleHelpIcon_s6El.removeAttribute('class') }
+      { const __x = size
+      if (!(10 in __l) || !Object.is(__l[10], __x)) {
+        { const __v = __x; if (__v != null) __CircleHelpIcon_s6El.setAttribute('size', String(__v)); else __CircleHelpIcon_s6El.removeAttribute('size') }
+      }
+      __l[10] = __x }
+      { const __x = className
+      if (!(11 in __l) || !Object.is(__l[11], __x)) {
+        { const __v = __x; if (__v != null) __CircleHelpIcon_s6El.setAttribute('class', String(__v)); else __CircleHelpIcon_s6El.removeAttribute('class') }
+      }
+      __l[11] = __x }
     }
     const [__CalendarIcon_s5El] = $c(__scope, 's5')
     if (__CalendarIcon_s5El) {
-      { const __v = size; if (__v != null) __CalendarIcon_s5El.setAttribute('size', String(__v)); else __CalendarIcon_s5El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __CalendarIcon_s5El.setAttribute('class', String(__v)); else __CalendarIcon_s5El.removeAttribute('class') }
+      { const __x = size
+      if (!(12 in __l) || !Object.is(__l[12], __x)) {
+        { const __v = __x; if (__v != null) __CalendarIcon_s5El.setAttribute('size', String(__v)); else __CalendarIcon_s5El.removeAttribute('size') }
+      }
+      __l[12] = __x }
+      { const __x = className
+      if (!(13 in __l) || !Object.is(__l[13], __x)) {
+        { const __v = __x; if (__v != null) __CalendarIcon_s5El.setAttribute('class', String(__v)); else __CalendarIcon_s5El.removeAttribute('class') }
+      }
+      __l[13] = __x }
     }
     const [__GripVerticalIcon_s4El] = $c(__scope, 's4')
     if (__GripVerticalIcon_s4El) {
-      { const __v = size; if (__v != null) __GripVerticalIcon_s4El.setAttribute('size', String(__v)); else __GripVerticalIcon_s4El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __GripVerticalIcon_s4El.setAttribute('class', String(__v)); else __GripVerticalIcon_s4El.removeAttribute('class') }
+      { const __x = size
+      if (!(14 in __l) || !Object.is(__l[14], __x)) {
+        { const __v = __x; if (__v != null) __GripVerticalIcon_s4El.setAttribute('size', String(__v)); else __GripVerticalIcon_s4El.removeAttribute('size') }
+      }
+      __l[14] = __x }
+      { const __x = className
+      if (!(15 in __l) || !Object.is(__l[15], __x)) {
+        { const __v = __x; if (__v != null) __GripVerticalIcon_s4El.setAttribute('class', String(__v)); else __GripVerticalIcon_s4El.removeAttribute('class') }
+      }
+      __l[15] = __x }
     }
     const [__LoaderCircleIcon_s3El] = $c(__scope, 's3')
     if (__LoaderCircleIcon_s3El) {
-      { const __v = size; if (__v != null) __LoaderCircleIcon_s3El.setAttribute('size', String(__v)); else __LoaderCircleIcon_s3El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __LoaderCircleIcon_s3El.setAttribute('class', String(__v)); else __LoaderCircleIcon_s3El.removeAttribute('class') }
+      { const __x = size
+      if (!(16 in __l) || !Object.is(__l[16], __x)) {
+        { const __v = __x; if (__v != null) __LoaderCircleIcon_s3El.setAttribute('size', String(__v)); else __LoaderCircleIcon_s3El.removeAttribute('size') }
+      }
+      __l[16] = __x }
+      { const __x = className
+      if (!(17 in __l) || !Object.is(__l[17], __x)) {
+        { const __v = __x; if (__v != null) __LoaderCircleIcon_s3El.setAttribute('class', String(__v)); else __LoaderCircleIcon_s3El.removeAttribute('class') }
+      }
+      __l[17] = __x }
     }
     const [__PanelLeftIcon_s2El] = $c(__scope, 's2')
     if (__PanelLeftIcon_s2El) {
-      { const __v = size; if (__v != null) __PanelLeftIcon_s2El.setAttribute('size', String(__v)); else __PanelLeftIcon_s2El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __PanelLeftIcon_s2El.setAttribute('class', String(__v)); else __PanelLeftIcon_s2El.removeAttribute('class') }
+      { const __x = size
+      if (!(18 in __l) || !Object.is(__l[18], __x)) {
+        { const __v = __x; if (__v != null) __PanelLeftIcon_s2El.setAttribute('size', String(__v)); else __PanelLeftIcon_s2El.removeAttribute('size') }
+      }
+      __l[18] = __x }
+      { const __x = className
+      if (!(19 in __l) || !Object.is(__l[19], __x)) {
+        { const __v = __x; if (__v != null) __PanelLeftIcon_s2El.setAttribute('class', String(__v)); else __PanelLeftIcon_s2El.removeAttribute('class') }
+      }
+      __l[19] = __x }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('GitHubIcon', _s11, forwardProps(_p, { get size() { return size }, get className() { return className } }, ["size","className"]))
@@ -2760,12 +3028,21 @@ export function initComboboxTrigger(__scope, _p = {}) {
   const [_s1] = $(__scope, 's1')
   const [_s0] = $c(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s1) {
-      { const __v = _p.id; if (__v != null) _s1.setAttribute('id', String(__v)); else _s1.removeAttribute('id') }
-      { const __v = `flex h-9 w-full items-center justify-between rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs transition-[color,box-shadow] outline-none focus:border-ring focus:ring-ring/50 focus:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[placeholder]:text-muted-foreground ${_p.className ?? ''}`; if (__v != null) _s1.setAttribute('class', String(__v)); else _s1.removeAttribute('class') }
+      { const __x = _p.id
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('id', String(__v)); else _s1.removeAttribute('id') }
+      }
+      __l[0] = __x }
+      { const __x = `flex h-9 w-full items-center justify-between rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs transition-[color,box-shadow] outline-none focus:border-ring focus:ring-ring/50 focus:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[placeholder]:text-muted-foreground ${_p.className ?? ''}`
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('class', String(__v)); else _s1.removeAttribute('class') }
+      }
+      __l[1] = __x }
     }
-  })
+  }) }
 
   if (_s1) (handleMount)(_s1)
 
@@ -2813,11 +3090,16 @@ export function initComboboxValue(__scope, _p = {}) {
     __bfw_s0('s0', escapeTextOrNode(__val))
   })
 
+  { const __l = []
   createEffect(() => {
     if (_s1) {
-      { const __v = _p.id; if (__v != null) _s1.setAttribute('id', String(__v)); else _s1.removeAttribute('id') }
+      { const __x = _p.id
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('id', String(__v)); else _s1.removeAttribute('id') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s1) (handleMount)(_s1)
 }
@@ -2966,12 +3248,21 @@ export function initComboboxContent(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = _p.id; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
-      { const __v = `${contentBaseClasses} ${contentClosedClasses} ${_p.className ?? ''}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = _p.id
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
+      }
+      __l[0] = __x }
+      { const __x = `${contentBaseClasses} ${contentClosedClasses} ${_p.className ?? ''}`
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[1] = __x }
     }
-  })
+  }) }
 
   if (_s0) (handleMount)(_s0)
 }
@@ -3006,14 +3297,31 @@ export function initComboboxInput(__scope, _p = {}) {
   const [_s2, _s1] = $(__scope, 's2', 's1')
   const [_s0] = $c(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s1) {
-      { const __v = _p.id; if (__v != null) _s1.setAttribute('id', String(__v)); else _s1.removeAttribute('id') }
-      { const __v = _p.placeholder; if (__v != null) _s1.setAttribute('placeholder', String(__v)); else _s1.removeAttribute('placeholder') }
-      _s1.disabled = !!(_p.disabled ?? false)
-      { const __v = `${inputClasses} ${_p.className ?? ''}`; if (__v != null) _s1.setAttribute('class', String(__v)); else _s1.removeAttribute('class') }
+      { const __x = _p.id
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('id', String(__v)); else _s1.removeAttribute('id') }
+      }
+      __l[0] = __x }
+      { const __x = _p.placeholder
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('placeholder', String(__v)); else _s1.removeAttribute('placeholder') }
+      }
+      __l[1] = __x }
+      { const __x = _p.disabled ?? false
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        _s1.disabled = !!(__x)
+      }
+      __l[2] = __x }
+      { const __x = `${inputClasses} ${_p.className ?? ''}`
+      if (!(3 in __l) || !Object.is(__l[3], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('class', String(__v)); else _s1.removeAttribute('class') }
+      }
+      __l[3] = __x }
     }
-  })
+  }) }
 
   if (_s2) (handleMount)(_s2)
 
@@ -3047,12 +3355,21 @@ export function initComboboxEmpty(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = _p.id; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
-      { const __v = `${emptyClasses} ${_p.className ?? ''}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = _p.id
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
+      }
+      __l[0] = __x }
+      { const __x = `${emptyClasses} ${_p.className ?? ''}`
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[1] = __x }
     }
-  })
+  }) }
 
   if (_s0) (handleMount)(_s0)
 }
@@ -3124,15 +3441,32 @@ export function initComboboxItem(__scope, _p = {}) {
   const [_s1] = $(__scope, 's1')
   const [_s0] = $c(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s1) {
-      { const __v = _p.value; if (__v != null) _s1.setAttribute('data-value', String(__v)); else _s1.removeAttribute('data-value') }
-      { const __v = _p.id; if (__v != null) _s1.setAttribute('id', String(__v)); else _s1.removeAttribute('id') }
-      if (isDisabled()) _s1.setAttribute('aria-disabled', 'true')
-      else _s1.removeAttribute('aria-disabled')
-      { const __v = `${itemBaseClasses} ${stateClasses()} ${_p.className ?? ''}`; if (__v != null) _s1.setAttribute('class', String(__v)); else _s1.removeAttribute('class') }
+      { const __x = _p.value
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('data-value', String(__v)); else _s1.removeAttribute('data-value') }
+      }
+      __l[0] = __x }
+      { const __x = _p.id
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('id', String(__v)); else _s1.removeAttribute('id') }
+      }
+      __l[1] = __x }
+      { const __x = isDisabled()
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        if (__x) _s1.setAttribute('aria-disabled', 'true')
+        else _s1.removeAttribute('aria-disabled')
+      }
+      __l[2] = __x }
+      { const __x = `${itemBaseClasses} ${stateClasses()} ${_p.className ?? ''}`
+      if (!(3 in __l) || !Object.is(__l[3], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('class', String(__v)); else _s1.removeAttribute('class') }
+      }
+      __l[3] = __x }
     }
-  })
+  }) }
 
   if (_s1) (handleMount)(_s1)
 
@@ -3164,12 +3498,21 @@ export function initComboboxGroup(__scope, _p = {}) {
 
   const [_s0, _s3] = $(__scope, 's0', 's3')
 
+  { const __l = []
   createEffect(() => {
     if (_s3) {
-      { const __v = _p.id; if (__v != null) _s3.setAttribute('id', String(__v)); else _s3.removeAttribute('id') }
-      { const __v = `${groupClasses} ${_p.className ?? ''}`; if (__v != null) _s3.setAttribute('class', String(__v)); else _s3.removeAttribute('class') }
+      { const __x = _p.id
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s3.setAttribute('id', String(__v)); else _s3.removeAttribute('id') }
+      }
+      __l[0] = __x }
+      { const __x = `${groupClasses} ${_p.className ?? ''}`
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s3.setAttribute('class', String(__v)); else _s3.removeAttribute('class') }
+      }
+      __l[1] = __x }
     }
-  })
+  }) }
 
   insert(__scope, 's0', () => _p.heading, {
     template: () => { const __slots = []; return { html: `<div bf-c="s0" data-slot="combobox-group-heading" aria-hidden="true" bf="s2"><!--bf:s1-->${__bfSlot(_p.heading, __slots)}<!--/--></div>`, slots: __slots } },
@@ -3198,11 +3541,16 @@ export function initComboboxSeparator(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `${separatorClasses} ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `${separatorClasses} ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["className","data-slot","role","class"])
 
@@ -3233,12 +3581,13 @@ export function initComboboxBasicDemo(__scope, _p = {}) {
   })
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     const [__Combobox_s10El] = $c(__scope, 's10')
     if (__Combobox_s10El) {
       if ('value' in __Combobox_s10El) { const __val = String(value()); if (__Combobox_s10El.value !== __val) __Combobox_s10El.value = __val }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('Combobox', _s10, { get value() { return value() }, onValueChange: setValue })
@@ -3289,6 +3638,7 @@ export function initComboboxFormDemo(__scope, _p = {}) {
   })
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     const [__Combobox_s10El] = $c(__scope, 's10')
     if (__Combobox_s10El) {
@@ -3298,7 +3648,7 @@ export function initComboboxFormDemo(__scope, _p = {}) {
     if (__Combobox_s21El) {
       if ('value' in __Combobox_s21El) { const __val = String(framework()); if (__Combobox_s21El.value !== __val) __Combobox_s21El.value = __val }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('Combobox', _s10, { get value() { return language() }, onValueChange: setLanguage })
@@ -3355,12 +3705,13 @@ export function initComboboxGroupedDemo(__scope, _p = {}) {
   })
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     const [__Combobox_s20El] = $c(__scope, 's20')
     if (__Combobox_s20El) {
       if ('value' in __Combobox_s20El) { const __val = String(timezone()); if (__Combobox_s20El.value !== __val) __Combobox_s20El.value = __val }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('Combobox', _s20, { get value() { return timezone() }, onValueChange: setTimezone })

--- a/packages/adapter-tests/fixtures/__snapshots__/command.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/command.client.js
@@ -39,11 +39,16 @@ export function initCheckIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -144,11 +149,16 @@ export function initChevronDownIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -249,11 +259,16 @@ export function initChevronUpIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -354,11 +369,16 @@ export function initChevronLeftIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -459,11 +479,16 @@ export function initChevronRightIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -564,11 +589,16 @@ export function initXIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -669,11 +699,16 @@ export function initPlusIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -774,11 +809,16 @@ export function initMinusIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -879,11 +919,16 @@ export function initSunIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -984,11 +1029,16 @@ export function initMoonIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1089,11 +1139,16 @@ export function initMonitorIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1194,11 +1249,16 @@ export function initCopyIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1299,11 +1359,16 @@ export function initClipboardIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1404,11 +1469,16 @@ export function initClipboardCheckIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1509,11 +1579,16 @@ export function initMenuIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1614,11 +1689,16 @@ export function initArrowLeftIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1719,11 +1799,16 @@ export function initArrowRightIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1824,11 +1909,16 @@ export function initArrowUpDownIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1906,11 +1996,16 @@ export function initEllipsisIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1944,11 +2039,16 @@ export function initGitHubIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","class","aria-hidden"])
 
@@ -1982,11 +2082,16 @@ export function initSettingsIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2020,11 +2125,16 @@ export function initGlobeIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2058,11 +2168,16 @@ export function initLogOutIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2096,11 +2211,16 @@ export function initCircleHelpIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2134,11 +2254,16 @@ export function initSearchIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2172,11 +2297,16 @@ export function initCircleCheckIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2210,11 +2340,16 @@ export function initCircleXIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2248,11 +2383,16 @@ export function initTriangleAlertIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2286,11 +2426,16 @@ export function initInfoIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2324,11 +2469,16 @@ export function initCalendarIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2362,11 +2512,16 @@ export function initGripVerticalIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2423,11 +2578,16 @@ export function initLoaderCircleIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2505,11 +2665,16 @@ export function initPanelLeftIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2576,77 +2741,180 @@ export function initIcon(__scope, _p = {}) {
   const [_s1, _s0] = $(__scope, 's1', 's0')
   const [_s11, _s10, _s9, _s8, _s7, _s6, _s5, _s4, _s3, _s2] = $c(__scope, 's11', 's10', 's9', 's8', 's7', 's6', 's5', 's4', 's3', 's2')
 
+  { const __l = []
   createEffect(() => {
     if (_s1) {
-      { const __v = sizeMap[(_p.size ?? 'md')]; if (__v != null) _s1.setAttribute('width', String(__v)); else _s1.removeAttribute('width') }
-      { const __v = sizeMap[(_p.size ?? 'md')]; if (__v != null) _s1.setAttribute('height', String(__v)); else _s1.removeAttribute('height') }
-      { const __v = (buttLinecapIcons).includes(_p.name) ? 'butt' : 'round'; if (__v != null) _s1.setAttribute('stroke-linecap', String(__v)); else _s1.removeAttribute('stroke-linecap') }
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s1.setAttribute('class', String(__v)); else _s1.removeAttribute('class') }
+      { const __x = sizeMap[(_p.size ?? 'md')]
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('width', String(__v)); else _s1.removeAttribute('width') }
+      }
+      __l[0] = __x }
+      { const __x = sizeMap[(_p.size ?? 'md')]
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('height', String(__v)); else _s1.removeAttribute('height') }
+      }
+      __l[1] = __x }
+      { const __x = (buttLinecapIcons).includes(_p.name) ? 'butt' : 'round'
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('stroke-linecap', String(__v)); else _s1.removeAttribute('stroke-linecap') }
+      }
+      __l[2] = __x }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(3 in __l) || !Object.is(__l[3], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('class', String(__v)); else _s1.removeAttribute('class') }
+      }
+      __l[3] = __x }
     }
-  })
+  }) }
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `${({"check": "M20 6 9 17l-5-5", "chevron-down": "m6 9 6 6 6-6", "chevron-up": "m18 15-6-6-6 6", "chevron-left": "m15 18-6-6 6-6", "chevron-right": "m9 18 6-6-6-6", "x": "M18 6 6 18M6 6l12 12", "plus": "M5 12h14M12 5v14", "minus": "M5 12h14", "sun": "M12 16a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41", "moon": "M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z", "monitor": "M20 3H4a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2zM8 21h8M12 17v4", "copy": "M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2M8 8h12a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V10a2 2 0 0 1 2-2z", "clipboard": "M9 2h6a1 1 0 0 1 1 1v1H8V3a1 1 0 0 1 1-1zM16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2", "clipboard-check": "M9 2h6a1 1 0 0 1 1 1v1H8V3a1 1 0 0 1 1-1zM16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2M9 14l2 2 4-4", "menu": "M4 6h16M4 12h16M4 18h16", "arrow-left": "m12 19-7-7 7-7M19 12H5", "arrow-right": "M5 12h14m-7-7 7 7-7 7", "ellipsis": "M5 12h.01M12 12h.01M19 12h.01", "arrow-up-down": "m21 16-4 4-4-4M17 20V4M3 8l4-4 4 4M7 4v16", "panel-left": "M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4M3 3h12v18H3zM9 3v18", "loader-circle": "M21 12a9 9 0 1 1-6.219-8.56"})[_p.name]}`; if (__v != null) _s0.setAttribute('d', String(__v)); else _s0.removeAttribute('d') }
+      { const __x = `${({"check": "M20 6 9 17l-5-5", "chevron-down": "m6 9 6 6 6-6", "chevron-up": "m18 15-6-6-6 6", "chevron-left": "m15 18-6-6 6-6", "chevron-right": "m9 18 6-6-6-6", "x": "M18 6 6 18M6 6l12 12", "plus": "M5 12h14M12 5v14", "minus": "M5 12h14", "sun": "M12 16a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41", "moon": "M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z", "monitor": "M20 3H4a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2zM8 21h8M12 17v4", "copy": "M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2M8 8h12a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V10a2 2 0 0 1 2-2z", "clipboard": "M9 2h6a1 1 0 0 1 1 1v1H8V3a1 1 0 0 1 1-1zM16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2", "clipboard-check": "M9 2h6a1 1 0 0 1 1 1v1H8V3a1 1 0 0 1 1-1zM16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2M9 14l2 2 4-4", "menu": "M4 6h16M4 12h16M4 18h16", "arrow-left": "m12 19-7-7 7-7M19 12H5", "arrow-right": "M5 12h14m-7-7 7 7-7 7", "ellipsis": "M5 12h.01M12 12h.01M19 12h.01", "arrow-up-down": "m21 16-4 4-4-4M17 20V4M3 8l4-4 4 4M7 4v16", "panel-left": "M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4M3 3h12v18H3zM9 3v18", "loader-circle": "M21 12a9 9 0 1 1-6.219-8.56"})[_p.name]}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('d', String(__v)); else _s0.removeAttribute('d') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s1) applyRestAttrs(_s1, _p, ["name","size","className","xmlns","width","height","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     const [__GitHubIcon_s11El] = $c(__scope, 's11')
     if (__GitHubIcon_s11El) {
-      { const __v = size; if (__v != null) __GitHubIcon_s11El.setAttribute('size', String(__v)); else __GitHubIcon_s11El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __GitHubIcon_s11El.setAttribute('class', String(__v)); else __GitHubIcon_s11El.removeAttribute('class') }
+      { const __x = size
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) __GitHubIcon_s11El.setAttribute('size', String(__v)); else __GitHubIcon_s11El.removeAttribute('size') }
+      }
+      __l[0] = __x }
+      { const __x = className
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) __GitHubIcon_s11El.setAttribute('class', String(__v)); else __GitHubIcon_s11El.removeAttribute('class') }
+      }
+      __l[1] = __x }
     }
     const [__SearchIcon_s10El] = $c(__scope, 's10')
     if (__SearchIcon_s10El) {
-      { const __v = size; if (__v != null) __SearchIcon_s10El.setAttribute('size', String(__v)); else __SearchIcon_s10El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __SearchIcon_s10El.setAttribute('class', String(__v)); else __SearchIcon_s10El.removeAttribute('class') }
+      { const __x = size
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        { const __v = __x; if (__v != null) __SearchIcon_s10El.setAttribute('size', String(__v)); else __SearchIcon_s10El.removeAttribute('size') }
+      }
+      __l[2] = __x }
+      { const __x = className
+      if (!(3 in __l) || !Object.is(__l[3], __x)) {
+        { const __v = __x; if (__v != null) __SearchIcon_s10El.setAttribute('class', String(__v)); else __SearchIcon_s10El.removeAttribute('class') }
+      }
+      __l[3] = __x }
     }
     const [__SettingsIcon_s9El] = $c(__scope, 's9')
     if (__SettingsIcon_s9El) {
-      { const __v = size; if (__v != null) __SettingsIcon_s9El.setAttribute('size', String(__v)); else __SettingsIcon_s9El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __SettingsIcon_s9El.setAttribute('class', String(__v)); else __SettingsIcon_s9El.removeAttribute('class') }
+      { const __x = size
+      if (!(4 in __l) || !Object.is(__l[4], __x)) {
+        { const __v = __x; if (__v != null) __SettingsIcon_s9El.setAttribute('size', String(__v)); else __SettingsIcon_s9El.removeAttribute('size') }
+      }
+      __l[4] = __x }
+      { const __x = className
+      if (!(5 in __l) || !Object.is(__l[5], __x)) {
+        { const __v = __x; if (__v != null) __SettingsIcon_s9El.setAttribute('class', String(__v)); else __SettingsIcon_s9El.removeAttribute('class') }
+      }
+      __l[5] = __x }
     }
     const [__GlobeIcon_s8El] = $c(__scope, 's8')
     if (__GlobeIcon_s8El) {
-      { const __v = size; if (__v != null) __GlobeIcon_s8El.setAttribute('size', String(__v)); else __GlobeIcon_s8El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __GlobeIcon_s8El.setAttribute('class', String(__v)); else __GlobeIcon_s8El.removeAttribute('class') }
+      { const __x = size
+      if (!(6 in __l) || !Object.is(__l[6], __x)) {
+        { const __v = __x; if (__v != null) __GlobeIcon_s8El.setAttribute('size', String(__v)); else __GlobeIcon_s8El.removeAttribute('size') }
+      }
+      __l[6] = __x }
+      { const __x = className
+      if (!(7 in __l) || !Object.is(__l[7], __x)) {
+        { const __v = __x; if (__v != null) __GlobeIcon_s8El.setAttribute('class', String(__v)); else __GlobeIcon_s8El.removeAttribute('class') }
+      }
+      __l[7] = __x }
     }
     const [__LogOutIcon_s7El] = $c(__scope, 's7')
     if (__LogOutIcon_s7El) {
-      { const __v = size; if (__v != null) __LogOutIcon_s7El.setAttribute('size', String(__v)); else __LogOutIcon_s7El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __LogOutIcon_s7El.setAttribute('class', String(__v)); else __LogOutIcon_s7El.removeAttribute('class') }
+      { const __x = size
+      if (!(8 in __l) || !Object.is(__l[8], __x)) {
+        { const __v = __x; if (__v != null) __LogOutIcon_s7El.setAttribute('size', String(__v)); else __LogOutIcon_s7El.removeAttribute('size') }
+      }
+      __l[8] = __x }
+      { const __x = className
+      if (!(9 in __l) || !Object.is(__l[9], __x)) {
+        { const __v = __x; if (__v != null) __LogOutIcon_s7El.setAttribute('class', String(__v)); else __LogOutIcon_s7El.removeAttribute('class') }
+      }
+      __l[9] = __x }
     }
     const [__CircleHelpIcon_s6El] = $c(__scope, 's6')
     if (__CircleHelpIcon_s6El) {
-      { const __v = size; if (__v != null) __CircleHelpIcon_s6El.setAttribute('size', String(__v)); else __CircleHelpIcon_s6El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __CircleHelpIcon_s6El.setAttribute('class', String(__v)); else __CircleHelpIcon_s6El.removeAttribute('class') }
+      { const __x = size
+      if (!(10 in __l) || !Object.is(__l[10], __x)) {
+        { const __v = __x; if (__v != null) __CircleHelpIcon_s6El.setAttribute('size', String(__v)); else __CircleHelpIcon_s6El.removeAttribute('size') }
+      }
+      __l[10] = __x }
+      { const __x = className
+      if (!(11 in __l) || !Object.is(__l[11], __x)) {
+        { const __v = __x; if (__v != null) __CircleHelpIcon_s6El.setAttribute('class', String(__v)); else __CircleHelpIcon_s6El.removeAttribute('class') }
+      }
+      __l[11] = __x }
     }
     const [__CalendarIcon_s5El] = $c(__scope, 's5')
     if (__CalendarIcon_s5El) {
-      { const __v = size; if (__v != null) __CalendarIcon_s5El.setAttribute('size', String(__v)); else __CalendarIcon_s5El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __CalendarIcon_s5El.setAttribute('class', String(__v)); else __CalendarIcon_s5El.removeAttribute('class') }
+      { const __x = size
+      if (!(12 in __l) || !Object.is(__l[12], __x)) {
+        { const __v = __x; if (__v != null) __CalendarIcon_s5El.setAttribute('size', String(__v)); else __CalendarIcon_s5El.removeAttribute('size') }
+      }
+      __l[12] = __x }
+      { const __x = className
+      if (!(13 in __l) || !Object.is(__l[13], __x)) {
+        { const __v = __x; if (__v != null) __CalendarIcon_s5El.setAttribute('class', String(__v)); else __CalendarIcon_s5El.removeAttribute('class') }
+      }
+      __l[13] = __x }
     }
     const [__GripVerticalIcon_s4El] = $c(__scope, 's4')
     if (__GripVerticalIcon_s4El) {
-      { const __v = size; if (__v != null) __GripVerticalIcon_s4El.setAttribute('size', String(__v)); else __GripVerticalIcon_s4El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __GripVerticalIcon_s4El.setAttribute('class', String(__v)); else __GripVerticalIcon_s4El.removeAttribute('class') }
+      { const __x = size
+      if (!(14 in __l) || !Object.is(__l[14], __x)) {
+        { const __v = __x; if (__v != null) __GripVerticalIcon_s4El.setAttribute('size', String(__v)); else __GripVerticalIcon_s4El.removeAttribute('size') }
+      }
+      __l[14] = __x }
+      { const __x = className
+      if (!(15 in __l) || !Object.is(__l[15], __x)) {
+        { const __v = __x; if (__v != null) __GripVerticalIcon_s4El.setAttribute('class', String(__v)); else __GripVerticalIcon_s4El.removeAttribute('class') }
+      }
+      __l[15] = __x }
     }
     const [__LoaderCircleIcon_s3El] = $c(__scope, 's3')
     if (__LoaderCircleIcon_s3El) {
-      { const __v = size; if (__v != null) __LoaderCircleIcon_s3El.setAttribute('size', String(__v)); else __LoaderCircleIcon_s3El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __LoaderCircleIcon_s3El.setAttribute('class', String(__v)); else __LoaderCircleIcon_s3El.removeAttribute('class') }
+      { const __x = size
+      if (!(16 in __l) || !Object.is(__l[16], __x)) {
+        { const __v = __x; if (__v != null) __LoaderCircleIcon_s3El.setAttribute('size', String(__v)); else __LoaderCircleIcon_s3El.removeAttribute('size') }
+      }
+      __l[16] = __x }
+      { const __x = className
+      if (!(17 in __l) || !Object.is(__l[17], __x)) {
+        { const __v = __x; if (__v != null) __LoaderCircleIcon_s3El.setAttribute('class', String(__v)); else __LoaderCircleIcon_s3El.removeAttribute('class') }
+      }
+      __l[17] = __x }
     }
     const [__PanelLeftIcon_s2El] = $c(__scope, 's2')
     if (__PanelLeftIcon_s2El) {
-      { const __v = size; if (__v != null) __PanelLeftIcon_s2El.setAttribute('size', String(__v)); else __PanelLeftIcon_s2El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __PanelLeftIcon_s2El.setAttribute('class', String(__v)); else __PanelLeftIcon_s2El.removeAttribute('class') }
+      { const __x = size
+      if (!(18 in __l) || !Object.is(__l[18], __x)) {
+        { const __v = __x; if (__v != null) __PanelLeftIcon_s2El.setAttribute('size', String(__v)); else __PanelLeftIcon_s2El.removeAttribute('size') }
+      }
+      __l[18] = __x }
+      { const __x = className
+      if (!(19 in __l) || !Object.is(__l[19], __x)) {
+        { const __v = __x; if (__v != null) __PanelLeftIcon_s2El.setAttribute('class', String(__v)); else __PanelLeftIcon_s2El.removeAttribute('class') }
+      }
+      __l[19] = __x }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('GitHubIcon', _s11, forwardProps(_p, { get size() { return size }, get className() { return className } }, ["size","className"]))
@@ -2736,13 +3004,26 @@ export function initDialogTrigger(__scope, _p = {}) {
 
   const [_s1, _s0] = $(__scope, 's1', 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = _p.id; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
-      { const __v = `${dialogTriggerClasses} ${_p.className ?? ''}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
-      _s0.disabled = !!(_p.disabled ?? false)
+      { const __x = _p.id
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
+      }
+      __l[0] = __x }
+      { const __x = `${dialogTriggerClasses} ${_p.className ?? ''}`
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[1] = __x }
+      { const __x = _p.disabled ?? false
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        _s0.disabled = !!(__x)
+      }
+      __l[2] = __x }
     }
-  })
+  }) }
 
   if (_s1) (handleMount)(_s1)
   if (_s0) (handleMount)(_s0)
@@ -2782,12 +3063,21 @@ export function initDialogOverlay(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = _p.id; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
-      { const __v = `${dialogOverlayBaseClasses} ${dialogOverlayClosedClasses} ${_p.className ?? ''}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = _p.id
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
+      }
+      __l[0] = __x }
+      { const __x = `${dialogOverlayBaseClasses} ${dialogOverlayClosedClasses} ${_p.className ?? ''}`
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[1] = __x }
     }
-  })
+  }) }
 
   if (_s0) (handleMount)(_s0)
 }
@@ -2877,14 +3167,31 @@ export function initDialogContent(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = _p.ariaLabelledby; if (__v != null) _s0.setAttribute('aria-labelledby', String(__v)); else _s0.removeAttribute('aria-labelledby') }
-      { const __v = _p.ariaDescribedby; if (__v != null) _s0.setAttribute('aria-describedby', String(__v)); else _s0.removeAttribute('aria-describedby') }
-      { const __v = _p.id; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
-      { const __v = `${dialogContentBaseClasses} ${dialogContentClosedClasses} ${_p.className ?? ''}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = _p.ariaLabelledby
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('aria-labelledby', String(__v)); else _s0.removeAttribute('aria-labelledby') }
+      }
+      __l[0] = __x }
+      { const __x = _p.ariaDescribedby
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('aria-describedby', String(__v)); else _s0.removeAttribute('aria-describedby') }
+      }
+      __l[1] = __x }
+      { const __x = _p.id
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
+      }
+      __l[2] = __x }
+      { const __x = `${dialogContentBaseClasses} ${dialogContentClosedClasses} ${_p.className ?? ''}`
+      if (!(3 in __l) || !Object.is(__l[3], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[3] = __x }
     }
-  })
+  }) }
 
   if (_s0) (handleMount)(_s0)
 }
@@ -2899,11 +3206,16 @@ export function initDialogHeader(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `${dialogHeaderClasses} ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `${dialogHeaderClasses} ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["className","children","data-slot","class"])
 
@@ -2919,12 +3231,21 @@ export function initDialogTitle(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = _p.id; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
-      { const __v = `${dialogTitleClasses} ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = _p.id
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
+      }
+      __l[0] = __x }
+      { const __x = `${dialogTitleClasses} ${(_p.className ?? '')}`
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[1] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["className","id","children","data-slot","class"])
 
@@ -2940,12 +3261,21 @@ export function initDialogDescription(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = _p.id; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
-      { const __v = `${dialogDescriptionClasses} ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = _p.id
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
+      }
+      __l[0] = __x }
+      { const __x = `${dialogDescriptionClasses} ${(_p.className ?? '')}`
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[1] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["className","id","children","data-slot","class"])
 
@@ -2961,11 +3291,16 @@ export function initDialogFooter(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `${dialogFooterClasses} ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `${dialogFooterClasses} ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["className","children","data-slot","class"])
 
@@ -2990,12 +3325,21 @@ export function initDialogClose(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = _p.id; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
-      { const __v = `${dialogCloseClasses} ${_p.className ?? ''}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = _p.id
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
+      }
+      __l[0] = __x }
+      { const __x = `${dialogCloseClasses} ${_p.className ?? ''}`
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[1] = __x }
     }
-  })
+  }) }
 
   if (_s0) (handleMount)(_s0)
 }
@@ -3071,12 +3415,21 @@ export function initCommand(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = _p.id; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
-      { const __v = `${commandRootClasses} ${_p.className ?? ''}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = _p.id
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
+      }
+      __l[0] = __x }
+      { const __x = `${commandRootClasses} ${_p.className ?? ''}`
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[1] = __x }
     }
-  })
+  }) }
 
   if (_s0) (handleMount)(_s0)
 
@@ -3125,14 +3478,31 @@ export function initCommandInput(__scope, _p = {}) {
   const [_s2, _s1] = $(__scope, 's2', 's1')
   const [_s0] = $c(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s1) {
-      { const __v = _p.id; if (__v != null) _s1.setAttribute('id', String(__v)); else _s1.removeAttribute('id') }
-      { const __v = _p.placeholder; if (__v != null) _s1.setAttribute('placeholder', String(__v)); else _s1.removeAttribute('placeholder') }
-      _s1.disabled = !!(_p.disabled ?? false)
-      { const __v = `${commandInputClasses} ${_p.className ?? ''}`; if (__v != null) _s1.setAttribute('class', String(__v)); else _s1.removeAttribute('class') }
+      { const __x = _p.id
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('id', String(__v)); else _s1.removeAttribute('id') }
+      }
+      __l[0] = __x }
+      { const __x = _p.placeholder
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('placeholder', String(__v)); else _s1.removeAttribute('placeholder') }
+      }
+      __l[1] = __x }
+      { const __x = _p.disabled ?? false
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        _s1.disabled = !!(__x)
+      }
+      __l[2] = __x }
+      { const __x = `${commandInputClasses} ${_p.className ?? ''}`
+      if (!(3 in __l) || !Object.is(__l[3], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('class', String(__v)); else _s1.removeAttribute('class') }
+      }
+      __l[3] = __x }
     }
-  })
+  }) }
 
   if (_s2) (handleMount)(_s2)
 
@@ -3150,11 +3520,16 @@ export function initCommandList(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `${commandListClasses} ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `${commandListClasses} ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["className","children","data-slot","role","class"])
 
@@ -3186,12 +3561,21 @@ export function initCommandEmpty(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = _p.id; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
-      { const __v = `${commandEmptyClasses} ${_p.className ?? ''}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = _p.id
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
+      }
+      __l[0] = __x }
+      { const __x = `${commandEmptyClasses} ${_p.className ?? ''}`
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[1] = __x }
     }
-  })
+  }) }
 
   if (_s0) (handleMount)(_s0)
 }
@@ -3222,12 +3606,21 @@ export function initCommandGroup(__scope, _p = {}) {
 
   const [_s0, _s3] = $(__scope, 's0', 's3')
 
+  { const __l = []
   createEffect(() => {
     if (_s3) {
-      { const __v = _p.id; if (__v != null) _s3.setAttribute('id', String(__v)); else _s3.removeAttribute('id') }
-      { const __v = `${commandGroupClasses} ${_p.className ?? ''}`; if (__v != null) _s3.setAttribute('class', String(__v)); else _s3.removeAttribute('class') }
+      { const __x = _p.id
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s3.setAttribute('id', String(__v)); else _s3.removeAttribute('id') }
+      }
+      __l[0] = __x }
+      { const __x = `${commandGroupClasses} ${_p.className ?? ''}`
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s3.setAttribute('class', String(__v)); else _s3.removeAttribute('class') }
+      }
+      __l[1] = __x }
     }
-  })
+  }) }
 
   insert(__scope, 's0', () => _p.heading, {
     template: () => { const __slots = []; return { html: `<div bf-c="s0" data-slot="command-group-heading" aria-hidden="true" bf="s2"><!--bf:s1-->${__bfSlot(_p.heading, __slots)}<!--/--></div>`, slots: __slots } },
@@ -3302,14 +3695,27 @@ export function initCommandItem(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = _p.id; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
-      if (isDisabled()) _s0.setAttribute('data-disabled', '')
-      else _s0.removeAttribute('data-disabled')
-      { const __v = `${commandItemClasses} ${_p.className ?? ''}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = _p.id
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
+      }
+      __l[0] = __x }
+      { const __x = isDisabled()
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        if (__x) _s0.setAttribute('data-disabled', '')
+        else _s0.removeAttribute('data-disabled')
+      }
+      __l[1] = __x }
+      { const __x = `${commandItemClasses} ${_p.className ?? ''}`
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[2] = __x }
     }
-  })
+  }) }
 
   if (_s0) (handleMount)(_s0)
 }
@@ -3324,11 +3730,16 @@ export function initCommandSeparator(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `${commandSeparatorClasses} ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `${commandSeparatorClasses} ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["className","data-slot","role","class"])
 
@@ -3344,11 +3755,16 @@ export function initCommandShortcut(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `${commandShortcutClasses} ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `${commandShortcutClasses} ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["className","children","data-slot","class"])
 
@@ -3366,16 +3782,29 @@ export function initCommandDialog(__scope, _p = {}) {
 
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     if (__scope) {
-      __scope.open = !!(_p.open ?? false)
+      { const __x = _p.open ?? false
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        __scope.open = !!(__x)
+      }
+      __l[0] = __x }
     }
     const [__Command_s1El] = $c(__scope, 's1')
     if (__Command_s1El) {
-      { const __v = _p.id; if (__v != null) __Command_s1El.setAttribute('id', String(__v)); else __Command_s1El.removeAttribute('id') }
-      { const __v = _p.filter; if (__v != null) __Command_s1El.setAttribute('filter', String(__v)); else __Command_s1El.removeAttribute('filter') }
+      { const __x = _p.id
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) __Command_s1El.setAttribute('id', String(__v)); else __Command_s1El.removeAttribute('id') }
+      }
+      __l[1] = __x }
+      { const __x = _p.filter
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        { const __v = __x; if (__v != null) __Command_s1El.setAttribute('filter', String(__v)); else __Command_s1El.removeAttribute('filter') }
+      }
+      __l[2] = __x }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('Dialog', __scope, { get open() { return _p.open ?? false }, onOpenChange: _p.onOpenChange ?? (() => {}) })
@@ -3401,12 +3830,17 @@ export function initSlot(__scope, _p = {}) {
 
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     const [__Tag_s0El] = $c(__scope, 's0')
     if (__Tag_s0El) {
-      { const __v = ([className, (((children.props).className) || '')].filter(Boolean).join(' ')); if (__v != null) __Tag_s0El.setAttribute('class', String(__v)); else __Tag_s0El.removeAttribute('class') }
+      { const __x = ([className, (((children.props).className) || '')].filter(Boolean).join(' '))
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) __Tag_s0El.setAttribute('class', String(__v)); else __Tag_s0El.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('Tag', _s0, forwardProps(_p, { get className() { return ([className, (((children.props).className) || '')].filter(Boolean).join(' ')) } }, ["className"]))
@@ -3425,22 +3859,32 @@ export function initKbd(__scope, _p = {}) {
   const [_s0] = $(__scope, 's0')
   const [_s1] = $c(__scope, 's1')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `pointer-events-none inline-flex h-5 w-fit min-w-5 items-center justify-center gap-1 rounded-sm border bg-muted px-1 font-sans text-xs font-medium text-muted-foreground select-none [&_svg:not([class*=size-])]:size-3 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `pointer-events-none inline-flex h-5 w-fit min-w-5 items-center justify-center gap-1 rounded-sm border bg-muted px-1 font-sans text-xs font-medium text-muted-foreground select-none [&_svg:not([class*=size-])]:size-3 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["className","asChild","children","data-slot","class"])
 
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     const [__Slot_s1El] = $c(__scope, 's1')
     if (__Slot_s1El) {
-      { const __v = `pointer-events-none inline-flex h-5 w-fit min-w-5 items-center justify-center gap-1 rounded-sm border bg-muted px-1 font-sans text-xs font-medium text-muted-foreground select-none [&_svg:not([class*=size-])]:size-3 ${className}`; if (__v != null) __Slot_s1El.setAttribute('class', String(__v)); else __Slot_s1El.removeAttribute('class') }
+      { const __x = `pointer-events-none inline-flex h-5 w-fit min-w-5 items-center justify-center gap-1 rounded-sm border bg-muted px-1 font-sans text-xs font-medium text-muted-foreground select-none [&_svg:not([class*=size-])]:size-3 ${className}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) __Slot_s1El.setAttribute('class', String(__v)); else __Slot_s1El.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('Slot', _s1, forwardProps(_p, { get className() { return `pointer-events-none inline-flex h-5 w-fit min-w-5 items-center justify-center gap-1 rounded-sm border bg-muted px-1 font-sans text-xs font-medium text-muted-foreground select-none [&_svg:not([class*=size-])]:size-3 ${className}` } }, ["className"]))
@@ -3459,22 +3903,32 @@ export function initKbdGroup(__scope, _p = {}) {
   const [_s0] = $(__scope, 's0')
   const [_s1] = $c(__scope, 's1')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `inline-flex items-center gap-1 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `inline-flex items-center gap-1 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["className","asChild","children","data-slot","class"])
 
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     const [__Slot_s1El] = $c(__scope, 's1')
     if (__Slot_s1El) {
-      { const __v = `inline-flex items-center gap-1 ${className}`; if (__v != null) __Slot_s1El.setAttribute('class', String(__v)); else __Slot_s1El.removeAttribute('class') }
+      { const __x = `inline-flex items-center gap-1 ${className}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) __Slot_s1El.setAttribute('class', String(__v)); else __Slot_s1El.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('Slot', _s1, forwardProps(_p, { get className() { return `inline-flex items-center gap-1 ${className}` } }, ["className"]))
@@ -3511,22 +3965,32 @@ export function initButton(__scope, _p = {}) {
   const [_s0] = $(__scope, 's0')
   const [_s1] = $c(__scope, 's1')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*="size-"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-[invalid]:ring-destructive/20 dark:aria-[invalid]:ring-destructive/40 aria-[invalid]:border-destructive touch-action-manipulation ${({"default": "bg-primary text-primary-foreground hover:bg-primary/90", "destructive": "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60", "outline": "border border-input bg-background text-foreground shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:hover:bg-input/50", "secondary": "bg-secondary text-secondary-foreground hover:bg-secondary/80", "ghost": "text-foreground hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50", "link": "text-foreground underline-offset-4 hover:underline hover:text-primary"})[(_p.variant ?? 'default')]} ${({"default": "h-9 px-4 py-2 has-[>svg]:px-3", "sm": "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5", "lg": "h-10 rounded-md px-6 has-[>svg]:px-4", "icon": "size-9", "icon-sm": "size-8", "icon-lg": "size-10"})[(_p.size ?? 'default')]} ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*="size-"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-[invalid]:ring-destructive/20 dark:aria-[invalid]:ring-destructive/40 aria-[invalid]:border-destructive touch-action-manipulation ${({"default": "bg-primary text-primary-foreground hover:bg-primary/90", "destructive": "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60", "outline": "border border-input bg-background text-foreground shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:hover:bg-input/50", "secondary": "bg-secondary text-secondary-foreground hover:bg-secondary/80", "ghost": "text-foreground hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50", "link": "text-foreground underline-offset-4 hover:underline hover:text-primary"})[(_p.variant ?? 'default')]} ${({"default": "h-9 px-4 py-2 has-[>svg]:px-3", "sm": "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5", "lg": "h-10 rounded-md px-6 has-[>svg]:px-4", "icon": "size-9", "icon-sm": "size-8", "icon-lg": "size-10"})[(_p.size ?? 'default')]} ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["className","variant","size","asChild","children","class"])
 
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     const [__Slot_s1El] = $c(__scope, 's1')
     if (__Slot_s1El) {
-      { const __v = `inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*="size-"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-[invalid]:ring-destructive/20 dark:aria-[invalid]:ring-destructive/40 aria-[invalid]:border-destructive touch-action-manipulation ${({"default": "bg-primary text-primary-foreground hover:bg-primary/90", "destructive": "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60", "outline": "border border-input bg-background text-foreground shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:hover:bg-input/50", "secondary": "bg-secondary text-secondary-foreground hover:bg-secondary/80", "ghost": "text-foreground hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50", "link": "text-foreground underline-offset-4 hover:underline hover:text-primary"})[variant]} ${({"default": "h-9 px-4 py-2 has-[>svg]:px-3", "sm": "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5", "lg": "h-10 rounded-md px-6 has-[>svg]:px-4", "icon": "size-9", "icon-sm": "size-8", "icon-lg": "size-10"})[size]} ${className}`; if (__v != null) __Slot_s1El.setAttribute('class', String(__v)); else __Slot_s1El.removeAttribute('class') }
+      { const __x = `inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*="size-"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-[invalid]:ring-destructive/20 dark:aria-[invalid]:ring-destructive/40 aria-[invalid]:border-destructive touch-action-manipulation ${({"default": "bg-primary text-primary-foreground hover:bg-primary/90", "destructive": "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60", "outline": "border border-input bg-background text-foreground shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:hover:bg-input/50", "secondary": "bg-secondary text-secondary-foreground hover:bg-secondary/80", "ghost": "text-foreground hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50", "link": "text-foreground underline-offset-4 hover:underline hover:text-primary"})[variant]} ${({"default": "h-9 px-4 py-2 has-[>svg]:px-3", "sm": "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5", "lg": "h-10 rounded-md px-6 has-[>svg]:px-4", "icon": "size-9", "icon-sm": "size-8", "icon-lg": "size-10"})[size]} ${className}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) __Slot_s1El.setAttribute('class', String(__v)); else __Slot_s1El.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('Slot', _s1, forwardProps(_p, { get className() { return `inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*="size-"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-[invalid]:ring-destructive/20 dark:aria-[invalid]:ring-destructive/40 aria-[invalid]:border-destructive touch-action-manipulation ${({"default": "bg-primary text-primary-foreground hover:bg-primary/90", "destructive": "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60", "outline": "border border-input bg-background text-foreground shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:hover:bg-input/50", "secondary": "bg-secondary text-secondary-foreground hover:bg-secondary/80", "ghost": "text-foreground hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50", "link": "text-foreground underline-offset-4 hover:underline hover:text-primary"})[variant]} ${({"default": "h-9 px-4 py-2 has-[>svg]:px-3", "sm": "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5", "lg": "h-10 rounded-md px-6 has-[>svg]:px-4", "icon": "size-9", "icon-sm": "size-8", "icon-lg": "size-10"})[size]} ${className}` } }, ["className"]))
@@ -3579,12 +4043,17 @@ export function initCommandDialogDemo(__scope, _p = {}) {
   })
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     const [__CommandDialog_s17El] = $c(__scope, 's17')
     if (__CommandDialog_s17El) {
-      __CommandDialog_s17El.open = !!(open())
+      { const __x = open()
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        __CommandDialog_s17El.open = !!(__x)
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
   createEffect(() => {
     const handleKeyDown = (e) => {
       if (e.key === 'j' && (e.metaKey || e.ctrlKey)) {

--- a/packages/adapter-tests/fixtures/__snapshots__/conditional-return-button.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/conditional-return-button.client.js
@@ -16,17 +16,27 @@ export function initConditionalReturn(__scope, _p = {}) {
     __bfw_s2('s0', escapeTextOrNode(__val))
   })
 
+  { const __l = []
   createEffect(() => {
     if (_s3) {
-      { const __v = count() > 0; if (__v != null) _s3.setAttribute('data-active', String(__v)); else _s3.removeAttribute('data-active') }
+      { const __x = count() > 0
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s3.setAttribute('data-active', String(__v)); else _s3.removeAttribute('data-active') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
+  { const __l = []
   createEffect(() => {
     if (_s1) {
-      { const __v = count() > 0; if (__v != null) _s1.setAttribute('data-active', String(__v)); else _s1.removeAttribute('data-active') }
+      { const __x = count() > 0
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('data-active', String(__v)); else _s1.removeAttribute('data-active') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s3) _s3.addEventListener('click', (e) => {
           e.preventDefault()

--- a/packages/adapter-tests/fixtures/__snapshots__/conditional-return-link.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/conditional-return-link.client.js
@@ -16,17 +16,27 @@ export function initConditionalReturn(__scope, _p = {}) {
     __bfw_s2('s0', escapeTextOrNode(__val))
   })
 
+  { const __l = []
   createEffect(() => {
     if (_s3) {
-      { const __v = count() > 0; if (__v != null) _s3.setAttribute('data-active', String(__v)); else _s3.removeAttribute('data-active') }
+      { const __x = count() > 0
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s3.setAttribute('data-active', String(__v)); else _s3.removeAttribute('data-active') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
+  { const __l = []
   createEffect(() => {
     if (_s1) {
-      { const __v = count() > 0; if (__v != null) _s1.setAttribute('data-active', String(__v)); else _s1.removeAttribute('data-active') }
+      { const __x = count() > 0
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('data-active', String(__v)); else _s1.removeAttribute('data-active') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s3) _s3.addEventListener('click', (e) => {
           e.preventDefault()

--- a/packages/adapter-tests/fixtures/__snapshots__/data-table.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/data-table.client.js
@@ -8,11 +8,16 @@ export function initTable(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `${tableClasses} ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `${tableClasses} ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot","class"])
 
@@ -28,11 +33,16 @@ export function initTableHeader(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `${tableHeaderClasses} ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `${tableHeaderClasses} ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot","class"])
 
@@ -48,11 +58,16 @@ export function initTableBody(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `${tableBodyClasses} ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `${tableBodyClasses} ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot","class"])
 
@@ -68,11 +83,16 @@ export function initTableFooter(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `${tableFooterClasses} ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `${tableFooterClasses} ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot","class"])
 
@@ -88,11 +108,16 @@ export function initTableRow(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `${tableRowClasses} ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `${tableRowClasses} ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot","class"])
 
@@ -108,11 +133,16 @@ export function initTableHead(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `${tableHeadClasses} ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `${tableHeadClasses} ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot","class"])
 
@@ -128,11 +158,16 @@ export function initTableCell(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `${tableCellClasses} ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `${tableCellClasses} ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot","class"])
 
@@ -148,11 +183,16 @@ export function initTableCaption(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `${tableCaptionClasses} ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `${tableCaptionClasses} ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot","class"])
 
@@ -199,11 +239,16 @@ export function initCheckIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -304,11 +349,16 @@ export function initChevronDownIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -409,11 +459,16 @@ export function initChevronUpIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -514,11 +569,16 @@ export function initChevronLeftIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -619,11 +679,16 @@ export function initChevronRightIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -724,11 +789,16 @@ export function initXIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -829,11 +899,16 @@ export function initPlusIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -934,11 +1009,16 @@ export function initMinusIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1039,11 +1119,16 @@ export function initSunIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1144,11 +1229,16 @@ export function initMoonIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1249,11 +1339,16 @@ export function initMonitorIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1354,11 +1449,16 @@ export function initCopyIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1459,11 +1559,16 @@ export function initClipboardIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1564,11 +1669,16 @@ export function initClipboardCheckIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1669,11 +1779,16 @@ export function initMenuIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1774,11 +1889,16 @@ export function initArrowLeftIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1879,11 +1999,16 @@ export function initArrowRightIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1984,11 +2109,16 @@ export function initArrowUpDownIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2066,11 +2196,16 @@ export function initEllipsisIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2104,11 +2239,16 @@ export function initGitHubIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","class","aria-hidden"])
 
@@ -2142,11 +2282,16 @@ export function initSettingsIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2180,11 +2325,16 @@ export function initGlobeIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2218,11 +2368,16 @@ export function initLogOutIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2256,11 +2411,16 @@ export function initCircleHelpIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2294,11 +2454,16 @@ export function initSearchIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2332,11 +2497,16 @@ export function initCircleCheckIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2370,11 +2540,16 @@ export function initCircleXIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2408,11 +2583,16 @@ export function initTriangleAlertIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2446,11 +2626,16 @@ export function initInfoIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2484,11 +2669,16 @@ export function initCalendarIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2522,11 +2712,16 @@ export function initGripVerticalIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2583,11 +2778,16 @@ export function initLoaderCircleIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2665,11 +2865,16 @@ export function initPanelLeftIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2736,77 +2941,180 @@ export function initIcon(__scope, _p = {}) {
   const [_s1, _s0] = $(__scope, 's1', 's0')
   const [_s11, _s10, _s9, _s8, _s7, _s6, _s5, _s4, _s3, _s2] = $c(__scope, 's11', 's10', 's9', 's8', 's7', 's6', 's5', 's4', 's3', 's2')
 
+  { const __l = []
   createEffect(() => {
     if (_s1) {
-      { const __v = sizeMap[(_p.size ?? 'md')]; if (__v != null) _s1.setAttribute('width', String(__v)); else _s1.removeAttribute('width') }
-      { const __v = sizeMap[(_p.size ?? 'md')]; if (__v != null) _s1.setAttribute('height', String(__v)); else _s1.removeAttribute('height') }
-      { const __v = (buttLinecapIcons).includes(_p.name) ? 'butt' : 'round'; if (__v != null) _s1.setAttribute('stroke-linecap', String(__v)); else _s1.removeAttribute('stroke-linecap') }
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s1.setAttribute('class', String(__v)); else _s1.removeAttribute('class') }
+      { const __x = sizeMap[(_p.size ?? 'md')]
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('width', String(__v)); else _s1.removeAttribute('width') }
+      }
+      __l[0] = __x }
+      { const __x = sizeMap[(_p.size ?? 'md')]
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('height', String(__v)); else _s1.removeAttribute('height') }
+      }
+      __l[1] = __x }
+      { const __x = (buttLinecapIcons).includes(_p.name) ? 'butt' : 'round'
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('stroke-linecap', String(__v)); else _s1.removeAttribute('stroke-linecap') }
+      }
+      __l[2] = __x }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(3 in __l) || !Object.is(__l[3], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('class', String(__v)); else _s1.removeAttribute('class') }
+      }
+      __l[3] = __x }
     }
-  })
+  }) }
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `${({"check": "M20 6 9 17l-5-5", "chevron-down": "m6 9 6 6 6-6", "chevron-up": "m18 15-6-6-6 6", "chevron-left": "m15 18-6-6 6-6", "chevron-right": "m9 18 6-6-6-6", "x": "M18 6 6 18M6 6l12 12", "plus": "M5 12h14M12 5v14", "minus": "M5 12h14", "sun": "M12 16a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41", "moon": "M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z", "monitor": "M20 3H4a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2zM8 21h8M12 17v4", "copy": "M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2M8 8h12a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V10a2 2 0 0 1 2-2z", "clipboard": "M9 2h6a1 1 0 0 1 1 1v1H8V3a1 1 0 0 1 1-1zM16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2", "clipboard-check": "M9 2h6a1 1 0 0 1 1 1v1H8V3a1 1 0 0 1 1-1zM16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2M9 14l2 2 4-4", "menu": "M4 6h16M4 12h16M4 18h16", "arrow-left": "m12 19-7-7 7-7M19 12H5", "arrow-right": "M5 12h14m-7-7 7 7-7 7", "ellipsis": "M5 12h.01M12 12h.01M19 12h.01", "arrow-up-down": "m21 16-4 4-4-4M17 20V4M3 8l4-4 4 4M7 4v16", "panel-left": "M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4M3 3h12v18H3zM9 3v18", "loader-circle": "M21 12a9 9 0 1 1-6.219-8.56"})[_p.name]}`; if (__v != null) _s0.setAttribute('d', String(__v)); else _s0.removeAttribute('d') }
+      { const __x = `${({"check": "M20 6 9 17l-5-5", "chevron-down": "m6 9 6 6 6-6", "chevron-up": "m18 15-6-6-6 6", "chevron-left": "m15 18-6-6 6-6", "chevron-right": "m9 18 6-6-6-6", "x": "M18 6 6 18M6 6l12 12", "plus": "M5 12h14M12 5v14", "minus": "M5 12h14", "sun": "M12 16a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41", "moon": "M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z", "monitor": "M20 3H4a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2zM8 21h8M12 17v4", "copy": "M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2M8 8h12a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V10a2 2 0 0 1 2-2z", "clipboard": "M9 2h6a1 1 0 0 1 1 1v1H8V3a1 1 0 0 1 1-1zM16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2", "clipboard-check": "M9 2h6a1 1 0 0 1 1 1v1H8V3a1 1 0 0 1 1-1zM16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2M9 14l2 2 4-4", "menu": "M4 6h16M4 12h16M4 18h16", "arrow-left": "m12 19-7-7 7-7M19 12H5", "arrow-right": "M5 12h14m-7-7 7 7-7 7", "ellipsis": "M5 12h.01M12 12h.01M19 12h.01", "arrow-up-down": "m21 16-4 4-4-4M17 20V4M3 8l4-4 4 4M7 4v16", "panel-left": "M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4M3 3h12v18H3zM9 3v18", "loader-circle": "M21 12a9 9 0 1 1-6.219-8.56"})[_p.name]}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('d', String(__v)); else _s0.removeAttribute('d') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s1) applyRestAttrs(_s1, _p, ["name","size","className","xmlns","width","height","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     const [__GitHubIcon_s11El] = $c(__scope, 's11')
     if (__GitHubIcon_s11El) {
-      { const __v = size; if (__v != null) __GitHubIcon_s11El.setAttribute('size', String(__v)); else __GitHubIcon_s11El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __GitHubIcon_s11El.setAttribute('class', String(__v)); else __GitHubIcon_s11El.removeAttribute('class') }
+      { const __x = size
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) __GitHubIcon_s11El.setAttribute('size', String(__v)); else __GitHubIcon_s11El.removeAttribute('size') }
+      }
+      __l[0] = __x }
+      { const __x = className
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) __GitHubIcon_s11El.setAttribute('class', String(__v)); else __GitHubIcon_s11El.removeAttribute('class') }
+      }
+      __l[1] = __x }
     }
     const [__SearchIcon_s10El] = $c(__scope, 's10')
     if (__SearchIcon_s10El) {
-      { const __v = size; if (__v != null) __SearchIcon_s10El.setAttribute('size', String(__v)); else __SearchIcon_s10El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __SearchIcon_s10El.setAttribute('class', String(__v)); else __SearchIcon_s10El.removeAttribute('class') }
+      { const __x = size
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        { const __v = __x; if (__v != null) __SearchIcon_s10El.setAttribute('size', String(__v)); else __SearchIcon_s10El.removeAttribute('size') }
+      }
+      __l[2] = __x }
+      { const __x = className
+      if (!(3 in __l) || !Object.is(__l[3], __x)) {
+        { const __v = __x; if (__v != null) __SearchIcon_s10El.setAttribute('class', String(__v)); else __SearchIcon_s10El.removeAttribute('class') }
+      }
+      __l[3] = __x }
     }
     const [__SettingsIcon_s9El] = $c(__scope, 's9')
     if (__SettingsIcon_s9El) {
-      { const __v = size; if (__v != null) __SettingsIcon_s9El.setAttribute('size', String(__v)); else __SettingsIcon_s9El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __SettingsIcon_s9El.setAttribute('class', String(__v)); else __SettingsIcon_s9El.removeAttribute('class') }
+      { const __x = size
+      if (!(4 in __l) || !Object.is(__l[4], __x)) {
+        { const __v = __x; if (__v != null) __SettingsIcon_s9El.setAttribute('size', String(__v)); else __SettingsIcon_s9El.removeAttribute('size') }
+      }
+      __l[4] = __x }
+      { const __x = className
+      if (!(5 in __l) || !Object.is(__l[5], __x)) {
+        { const __v = __x; if (__v != null) __SettingsIcon_s9El.setAttribute('class', String(__v)); else __SettingsIcon_s9El.removeAttribute('class') }
+      }
+      __l[5] = __x }
     }
     const [__GlobeIcon_s8El] = $c(__scope, 's8')
     if (__GlobeIcon_s8El) {
-      { const __v = size; if (__v != null) __GlobeIcon_s8El.setAttribute('size', String(__v)); else __GlobeIcon_s8El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __GlobeIcon_s8El.setAttribute('class', String(__v)); else __GlobeIcon_s8El.removeAttribute('class') }
+      { const __x = size
+      if (!(6 in __l) || !Object.is(__l[6], __x)) {
+        { const __v = __x; if (__v != null) __GlobeIcon_s8El.setAttribute('size', String(__v)); else __GlobeIcon_s8El.removeAttribute('size') }
+      }
+      __l[6] = __x }
+      { const __x = className
+      if (!(7 in __l) || !Object.is(__l[7], __x)) {
+        { const __v = __x; if (__v != null) __GlobeIcon_s8El.setAttribute('class', String(__v)); else __GlobeIcon_s8El.removeAttribute('class') }
+      }
+      __l[7] = __x }
     }
     const [__LogOutIcon_s7El] = $c(__scope, 's7')
     if (__LogOutIcon_s7El) {
-      { const __v = size; if (__v != null) __LogOutIcon_s7El.setAttribute('size', String(__v)); else __LogOutIcon_s7El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __LogOutIcon_s7El.setAttribute('class', String(__v)); else __LogOutIcon_s7El.removeAttribute('class') }
+      { const __x = size
+      if (!(8 in __l) || !Object.is(__l[8], __x)) {
+        { const __v = __x; if (__v != null) __LogOutIcon_s7El.setAttribute('size', String(__v)); else __LogOutIcon_s7El.removeAttribute('size') }
+      }
+      __l[8] = __x }
+      { const __x = className
+      if (!(9 in __l) || !Object.is(__l[9], __x)) {
+        { const __v = __x; if (__v != null) __LogOutIcon_s7El.setAttribute('class', String(__v)); else __LogOutIcon_s7El.removeAttribute('class') }
+      }
+      __l[9] = __x }
     }
     const [__CircleHelpIcon_s6El] = $c(__scope, 's6')
     if (__CircleHelpIcon_s6El) {
-      { const __v = size; if (__v != null) __CircleHelpIcon_s6El.setAttribute('size', String(__v)); else __CircleHelpIcon_s6El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __CircleHelpIcon_s6El.setAttribute('class', String(__v)); else __CircleHelpIcon_s6El.removeAttribute('class') }
+      { const __x = size
+      if (!(10 in __l) || !Object.is(__l[10], __x)) {
+        { const __v = __x; if (__v != null) __CircleHelpIcon_s6El.setAttribute('size', String(__v)); else __CircleHelpIcon_s6El.removeAttribute('size') }
+      }
+      __l[10] = __x }
+      { const __x = className
+      if (!(11 in __l) || !Object.is(__l[11], __x)) {
+        { const __v = __x; if (__v != null) __CircleHelpIcon_s6El.setAttribute('class', String(__v)); else __CircleHelpIcon_s6El.removeAttribute('class') }
+      }
+      __l[11] = __x }
     }
     const [__CalendarIcon_s5El] = $c(__scope, 's5')
     if (__CalendarIcon_s5El) {
-      { const __v = size; if (__v != null) __CalendarIcon_s5El.setAttribute('size', String(__v)); else __CalendarIcon_s5El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __CalendarIcon_s5El.setAttribute('class', String(__v)); else __CalendarIcon_s5El.removeAttribute('class') }
+      { const __x = size
+      if (!(12 in __l) || !Object.is(__l[12], __x)) {
+        { const __v = __x; if (__v != null) __CalendarIcon_s5El.setAttribute('size', String(__v)); else __CalendarIcon_s5El.removeAttribute('size') }
+      }
+      __l[12] = __x }
+      { const __x = className
+      if (!(13 in __l) || !Object.is(__l[13], __x)) {
+        { const __v = __x; if (__v != null) __CalendarIcon_s5El.setAttribute('class', String(__v)); else __CalendarIcon_s5El.removeAttribute('class') }
+      }
+      __l[13] = __x }
     }
     const [__GripVerticalIcon_s4El] = $c(__scope, 's4')
     if (__GripVerticalIcon_s4El) {
-      { const __v = size; if (__v != null) __GripVerticalIcon_s4El.setAttribute('size', String(__v)); else __GripVerticalIcon_s4El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __GripVerticalIcon_s4El.setAttribute('class', String(__v)); else __GripVerticalIcon_s4El.removeAttribute('class') }
+      { const __x = size
+      if (!(14 in __l) || !Object.is(__l[14], __x)) {
+        { const __v = __x; if (__v != null) __GripVerticalIcon_s4El.setAttribute('size', String(__v)); else __GripVerticalIcon_s4El.removeAttribute('size') }
+      }
+      __l[14] = __x }
+      { const __x = className
+      if (!(15 in __l) || !Object.is(__l[15], __x)) {
+        { const __v = __x; if (__v != null) __GripVerticalIcon_s4El.setAttribute('class', String(__v)); else __GripVerticalIcon_s4El.removeAttribute('class') }
+      }
+      __l[15] = __x }
     }
     const [__LoaderCircleIcon_s3El] = $c(__scope, 's3')
     if (__LoaderCircleIcon_s3El) {
-      { const __v = size; if (__v != null) __LoaderCircleIcon_s3El.setAttribute('size', String(__v)); else __LoaderCircleIcon_s3El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __LoaderCircleIcon_s3El.setAttribute('class', String(__v)); else __LoaderCircleIcon_s3El.removeAttribute('class') }
+      { const __x = size
+      if (!(16 in __l) || !Object.is(__l[16], __x)) {
+        { const __v = __x; if (__v != null) __LoaderCircleIcon_s3El.setAttribute('size', String(__v)); else __LoaderCircleIcon_s3El.removeAttribute('size') }
+      }
+      __l[16] = __x }
+      { const __x = className
+      if (!(17 in __l) || !Object.is(__l[17], __x)) {
+        { const __v = __x; if (__v != null) __LoaderCircleIcon_s3El.setAttribute('class', String(__v)); else __LoaderCircleIcon_s3El.removeAttribute('class') }
+      }
+      __l[17] = __x }
     }
     const [__PanelLeftIcon_s2El] = $c(__scope, 's2')
     if (__PanelLeftIcon_s2El) {
-      { const __v = size; if (__v != null) __PanelLeftIcon_s2El.setAttribute('size', String(__v)); else __PanelLeftIcon_s2El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __PanelLeftIcon_s2El.setAttribute('class', String(__v)); else __PanelLeftIcon_s2El.removeAttribute('class') }
+      { const __x = size
+      if (!(18 in __l) || !Object.is(__l[18], __x)) {
+        { const __v = __x; if (__v != null) __PanelLeftIcon_s2El.setAttribute('size', String(__v)); else __PanelLeftIcon_s2El.removeAttribute('size') }
+      }
+      __l[18] = __x }
+      { const __x = className
+      if (!(19 in __l) || !Object.is(__l[19], __x)) {
+        { const __v = __x; if (__v != null) __PanelLeftIcon_s2El.setAttribute('class', String(__v)); else __PanelLeftIcon_s2El.removeAttribute('class') }
+      }
+      __l[19] = __x }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('GitHubIcon', _s11, forwardProps(_p, { get size() { return size }, get className() { return className } }, ["size","className"]))
@@ -2862,11 +3170,16 @@ export function initDataTableColumnHeader(__scope, _p = {}) {
     __bfw_s0('s0', escapeTextOrNode(__val))
   })
 
+  { const __l = []
   createEffect(() => {
     if (_s6) {
-      { const __v = `${columnHeaderClasses} ${(_p.className ?? '')}`; if (__v != null) _s6.setAttribute('class', String(__v)); else _s6.removeAttribute('class') }
+      { const __x = `${columnHeaderClasses} ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s6.setAttribute('class', String(__v)); else _s6.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   insert(__scope, 's1', () => sorted === 'asc', {
     template: () => { const __slots = []; return { html: `<!--bf-cond-start:s1-->${renderChild('ChevronUpIcon', {size: "sm"}, undefined, 's2')}<!--bf-cond-end:s1-->`, slots: __slots } },
@@ -2925,23 +3238,38 @@ export function initDataTablePagination(__scope, _p = {}) {
   const [_s1, _s3, _s4] = $(__scope, 's1', 's3', 's4')
   const [_s0, _s2] = $c(__scope, 's0', 's2')
 
+  { const __l = []
   createEffect(() => {
     if (_s4) {
-      { const __v = `${paginationClasses} ${(_p.className ?? '')}`; if (__v != null) _s4.setAttribute('class', String(__v)); else _s4.removeAttribute('class') }
+      { const __x = `${paginationClasses} ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s4.setAttribute('class', String(__v)); else _s4.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
+  { const __l = []
   createEffect(() => {
     if (_s1) {
-      _s1.disabled = !!(!_p.canPrev)
+      { const __x = !_p.canPrev
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        _s1.disabled = !!(__x)
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
+  { const __l = []
   createEffect(() => {
     if (_s3) {
-      _s3.disabled = !!(!_p.canNext)
+      { const __x = !_p.canNext
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        _s3.disabled = !!(__x)
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s4) applyRestAttrs(_s4, _p, ["canPrev","canNext","onPrev","onNext","children","className","data-slot","class"])
 
@@ -2997,17 +3325,42 @@ export function initCheckbox(__scope, _p = {}) {
   const [_s2, _s0] = $(__scope, 's2', 's0')
   const [_s1] = $c(__scope, 's1')
 
+  { const __l = []
   createEffect(() => {
     if (_s2) {
-      { const __v = `${isChecked() ? 'checked' : 'unchecked'}`; if (__v != null) _s2.setAttribute('data-state', String(__v)); else _s2.removeAttribute('data-state') }
-      { const __v = _p.id; if (__v != null) _s2.setAttribute('id', String(__v)); else _s2.removeAttribute('id') }
-      { const __v = isChecked(); if (__v != null) _s2.setAttribute('aria-checked', String(__v)); else _s2.removeAttribute('aria-checked') }
-      if (_p.error) _s2.setAttribute('aria-invalid', 'true')
-      else _s2.removeAttribute('aria-invalid')
-      _s2.disabled = !!(_p.disabled ?? false)
-      { const __v = classes(); if (__v != null) _s2.setAttribute('class', String(__v)); else _s2.removeAttribute('class') }
+      { const __x = `${isChecked() ? 'checked' : 'unchecked'}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s2.setAttribute('data-state', String(__v)); else _s2.removeAttribute('data-state') }
+      }
+      __l[0] = __x }
+      { const __x = _p.id
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s2.setAttribute('id', String(__v)); else _s2.removeAttribute('id') }
+      }
+      __l[1] = __x }
+      { const __x = isChecked()
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        { const __v = __x; if (__v != null) _s2.setAttribute('aria-checked', String(__v)); else _s2.removeAttribute('aria-checked') }
+      }
+      __l[2] = __x }
+      { const __x = _p.error
+      if (!(3 in __l) || !Object.is(__l[3], __x)) {
+        if (__x) _s2.setAttribute('aria-invalid', 'true')
+        else _s2.removeAttribute('aria-invalid')
+      }
+      __l[3] = __x }
+      { const __x = _p.disabled ?? false
+      if (!(4 in __l) || !Object.is(__l[4], __x)) {
+        _s2.disabled = !!(__x)
+      }
+      __l[4] = __x }
+      { const __x = classes()
+      if (!(5 in __l) || !Object.is(__l[5], __x)) {
+        { const __v = __x; if (__v != null) _s2.setAttribute('class', String(__v)); else _s2.removeAttribute('class') }
+      }
+      __l[5] = __x }
     }
-  })
+  }) }
 
   insert(__scope, 's0', () => isChecked(), {
     template: () => { const __slots = []; return { html: `<!--bf-cond-start:s0-->${renderChild('CheckIcon', {"data-slot": "checkbox-indicator", className: "size-3.5 text-current"}, undefined, 's1')}<!--bf-cond-end:s0-->`, slots: __slots } },
@@ -3091,16 +3444,25 @@ export function initDataTablePreviewDemo(__scope, _p = {}) {
 
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     const [__DataTableColumnHeader_s1El] = $c(__scope, 's1')
     if (__DataTableColumnHeader_s1El) {
-      { const __v = sortKey() === 'status' ? sortDir() : false; if (__v != null) __DataTableColumnHeader_s1El.setAttribute('sorted', String(__v)); else __DataTableColumnHeader_s1El.removeAttribute('sorted') }
+      { const __x = sortKey() === 'status' ? sortDir() : false
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) __DataTableColumnHeader_s1El.setAttribute('sorted', String(__v)); else __DataTableColumnHeader_s1El.removeAttribute('sorted') }
+      }
+      __l[0] = __x }
     }
     const [__DataTableColumnHeader_s4El] = $c(__scope, 's4')
     if (__DataTableColumnHeader_s4El) {
-      { const __v = sortKey() === 'amount' ? sortDir() : false; if (__v != null) __DataTableColumnHeader_s4El.setAttribute('sorted', String(__v)); else __DataTableColumnHeader_s4El.removeAttribute('sorted') }
+      { const __x = sortKey() === 'amount' ? sortDir() : false
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) __DataTableColumnHeader_s4El.setAttribute('sorted', String(__v)); else __DataTableColumnHeader_s4El.removeAttribute('sorted') }
+      }
+      __l[1] = __x }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('Table', _s18, {})
@@ -3224,21 +3586,38 @@ export function initDataTableUsageDemo(__scope, _p = {}) {
 
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     const [__DataTableColumnHeader_s1El] = $c(__scope, 's1')
     if (__DataTableColumnHeader_s1El) {
-      { const __v = sortKey() === 'status' ? sortDir() : false; if (__v != null) __DataTableColumnHeader_s1El.setAttribute('sorted', String(__v)); else __DataTableColumnHeader_s1El.removeAttribute('sorted') }
+      { const __x = sortKey() === 'status' ? sortDir() : false
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) __DataTableColumnHeader_s1El.setAttribute('sorted', String(__v)); else __DataTableColumnHeader_s1El.removeAttribute('sorted') }
+      }
+      __l[0] = __x }
     }
     const [__DataTableColumnHeader_s4El] = $c(__scope, 's4')
     if (__DataTableColumnHeader_s4El) {
-      { const __v = sortKey() === 'amount' ? sortDir() : false; if (__v != null) __DataTableColumnHeader_s4El.setAttribute('sorted', String(__v)); else __DataTableColumnHeader_s4El.removeAttribute('sorted') }
+      { const __x = sortKey() === 'amount' ? sortDir() : false
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) __DataTableColumnHeader_s4El.setAttribute('sorted', String(__v)); else __DataTableColumnHeader_s4El.removeAttribute('sorted') }
+      }
+      __l[1] = __x }
     }
     const [__DataTablePagination_s21El] = $c(__scope, 's21')
     if (__DataTablePagination_s21El) {
-      { const __v = page() > 0; if (__v != null) __DataTablePagination_s21El.setAttribute('canPrev', String(__v)); else __DataTablePagination_s21El.removeAttribute('canPrev') }
-      { const __v = page() < pageCount() - 1; if (__v != null) __DataTablePagination_s21El.setAttribute('canNext', String(__v)); else __DataTablePagination_s21El.removeAttribute('canNext') }
+      { const __x = page() > 0
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        { const __v = __x; if (__v != null) __DataTablePagination_s21El.setAttribute('canPrev', String(__v)); else __DataTablePagination_s21El.removeAttribute('canPrev') }
+      }
+      __l[2] = __x }
+      { const __x = page() < pageCount() - 1
+      if (!(3 in __l) || !Object.is(__l[3], __x)) {
+        { const __v = __x; if (__v != null) __DataTablePagination_s21El.setAttribute('canNext', String(__v)); else __DataTablePagination_s21El.removeAttribute('canNext') }
+      }
+      __l[3] = __x }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('Table', _s18, {})
@@ -3407,23 +3786,37 @@ export function initDataTableFilteringDemo(__scope, _p = {}) {
     __bfw_s19('^s19', escapeTextOrNode(__val))
   })
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      const __val = String(filter())
-      if ('value' in _s0) { if (_s0.value !== __val) _s0.value = __val } else { _s0.setAttribute('value', __val) }
+      { const __x = filter()
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        const __val = String(__x)
+        if ('value' in _s0) { if (_s0.value !== __val) _s0.value = __val } else { _s0.setAttribute('value', __val) }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) _s0.addEventListener('input', handleFilterInput)
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     const [__DataTablePagination_s20El] = $c(__scope, 's20')
     if (__DataTablePagination_s20El) {
-      { const __v = page() > 0; if (__v != null) __DataTablePagination_s20El.setAttribute('canPrev', String(__v)); else __DataTablePagination_s20El.removeAttribute('canPrev') }
-      { const __v = page() < pageCount() - 1; if (__v != null) __DataTablePagination_s20El.setAttribute('canNext', String(__v)); else __DataTablePagination_s20El.removeAttribute('canNext') }
+      { const __x = page() > 0
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) __DataTablePagination_s20El.setAttribute('canPrev', String(__v)); else __DataTablePagination_s20El.removeAttribute('canPrev') }
+      }
+      __l[0] = __x }
+      { const __x = page() < pageCount() - 1
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) __DataTablePagination_s20El.setAttribute('canNext', String(__v)); else __DataTablePagination_s20El.removeAttribute('canNext') }
+      }
+      __l[1] = __x }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('Table', _s17, {})
@@ -3549,12 +3942,17 @@ export function initDataTableSelectionDemo(__scope, _p = {}) {
   })
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     const [__Checkbox_s0El] = $c(__scope, 's0')
     if (__Checkbox_s0El) {
-      __Checkbox_s0El.checked = !!(isAllSelected())
+      { const __x = isAllSelected()
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        __Checkbox_s0El.checked = !!(__x)
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('Table', _s20, {})

--- a/packages/adapter-tests/fixtures/__snapshots__/details-shared.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/details-shared.client.js
@@ -9,11 +9,16 @@ export function initDetailsFaq(__scope, _p = {}) {
 
   const [_s0, _s1] = $(__scope, 's0', 's1')
 
+  { const __l = []
   createEffect(() => {
     if (_s1) {
-      _s1.open = !!(open())
+      { const __x = open()
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        _s1.open = !!(__x)
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) _s0.addEventListener('click', (e) => {
           e.preventDefault()

--- a/packages/adapter-tests/fixtures/__snapshots__/dialog.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/dialog.client.js
@@ -53,13 +53,26 @@ export function initDialogTrigger(__scope, _p = {}) {
 
   const [_s1, _s0] = $(__scope, 's1', 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = _p.id; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
-      { const __v = `${dialogTriggerClasses} ${_p.className ?? ''}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
-      _s0.disabled = !!(_p.disabled ?? false)
+      { const __x = _p.id
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
+      }
+      __l[0] = __x }
+      { const __x = `${dialogTriggerClasses} ${_p.className ?? ''}`
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[1] = __x }
+      { const __x = _p.disabled ?? false
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        _s0.disabled = !!(__x)
+      }
+      __l[2] = __x }
     }
-  })
+  }) }
 
   if (_s1) (handleMount)(_s1)
   if (_s0) (handleMount)(_s0)
@@ -99,12 +112,21 @@ export function initDialogOverlay(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = _p.id; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
-      { const __v = `${dialogOverlayBaseClasses} ${dialogOverlayClosedClasses} ${_p.className ?? ''}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = _p.id
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
+      }
+      __l[0] = __x }
+      { const __x = `${dialogOverlayBaseClasses} ${dialogOverlayClosedClasses} ${_p.className ?? ''}`
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[1] = __x }
     }
-  })
+  }) }
 
   if (_s0) (handleMount)(_s0)
 }
@@ -194,14 +216,31 @@ export function initDialogContent(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = _p.ariaLabelledby; if (__v != null) _s0.setAttribute('aria-labelledby', String(__v)); else _s0.removeAttribute('aria-labelledby') }
-      { const __v = _p.ariaDescribedby; if (__v != null) _s0.setAttribute('aria-describedby', String(__v)); else _s0.removeAttribute('aria-describedby') }
-      { const __v = _p.id; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
-      { const __v = `${dialogContentBaseClasses} ${dialogContentClosedClasses} ${_p.className ?? ''}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = _p.ariaLabelledby
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('aria-labelledby', String(__v)); else _s0.removeAttribute('aria-labelledby') }
+      }
+      __l[0] = __x }
+      { const __x = _p.ariaDescribedby
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('aria-describedby', String(__v)); else _s0.removeAttribute('aria-describedby') }
+      }
+      __l[1] = __x }
+      { const __x = _p.id
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
+      }
+      __l[2] = __x }
+      { const __x = `${dialogContentBaseClasses} ${dialogContentClosedClasses} ${_p.className ?? ''}`
+      if (!(3 in __l) || !Object.is(__l[3], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[3] = __x }
     }
-  })
+  }) }
 
   if (_s0) (handleMount)(_s0)
 }
@@ -216,11 +255,16 @@ export function initDialogHeader(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `${dialogHeaderClasses} ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `${dialogHeaderClasses} ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["className","children","data-slot","class"])
 
@@ -236,12 +280,21 @@ export function initDialogTitle(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = _p.id; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
-      { const __v = `${dialogTitleClasses} ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = _p.id
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
+      }
+      __l[0] = __x }
+      { const __x = `${dialogTitleClasses} ${(_p.className ?? '')}`
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[1] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["className","id","children","data-slot","class"])
 
@@ -257,12 +310,21 @@ export function initDialogDescription(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = _p.id; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
-      { const __v = `${dialogDescriptionClasses} ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = _p.id
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
+      }
+      __l[0] = __x }
+      { const __x = `${dialogDescriptionClasses} ${(_p.className ?? '')}`
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[1] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["className","id","children","data-slot","class"])
 
@@ -278,11 +340,16 @@ export function initDialogFooter(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `${dialogFooterClasses} ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `${dialogFooterClasses} ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["className","children","data-slot","class"])
 
@@ -307,12 +374,21 @@ export function initDialogClose(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = _p.id; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
-      { const __v = `${dialogCloseClasses} ${_p.className ?? ''}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = _p.id
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
+      }
+      __l[0] = __x }
+      { const __x = `${dialogCloseClasses} ${_p.className ?? ''}`
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[1] = __x }
     }
-  })
+  }) }
 
   if (_s0) (handleMount)(_s0)
 }
@@ -336,12 +412,17 @@ export function initDialogBasicDemo(__scope, _p = {}) {
   })
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     const [__Dialog_s9El] = $c(__scope, 's9')
     if (__Dialog_s9El) {
-      __Dialog_s9El.open = !!(open())
+      { const __x = open()
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        __Dialog_s9El.open = !!(__x)
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('Dialog', _s9, { get open() { return open() }, onOpenChange: setOpen })
@@ -380,18 +461,28 @@ export function initDialogFormDemo(__scope, _p = {}) {
   const [_s5, _s7] = $(__scope, '^s5', '^s7')
   const [_s10, _s0, _s1, _s9, _s4, _s2, _s3, _s8, _s6] = $c(__scope, 's10', 's0', 's1', 's9', 's4', 's2', 's3', 's8', 's6')
 
+  { const __l = []
   createEffect(() => {
     if (_s5) {
-      const __val = String(confirmText())
-      if ('value' in _s5) { if (_s5.value !== __val) _s5.value = __val } else { _s5.setAttribute('value', __val) }
+      { const __x = confirmText()
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        const __val = String(__x)
+        if ('value' in _s5) { if (_s5.value !== __val) _s5.value = __val } else { _s5.setAttribute('value', __val) }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
+  { const __l = []
   createEffect(() => {
     if (_s7) {
-      _s7.disabled = !!(!isConfirmed())
+      { const __x = !isConfirmed()
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        _s7.disabled = !!(__x)
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s5) _s5.addEventListener('input', (e) => { setConfirmText((e.target).value) })
   if (_s7) _s7.addEventListener('click', handleDelete)
@@ -404,12 +495,17 @@ export function initDialogFormDemo(__scope, _p = {}) {
   })
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     const [__Dialog_s10El] = $c(__scope, 's10')
     if (__Dialog_s10El) {
-      __Dialog_s10El.open = !!(open())
+      { const __x = open()
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        __Dialog_s10El.open = !!(__x)
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
   createEffect(() => {
     if (!open()) return
 
@@ -474,12 +570,17 @@ export function initDialogLongContentDemo(__scope, _p = {}) {
   })
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     const [__Dialog_s9El] = $c(__scope, 's9')
     if (__Dialog_s9El) {
-      __Dialog_s9El.open = !!(open())
+      { const __x = open()
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        __Dialog_s9El.open = !!(__x)
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('Dialog', _s9, { get open() { return open() }, onOpenChange: setOpen })

--- a/packages/adapter-tests/fixtures/__snapshots__/dropdown-menu.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/dropdown-menu.client.js
@@ -39,11 +39,16 @@ export function initCheckIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -144,11 +149,16 @@ export function initChevronDownIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -249,11 +259,16 @@ export function initChevronUpIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -354,11 +369,16 @@ export function initChevronLeftIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -459,11 +479,16 @@ export function initChevronRightIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -564,11 +589,16 @@ export function initXIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -669,11 +699,16 @@ export function initPlusIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -774,11 +809,16 @@ export function initMinusIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -879,11 +919,16 @@ export function initSunIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -984,11 +1029,16 @@ export function initMoonIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1089,11 +1139,16 @@ export function initMonitorIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1194,11 +1249,16 @@ export function initCopyIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1299,11 +1359,16 @@ export function initClipboardIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1404,11 +1469,16 @@ export function initClipboardCheckIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1509,11 +1579,16 @@ export function initMenuIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1614,11 +1689,16 @@ export function initArrowLeftIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1719,11 +1799,16 @@ export function initArrowRightIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1824,11 +1909,16 @@ export function initArrowUpDownIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1906,11 +1996,16 @@ export function initEllipsisIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1944,11 +2039,16 @@ export function initGitHubIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","class","aria-hidden"])
 
@@ -1982,11 +2082,16 @@ export function initSettingsIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2020,11 +2125,16 @@ export function initGlobeIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2058,11 +2168,16 @@ export function initLogOutIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2096,11 +2211,16 @@ export function initCircleHelpIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2134,11 +2254,16 @@ export function initSearchIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2172,11 +2297,16 @@ export function initCircleCheckIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2210,11 +2340,16 @@ export function initCircleXIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2248,11 +2383,16 @@ export function initTriangleAlertIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2286,11 +2426,16 @@ export function initInfoIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2324,11 +2469,16 @@ export function initCalendarIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2362,11 +2512,16 @@ export function initGripVerticalIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2423,11 +2578,16 @@ export function initLoaderCircleIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2505,11 +2665,16 @@ export function initPanelLeftIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2576,77 +2741,180 @@ export function initIcon(__scope, _p = {}) {
   const [_s1, _s0] = $(__scope, 's1', 's0')
   const [_s11, _s10, _s9, _s8, _s7, _s6, _s5, _s4, _s3, _s2] = $c(__scope, 's11', 's10', 's9', 's8', 's7', 's6', 's5', 's4', 's3', 's2')
 
+  { const __l = []
   createEffect(() => {
     if (_s1) {
-      { const __v = sizeMap[(_p.size ?? 'md')]; if (__v != null) _s1.setAttribute('width', String(__v)); else _s1.removeAttribute('width') }
-      { const __v = sizeMap[(_p.size ?? 'md')]; if (__v != null) _s1.setAttribute('height', String(__v)); else _s1.removeAttribute('height') }
-      { const __v = (buttLinecapIcons).includes(_p.name) ? 'butt' : 'round'; if (__v != null) _s1.setAttribute('stroke-linecap', String(__v)); else _s1.removeAttribute('stroke-linecap') }
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s1.setAttribute('class', String(__v)); else _s1.removeAttribute('class') }
+      { const __x = sizeMap[(_p.size ?? 'md')]
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('width', String(__v)); else _s1.removeAttribute('width') }
+      }
+      __l[0] = __x }
+      { const __x = sizeMap[(_p.size ?? 'md')]
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('height', String(__v)); else _s1.removeAttribute('height') }
+      }
+      __l[1] = __x }
+      { const __x = (buttLinecapIcons).includes(_p.name) ? 'butt' : 'round'
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('stroke-linecap', String(__v)); else _s1.removeAttribute('stroke-linecap') }
+      }
+      __l[2] = __x }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(3 in __l) || !Object.is(__l[3], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('class', String(__v)); else _s1.removeAttribute('class') }
+      }
+      __l[3] = __x }
     }
-  })
+  }) }
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `${({"check": "M20 6 9 17l-5-5", "chevron-down": "m6 9 6 6 6-6", "chevron-up": "m18 15-6-6-6 6", "chevron-left": "m15 18-6-6 6-6", "chevron-right": "m9 18 6-6-6-6", "x": "M18 6 6 18M6 6l12 12", "plus": "M5 12h14M12 5v14", "minus": "M5 12h14", "sun": "M12 16a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41", "moon": "M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z", "monitor": "M20 3H4a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2zM8 21h8M12 17v4", "copy": "M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2M8 8h12a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V10a2 2 0 0 1 2-2z", "clipboard": "M9 2h6a1 1 0 0 1 1 1v1H8V3a1 1 0 0 1 1-1zM16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2", "clipboard-check": "M9 2h6a1 1 0 0 1 1 1v1H8V3a1 1 0 0 1 1-1zM16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2M9 14l2 2 4-4", "menu": "M4 6h16M4 12h16M4 18h16", "arrow-left": "m12 19-7-7 7-7M19 12H5", "arrow-right": "M5 12h14m-7-7 7 7-7 7", "ellipsis": "M5 12h.01M12 12h.01M19 12h.01", "arrow-up-down": "m21 16-4 4-4-4M17 20V4M3 8l4-4 4 4M7 4v16", "panel-left": "M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4M3 3h12v18H3zM9 3v18", "loader-circle": "M21 12a9 9 0 1 1-6.219-8.56"})[_p.name]}`; if (__v != null) _s0.setAttribute('d', String(__v)); else _s0.removeAttribute('d') }
+      { const __x = `${({"check": "M20 6 9 17l-5-5", "chevron-down": "m6 9 6 6 6-6", "chevron-up": "m18 15-6-6-6 6", "chevron-left": "m15 18-6-6 6-6", "chevron-right": "m9 18 6-6-6-6", "x": "M18 6 6 18M6 6l12 12", "plus": "M5 12h14M12 5v14", "minus": "M5 12h14", "sun": "M12 16a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41", "moon": "M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z", "monitor": "M20 3H4a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2zM8 21h8M12 17v4", "copy": "M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2M8 8h12a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V10a2 2 0 0 1 2-2z", "clipboard": "M9 2h6a1 1 0 0 1 1 1v1H8V3a1 1 0 0 1 1-1zM16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2", "clipboard-check": "M9 2h6a1 1 0 0 1 1 1v1H8V3a1 1 0 0 1 1-1zM16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2M9 14l2 2 4-4", "menu": "M4 6h16M4 12h16M4 18h16", "arrow-left": "m12 19-7-7 7-7M19 12H5", "arrow-right": "M5 12h14m-7-7 7 7-7 7", "ellipsis": "M5 12h.01M12 12h.01M19 12h.01", "arrow-up-down": "m21 16-4 4-4-4M17 20V4M3 8l4-4 4 4M7 4v16", "panel-left": "M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4M3 3h12v18H3zM9 3v18", "loader-circle": "M21 12a9 9 0 1 1-6.219-8.56"})[_p.name]}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('d', String(__v)); else _s0.removeAttribute('d') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s1) applyRestAttrs(_s1, _p, ["name","size","className","xmlns","width","height","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     const [__GitHubIcon_s11El] = $c(__scope, 's11')
     if (__GitHubIcon_s11El) {
-      { const __v = size; if (__v != null) __GitHubIcon_s11El.setAttribute('size', String(__v)); else __GitHubIcon_s11El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __GitHubIcon_s11El.setAttribute('class', String(__v)); else __GitHubIcon_s11El.removeAttribute('class') }
+      { const __x = size
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) __GitHubIcon_s11El.setAttribute('size', String(__v)); else __GitHubIcon_s11El.removeAttribute('size') }
+      }
+      __l[0] = __x }
+      { const __x = className
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) __GitHubIcon_s11El.setAttribute('class', String(__v)); else __GitHubIcon_s11El.removeAttribute('class') }
+      }
+      __l[1] = __x }
     }
     const [__SearchIcon_s10El] = $c(__scope, 's10')
     if (__SearchIcon_s10El) {
-      { const __v = size; if (__v != null) __SearchIcon_s10El.setAttribute('size', String(__v)); else __SearchIcon_s10El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __SearchIcon_s10El.setAttribute('class', String(__v)); else __SearchIcon_s10El.removeAttribute('class') }
+      { const __x = size
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        { const __v = __x; if (__v != null) __SearchIcon_s10El.setAttribute('size', String(__v)); else __SearchIcon_s10El.removeAttribute('size') }
+      }
+      __l[2] = __x }
+      { const __x = className
+      if (!(3 in __l) || !Object.is(__l[3], __x)) {
+        { const __v = __x; if (__v != null) __SearchIcon_s10El.setAttribute('class', String(__v)); else __SearchIcon_s10El.removeAttribute('class') }
+      }
+      __l[3] = __x }
     }
     const [__SettingsIcon_s9El] = $c(__scope, 's9')
     if (__SettingsIcon_s9El) {
-      { const __v = size; if (__v != null) __SettingsIcon_s9El.setAttribute('size', String(__v)); else __SettingsIcon_s9El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __SettingsIcon_s9El.setAttribute('class', String(__v)); else __SettingsIcon_s9El.removeAttribute('class') }
+      { const __x = size
+      if (!(4 in __l) || !Object.is(__l[4], __x)) {
+        { const __v = __x; if (__v != null) __SettingsIcon_s9El.setAttribute('size', String(__v)); else __SettingsIcon_s9El.removeAttribute('size') }
+      }
+      __l[4] = __x }
+      { const __x = className
+      if (!(5 in __l) || !Object.is(__l[5], __x)) {
+        { const __v = __x; if (__v != null) __SettingsIcon_s9El.setAttribute('class', String(__v)); else __SettingsIcon_s9El.removeAttribute('class') }
+      }
+      __l[5] = __x }
     }
     const [__GlobeIcon_s8El] = $c(__scope, 's8')
     if (__GlobeIcon_s8El) {
-      { const __v = size; if (__v != null) __GlobeIcon_s8El.setAttribute('size', String(__v)); else __GlobeIcon_s8El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __GlobeIcon_s8El.setAttribute('class', String(__v)); else __GlobeIcon_s8El.removeAttribute('class') }
+      { const __x = size
+      if (!(6 in __l) || !Object.is(__l[6], __x)) {
+        { const __v = __x; if (__v != null) __GlobeIcon_s8El.setAttribute('size', String(__v)); else __GlobeIcon_s8El.removeAttribute('size') }
+      }
+      __l[6] = __x }
+      { const __x = className
+      if (!(7 in __l) || !Object.is(__l[7], __x)) {
+        { const __v = __x; if (__v != null) __GlobeIcon_s8El.setAttribute('class', String(__v)); else __GlobeIcon_s8El.removeAttribute('class') }
+      }
+      __l[7] = __x }
     }
     const [__LogOutIcon_s7El] = $c(__scope, 's7')
     if (__LogOutIcon_s7El) {
-      { const __v = size; if (__v != null) __LogOutIcon_s7El.setAttribute('size', String(__v)); else __LogOutIcon_s7El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __LogOutIcon_s7El.setAttribute('class', String(__v)); else __LogOutIcon_s7El.removeAttribute('class') }
+      { const __x = size
+      if (!(8 in __l) || !Object.is(__l[8], __x)) {
+        { const __v = __x; if (__v != null) __LogOutIcon_s7El.setAttribute('size', String(__v)); else __LogOutIcon_s7El.removeAttribute('size') }
+      }
+      __l[8] = __x }
+      { const __x = className
+      if (!(9 in __l) || !Object.is(__l[9], __x)) {
+        { const __v = __x; if (__v != null) __LogOutIcon_s7El.setAttribute('class', String(__v)); else __LogOutIcon_s7El.removeAttribute('class') }
+      }
+      __l[9] = __x }
     }
     const [__CircleHelpIcon_s6El] = $c(__scope, 's6')
     if (__CircleHelpIcon_s6El) {
-      { const __v = size; if (__v != null) __CircleHelpIcon_s6El.setAttribute('size', String(__v)); else __CircleHelpIcon_s6El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __CircleHelpIcon_s6El.setAttribute('class', String(__v)); else __CircleHelpIcon_s6El.removeAttribute('class') }
+      { const __x = size
+      if (!(10 in __l) || !Object.is(__l[10], __x)) {
+        { const __v = __x; if (__v != null) __CircleHelpIcon_s6El.setAttribute('size', String(__v)); else __CircleHelpIcon_s6El.removeAttribute('size') }
+      }
+      __l[10] = __x }
+      { const __x = className
+      if (!(11 in __l) || !Object.is(__l[11], __x)) {
+        { const __v = __x; if (__v != null) __CircleHelpIcon_s6El.setAttribute('class', String(__v)); else __CircleHelpIcon_s6El.removeAttribute('class') }
+      }
+      __l[11] = __x }
     }
     const [__CalendarIcon_s5El] = $c(__scope, 's5')
     if (__CalendarIcon_s5El) {
-      { const __v = size; if (__v != null) __CalendarIcon_s5El.setAttribute('size', String(__v)); else __CalendarIcon_s5El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __CalendarIcon_s5El.setAttribute('class', String(__v)); else __CalendarIcon_s5El.removeAttribute('class') }
+      { const __x = size
+      if (!(12 in __l) || !Object.is(__l[12], __x)) {
+        { const __v = __x; if (__v != null) __CalendarIcon_s5El.setAttribute('size', String(__v)); else __CalendarIcon_s5El.removeAttribute('size') }
+      }
+      __l[12] = __x }
+      { const __x = className
+      if (!(13 in __l) || !Object.is(__l[13], __x)) {
+        { const __v = __x; if (__v != null) __CalendarIcon_s5El.setAttribute('class', String(__v)); else __CalendarIcon_s5El.removeAttribute('class') }
+      }
+      __l[13] = __x }
     }
     const [__GripVerticalIcon_s4El] = $c(__scope, 's4')
     if (__GripVerticalIcon_s4El) {
-      { const __v = size; if (__v != null) __GripVerticalIcon_s4El.setAttribute('size', String(__v)); else __GripVerticalIcon_s4El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __GripVerticalIcon_s4El.setAttribute('class', String(__v)); else __GripVerticalIcon_s4El.removeAttribute('class') }
+      { const __x = size
+      if (!(14 in __l) || !Object.is(__l[14], __x)) {
+        { const __v = __x; if (__v != null) __GripVerticalIcon_s4El.setAttribute('size', String(__v)); else __GripVerticalIcon_s4El.removeAttribute('size') }
+      }
+      __l[14] = __x }
+      { const __x = className
+      if (!(15 in __l) || !Object.is(__l[15], __x)) {
+        { const __v = __x; if (__v != null) __GripVerticalIcon_s4El.setAttribute('class', String(__v)); else __GripVerticalIcon_s4El.removeAttribute('class') }
+      }
+      __l[15] = __x }
     }
     const [__LoaderCircleIcon_s3El] = $c(__scope, 's3')
     if (__LoaderCircleIcon_s3El) {
-      { const __v = size; if (__v != null) __LoaderCircleIcon_s3El.setAttribute('size', String(__v)); else __LoaderCircleIcon_s3El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __LoaderCircleIcon_s3El.setAttribute('class', String(__v)); else __LoaderCircleIcon_s3El.removeAttribute('class') }
+      { const __x = size
+      if (!(16 in __l) || !Object.is(__l[16], __x)) {
+        { const __v = __x; if (__v != null) __LoaderCircleIcon_s3El.setAttribute('size', String(__v)); else __LoaderCircleIcon_s3El.removeAttribute('size') }
+      }
+      __l[16] = __x }
+      { const __x = className
+      if (!(17 in __l) || !Object.is(__l[17], __x)) {
+        { const __v = __x; if (__v != null) __LoaderCircleIcon_s3El.setAttribute('class', String(__v)); else __LoaderCircleIcon_s3El.removeAttribute('class') }
+      }
+      __l[17] = __x }
     }
     const [__PanelLeftIcon_s2El] = $c(__scope, 's2')
     if (__PanelLeftIcon_s2El) {
-      { const __v = size; if (__v != null) __PanelLeftIcon_s2El.setAttribute('size', String(__v)); else __PanelLeftIcon_s2El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __PanelLeftIcon_s2El.setAttribute('class', String(__v)); else __PanelLeftIcon_s2El.removeAttribute('class') }
+      { const __x = size
+      if (!(18 in __l) || !Object.is(__l[18], __x)) {
+        { const __v = __x; if (__v != null) __PanelLeftIcon_s2El.setAttribute('size', String(__v)); else __PanelLeftIcon_s2El.removeAttribute('size') }
+      }
+      __l[18] = __x }
+      { const __x = className
+      if (!(19 in __l) || !Object.is(__l[19], __x)) {
+        { const __v = __x; if (__v != null) __PanelLeftIcon_s2El.setAttribute('class', String(__v)); else __PanelLeftIcon_s2El.removeAttribute('class') }
+      }
+      __l[19] = __x }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('GitHubIcon', _s11, forwardProps(_p, { get size() { return size }, get className() { return className } }, ["size","className"]))
@@ -2742,13 +3010,26 @@ export function initDropdownMenuTrigger(__scope, _p = {}) {
 
   const [_s1, _s0] = $(__scope, 's1', 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = _p.id; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
-      _s0.disabled = !!(_p.disabled ?? false)
-      { const __v = `${dropdownMenuTriggerClasses} ${_p.className ?? ''}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = _p.id
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
+      }
+      __l[0] = __x }
+      { const __x = _p.disabled ?? false
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        _s0.disabled = !!(__x)
+      }
+      __l[1] = __x }
+      { const __x = `${dropdownMenuTriggerClasses} ${_p.className ?? ''}`
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[2] = __x }
     }
-  })
+  }) }
 
   if (_s1) (handleMount)(_s1)
   if (_s0) (handleMount)(_s0)
@@ -2905,12 +3186,21 @@ export function initDropdownMenuContent(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = _p.id; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
-      { const __v = `${dropdownMenuContentBaseClasses} ${dropdownMenuContentClosedClasses} ${_p.className ?? ''}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = _p.id
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
+      }
+      __l[0] = __x }
+      { const __x = `${dropdownMenuContentBaseClasses} ${dropdownMenuContentClosedClasses} ${_p.className ?? ''}`
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[1] = __x }
     }
-  })
+  }) }
 
   if (_s0) (handleMount)(_s0)
 }
@@ -2952,15 +3242,32 @@ export function initDropdownMenuItem(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = _p.id; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
-      if (isDisabled()) _s0.setAttribute('aria-disabled', 'true')
-      else _s0.removeAttribute('aria-disabled')
-      { const __v = isDisabled() ? -1 : 0; if (__v != null) _s0.setAttribute('tabindex', String(__v)); else _s0.removeAttribute('tabindex') }
-      { const __v = `${dropdownMenuItemBaseClasses} ${stateClasses()} ${_p.className ?? ''}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = _p.id
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
+      }
+      __l[0] = __x }
+      { const __x = isDisabled()
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        if (__x) _s0.setAttribute('aria-disabled', 'true')
+        else _s0.removeAttribute('aria-disabled')
+      }
+      __l[1] = __x }
+      { const __x = isDisabled() ? -1 : 0
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('tabindex', String(__v)); else _s0.removeAttribute('tabindex') }
+      }
+      __l[2] = __x }
+      { const __x = `${dropdownMenuItemBaseClasses} ${stateClasses()} ${_p.className ?? ''}`
+      if (!(3 in __l) || !Object.is(__l[3], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[3] = __x }
     }
-  })
+  }) }
 
   if (_s0) (handleMount)(_s0)
 }
@@ -2997,16 +3304,37 @@ export function initDropdownMenuCheckboxItem(__scope, _p = {}) {
   const [_s0, _s3] = $(__scope, 's0', 's3')
   const [_s1] = $c(__scope, 's1')
 
+  { const __l = []
   createEffect(() => {
     if (_s3) {
-      { const __v = _p.id; if (__v != null) _s3.setAttribute('id', String(__v)); else _s3.removeAttribute('id') }
-      { const __v = String(_p.checked ?? false); if (__v != null) _s3.setAttribute('aria-checked', String(__v)); else _s3.removeAttribute('aria-checked') }
-      if (isDisabled()) _s3.setAttribute('aria-disabled', 'true')
-      else _s3.removeAttribute('aria-disabled')
-      { const __v = isDisabled() ? -1 : 0; if (__v != null) _s3.setAttribute('tabindex', String(__v)); else _s3.removeAttribute('tabindex') }
-      { const __v = `${dropdownMenuCheckableItemClasses} ${isDisabled() ? dropdownMenuItemDisabledClasses : dropdownMenuItemDefaultClasses} ${_p.className ?? ''}`; if (__v != null) _s3.setAttribute('class', String(__v)); else _s3.removeAttribute('class') }
+      { const __x = _p.id
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s3.setAttribute('id', String(__v)); else _s3.removeAttribute('id') }
+      }
+      __l[0] = __x }
+      { const __x = String(_p.checked ?? false)
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s3.setAttribute('aria-checked', String(__v)); else _s3.removeAttribute('aria-checked') }
+      }
+      __l[1] = __x }
+      { const __x = isDisabled()
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        if (__x) _s3.setAttribute('aria-disabled', 'true')
+        else _s3.removeAttribute('aria-disabled')
+      }
+      __l[2] = __x }
+      { const __x = isDisabled() ? -1 : 0
+      if (!(3 in __l) || !Object.is(__l[3], __x)) {
+        { const __v = __x; if (__v != null) _s3.setAttribute('tabindex', String(__v)); else _s3.removeAttribute('tabindex') }
+      }
+      __l[3] = __x }
+      { const __x = `${dropdownMenuCheckableItemClasses} ${isDisabled() ? dropdownMenuItemDisabledClasses : dropdownMenuItemDefaultClasses} ${_p.className ?? ''}`
+      if (!(4 in __l) || !Object.is(__l[4], __x)) {
+        { const __v = __x; if (__v != null) _s3.setAttribute('class', String(__v)); else _s3.removeAttribute('class') }
+      }
+      __l[4] = __x }
     }
-  })
+  }) }
 
   insert(__scope, 's0', () => (_p.checked ?? false), {
     template: () => { const __slots = []; return { html: `<!--bf-cond-start:s0-->${renderChild('CheckIcon', {className: "size-4"}, undefined, 's1')}<!--bf-cond-end:s0-->`, slots: __slots } },
@@ -3069,15 +3397,32 @@ export function initDropdownMenuRadioItem(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = _p.id; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
-      if (isDisabled()) _s0.setAttribute('aria-disabled', 'true')
-      else _s0.removeAttribute('aria-disabled')
-      { const __v = isDisabled() ? -1 : 0; if (__v != null) _s0.setAttribute('tabindex', String(__v)); else _s0.removeAttribute('tabindex') }
-      { const __v = `${dropdownMenuCheckableItemClasses} ${isDisabled() ? dropdownMenuItemDisabledClasses : dropdownMenuItemDefaultClasses} ${_p.className ?? ''}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = _p.id
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
+      }
+      __l[0] = __x }
+      { const __x = isDisabled()
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        if (__x) _s0.setAttribute('aria-disabled', 'true')
+        else _s0.removeAttribute('aria-disabled')
+      }
+      __l[1] = __x }
+      { const __x = isDisabled() ? -1 : 0
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('tabindex', String(__v)); else _s0.removeAttribute('tabindex') }
+      }
+      __l[2] = __x }
+      { const __x = `${dropdownMenuCheckableItemClasses} ${isDisabled() ? dropdownMenuItemDisabledClasses : dropdownMenuItemDefaultClasses} ${_p.className ?? ''}`
+      if (!(3 in __l) || !Object.is(__l[3], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[3] = __x }
     }
-  })
+  }) }
 
   if (_s0) (handleMount)(_s0)
 }
@@ -3143,15 +3488,32 @@ export function initDropdownMenuSubTrigger(__scope, _p = {}) {
   const [_s1] = $(__scope, 's1')
   const [_s0] = $c(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s1) {
-      { const __v = _p.id; if (__v != null) _s1.setAttribute('id', String(__v)); else _s1.removeAttribute('id') }
-      if (isDisabled) _s1.setAttribute('aria-disabled', 'true')
-      else _s1.removeAttribute('aria-disabled')
-      { const __v = isDisabled ? -1 : 0; if (__v != null) _s1.setAttribute('tabindex', String(__v)); else _s1.removeAttribute('tabindex') }
-      { const __v = `${dropdownMenuSubTriggerClasses} ${isDisabled ? dropdownMenuItemDisabledClasses : dropdownMenuItemDefaultClasses} ${_p.className ?? ''}`; if (__v != null) _s1.setAttribute('class', String(__v)); else _s1.removeAttribute('class') }
+      { const __x = _p.id
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('id', String(__v)); else _s1.removeAttribute('id') }
+      }
+      __l[0] = __x }
+      { const __x = isDisabled
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        if (__x) _s1.setAttribute('aria-disabled', 'true')
+        else _s1.removeAttribute('aria-disabled')
+      }
+      __l[1] = __x }
+      { const __x = isDisabled ? -1 : 0
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('tabindex', String(__v)); else _s1.removeAttribute('tabindex') }
+      }
+      __l[2] = __x }
+      { const __x = `${dropdownMenuSubTriggerClasses} ${isDisabled ? dropdownMenuItemDisabledClasses : dropdownMenuItemDefaultClasses} ${_p.className ?? ''}`
+      if (!(3 in __l) || !Object.is(__l[3], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('class', String(__v)); else _s1.removeAttribute('class') }
+      }
+      __l[3] = __x }
     }
-  })
+  }) }
 
   if (_s1) (handleMount)(_s1)
 
@@ -3230,12 +3592,21 @@ export function initDropdownMenuSubContent(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = _p.id; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
-      { const __v = `${dropdownMenuSubContentBaseClasses} left-full top-0 ${_p.className ?? ''}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = _p.id
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
+      }
+      __l[0] = __x }
+      { const __x = `${dropdownMenuSubContentBaseClasses} left-full top-0 ${_p.className ?? ''}`
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[1] = __x }
     }
-  })
+  }) }
 
   if (_s0) (handleMount)(_s0)
 }
@@ -3250,11 +3621,16 @@ export function initDropdownMenuLabel(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `${dropdownMenuLabelClasses} ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `${dropdownMenuLabelClasses} ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot","class"])
 
@@ -3270,11 +3646,16 @@ export function initDropdownMenuSeparator(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `${dropdownMenuSeparatorClasses} ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `${dropdownMenuSeparatorClasses} ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["className","data-slot","role","class"])
 
@@ -3290,11 +3671,16 @@ export function initDropdownMenuShortcut(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `${dropdownMenuShortcutClasses} ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `${dropdownMenuShortcutClasses} ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot","class"])
 
@@ -3308,11 +3694,16 @@ export function initDropdownMenuGroup(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = (_p.className ?? ''); if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = (_p.className ?? '')
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot","role","class"])
 
@@ -3337,11 +3728,16 @@ export function initDropdownMenuBasicDemo(__scope, _p = {}) {
   })
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     if (__scope) {
-      __scope.open = !!(open())
+      { const __x = open()
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        __scope.open = !!(__x)
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('DropdownMenu', __scope, { get open() { return open() }, onOpenChange: setOpen })
@@ -3382,19 +3778,32 @@ export function initDropdownMenuCheckboxDemo(__scope, _p = {}) {
   })
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     if (__scope) {
-      __scope.open = !!(open())
+      { const __x = open()
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        __scope.open = !!(__x)
+      }
+      __l[0] = __x }
     }
     const [__DropdownMenuCheckboxItem_s3El] = $c(__scope, 's3')
     if (__DropdownMenuCheckboxItem_s3El) {
-      __DropdownMenuCheckboxItem_s3El.checked = !!(showStatus())
+      { const __x = showStatus()
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        __DropdownMenuCheckboxItem_s3El.checked = !!(__x)
+      }
+      __l[1] = __x }
     }
     const [__DropdownMenuCheckboxItem_s4El] = $c(__scope, 's4')
     if (__DropdownMenuCheckboxItem_s4El) {
-      __DropdownMenuCheckboxItem_s4El.checked = !!(showActivity())
+      { const __x = showActivity()
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        __DropdownMenuCheckboxItem_s4El.checked = !!(__x)
+      }
+      __l[2] = __x }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('DropdownMenu', __scope, { get open() { return open() }, onOpenChange: setOpen })
@@ -3437,9 +3846,14 @@ export function initDropdownMenuProfileDemo(__scope, _p = {}) {
   })
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     if (__scope) {
-      __scope.open = !!(open())
+      { const __x = open()
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        __scope.open = !!(__x)
+      }
+      __l[0] = __x }
     }
     const [__DropdownMenuRadioGroup_s11El] = $c(__scope, 's11')
     if (__DropdownMenuRadioGroup_s11El) {
@@ -3447,13 +3861,21 @@ export function initDropdownMenuProfileDemo(__scope, _p = {}) {
     }
     const [__DropdownMenuCheckboxItem_s18El] = $c(__scope, 's18')
     if (__DropdownMenuCheckboxItem_s18El) {
-      __DropdownMenuCheckboxItem_s18El.checked = !!(showBookmarks())
+      { const __x = showBookmarks()
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        __DropdownMenuCheckboxItem_s18El.checked = !!(__x)
+      }
+      __l[1] = __x }
     }
     const [__DropdownMenuCheckboxItem_s19El] = $c(__scope, 's19')
     if (__DropdownMenuCheckboxItem_s19El) {
-      __DropdownMenuCheckboxItem_s19El.checked = !!(showToolbar())
+      { const __x = showToolbar()
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        __DropdownMenuCheckboxItem_s19El.checked = !!(__x)
+      }
+      __l[2] = __x }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('DropdownMenu', __scope, { get open() { return open() }, onOpenChange: setOpen })

--- a/packages/adapter-tests/fixtures/__snapshots__/form.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/form.client.js
@@ -9,20 +9,42 @@ export function initForm(__scope, _p = {}) {
 
   const [_s1, _s0, _s2] = $(__scope, 's1', 's0', 's2')
 
+  { const __l = []
   createEffect(() => {
     if (_s1) {
-      { const __v = `${accepted() ? 'checked' : 'unchecked'}`; if (__v != null) _s1.setAttribute('data-state', String(__v)); else _s1.removeAttribute('data-state') }
-      { const __v = styleToCss(`width: 24px; height: 24px; border: 2px solid ${accepted() ? '#4caf50' : '#ccc'}; border-radius: 4px; background: ${accepted() ? '#4caf50' : 'white'}; cursor: pointer; display: flex; align-items: center; justify-content: center; padding: 0;`); if (__v != null) _s1.setAttribute('style', __v); else _s1.removeAttribute('style') }
-      { const __v = accepted(); if (__v != null) _s1.setAttribute('aria-checked', String(__v)); else _s1.removeAttribute('aria-checked') }
+      { const __x = `${accepted() ? 'checked' : 'unchecked'}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('data-state', String(__v)); else _s1.removeAttribute('data-state') }
+      }
+      __l[0] = __x }
+      { const __x = `width: 24px; height: 24px; border: 2px solid ${accepted() ? '#4caf50' : '#ccc'}; border-radius: 4px; background: ${accepted() ? '#4caf50' : 'white'}; cursor: pointer; display: flex; align-items: center; justify-content: center; padding: 0;`
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = styleToCss(__x); if (__v != null) _s1.setAttribute('style', __v); else _s1.removeAttribute('style') }
+      }
+      __l[1] = __x }
+      { const __x = accepted()
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('aria-checked', String(__v)); else _s1.removeAttribute('aria-checked') }
+      }
+      __l[2] = __x }
     }
-  })
+  }) }
 
+  { const __l = []
   createEffect(() => {
     if (_s2) {
-      _s2.disabled = !!(!accepted())
-      { const __v = styleToCss(`width: 100%; padding: 12px 24px; font-size: 16px; border: none; border-radius: 6px; cursor: ${accepted() ? 'pointer' : 'not-allowed'}; background: ${accepted() ? '#4caf50' : '#e0e0e0'}; color: ${accepted() ? 'white' : '#999'};`); if (__v != null) _s2.setAttribute('style', __v); else _s2.removeAttribute('style') }
+      { const __x = !accepted()
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        _s2.disabled = !!(__x)
+      }
+      __l[0] = __x }
+      { const __x = `width: 100%; padding: 12px 24px; font-size: 16px; border: none; border-radius: 6px; cursor: ${accepted() ? 'pointer' : 'not-allowed'}; background: ${accepted() ? '#4caf50' : '#e0e0e0'}; color: ${accepted() ? 'white' : '#999'};`
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = styleToCss(__x); if (__v != null) _s2.setAttribute('style', __v); else _s2.removeAttribute('style') }
+      }
+      __l[1] = __x }
     }
-  })
+  }) }
 
   insert(__scope, 's0', () => accepted(), {
     template: () => { const __slots = []; return { html: `<svg bf-c="s0" class="checkmark" width="16" height="16" viewBox="0 0 16 16" fill="none" style="display: block;"><path d="M3 8L6.5 11.5L13 5" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path></svg>`, slots: __slots } },

--- a/packages/adapter-tests/fixtures/__snapshots__/input.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/input.client.js
@@ -11,12 +11,21 @@ export function initInput(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = _p.type; if (__v != null) _s0.setAttribute('type', String(__v)); else _s0.removeAttribute('type') }
-      { const __v = `${baseClasses} ${focusClasses} ${errorClasses} ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = _p.type
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('type', String(__v)); else _s0.removeAttribute('type') }
+      }
+      __l[0] = __x }
+      { const __x = `${baseClasses} ${focusClasses} ${errorClasses} ${(_p.className ?? '')}`
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[1] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["className","type","data-slot","class"])
 

--- a/packages/adapter-tests/fixtures/__snapshots__/kbd.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/kbd.client.js
@@ -15,12 +15,17 @@ export function initSlot(__scope, _p = {}) {
 
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     const [__Tag_s0El] = $c(__scope, 's0')
     if (__Tag_s0El) {
-      { const __v = ([className, (((children.props).className) || '')].filter(Boolean).join(' ')); if (__v != null) __Tag_s0El.setAttribute('class', String(__v)); else __Tag_s0El.removeAttribute('class') }
+      { const __x = ([className, (((children.props).className) || '')].filter(Boolean).join(' '))
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) __Tag_s0El.setAttribute('class', String(__v)); else __Tag_s0El.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('Tag', _s0, forwardProps(_p, { get className() { return ([className, (((children.props).className) || '')].filter(Boolean).join(' ')) } }, ["className"]))
@@ -39,22 +44,32 @@ export function initKbd(__scope, _p = {}) {
   const [_s0] = $(__scope, 's0')
   const [_s1] = $c(__scope, 's1')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `pointer-events-none inline-flex h-5 w-fit min-w-5 items-center justify-center gap-1 rounded-sm border bg-muted px-1 font-sans text-xs font-medium text-muted-foreground select-none [&_svg:not([class*=size-])]:size-3 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `pointer-events-none inline-flex h-5 w-fit min-w-5 items-center justify-center gap-1 rounded-sm border bg-muted px-1 font-sans text-xs font-medium text-muted-foreground select-none [&_svg:not([class*=size-])]:size-3 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["className","asChild","children","data-slot","class"])
 
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     const [__Slot_s1El] = $c(__scope, 's1')
     if (__Slot_s1El) {
-      { const __v = `pointer-events-none inline-flex h-5 w-fit min-w-5 items-center justify-center gap-1 rounded-sm border bg-muted px-1 font-sans text-xs font-medium text-muted-foreground select-none [&_svg:not([class*=size-])]:size-3 ${className}`; if (__v != null) __Slot_s1El.setAttribute('class', String(__v)); else __Slot_s1El.removeAttribute('class') }
+      { const __x = `pointer-events-none inline-flex h-5 w-fit min-w-5 items-center justify-center gap-1 rounded-sm border bg-muted px-1 font-sans text-xs font-medium text-muted-foreground select-none [&_svg:not([class*=size-])]:size-3 ${className}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) __Slot_s1El.setAttribute('class', String(__v)); else __Slot_s1El.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('Slot', _s1, forwardProps(_p, { get className() { return `pointer-events-none inline-flex h-5 w-fit min-w-5 items-center justify-center gap-1 rounded-sm border bg-muted px-1 font-sans text-xs font-medium text-muted-foreground select-none [&_svg:not([class*=size-])]:size-3 ${className}` } }, ["className"]))
@@ -73,22 +88,32 @@ export function initKbdGroup(__scope, _p = {}) {
   const [_s0] = $(__scope, 's0')
   const [_s1] = $c(__scope, 's1')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `inline-flex items-center gap-1 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `inline-flex items-center gap-1 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["className","asChild","children","data-slot","class"])
 
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     const [__Slot_s1El] = $c(__scope, 's1')
     if (__Slot_s1El) {
-      { const __v = `inline-flex items-center gap-1 ${className}`; if (__v != null) __Slot_s1El.setAttribute('class', String(__v)); else __Slot_s1El.removeAttribute('class') }
+      { const __x = `inline-flex items-center gap-1 ${className}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) __Slot_s1El.setAttribute('class', String(__v)); else __Slot_s1El.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('Slot', _s1, forwardProps(_p, { get className() { return `inline-flex items-center gap-1 ${className}` } }, ["className"]))

--- a/packages/adapter-tests/fixtures/__snapshots__/keyed-loop-index-reorder.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/keyed-loop-index-reorder.client.js
@@ -35,9 +35,9 @@ export function initKeyedLoopIndexReorder(__scope, _p = {}) {
       const __l = __e.last = []
       { const __t = __r[0]
       if (__t) {
-        const __x = `${selected() === i ? 'row selected' : 'row'}`
+        { const __x = `${selected() === i ? 'row selected' : 'row'}`
         { const __v = __x; if (__v != null) __t.setAttribute('class', String(__v)); else __t.removeAttribute('class') }
-        __l[0] = __x
+        __l[0] = __x }
       } }
       { const __x = String(i + 1)
       __r[1]('s1', textOrNode(__x))
@@ -54,11 +54,11 @@ export function initKeyedLoopIndexReorder(__scope, _p = {}) {
       const __l = __e.last ?? (__e.last = [])
       { const __t = 0 in __r ? __r[0] : (__r[0] = qsa(__e.primaryEl, '[bf="s3"]'))
       if (__t) {
-        const __x = `${selected() === i ? 'row selected' : 'row'}`
+        { const __x = `${selected() === i ? 'row selected' : 'row'}`
         if (!(0 in __l) || !Object.is(__l[0], __x)) {
           { const __v = __x; if (__v != null) __t.setAttribute('class', String(__v)); else __t.removeAttribute('class') }
         }
-        __l[0] = __x
+        __l[0] = __x }
       } }
       const __d = __r[1] ?? (__r[1] = lazySlots(__e.primaryEl, __lzs_l0))
       { const __x = String(i + 1)
@@ -77,11 +77,11 @@ export function initKeyedLoopIndexReorder(__scope, _p = {}) {
         const __l = __e.last ?? (__e.last = [])
         { const __t = 0 in __r ? __r[0] : (__r[0] = qsa(__e.primaryEl, '[bf="s3"]'))
         if (__t) {
-          const __x = `${selected() === i ? 'row selected' : 'row'}`
+          { const __x = `${selected() === i ? 'row selected' : 'row'}`
           if (__seed ? (__t.getAttribute('class') !== (__x != null ? String(__x) : null)) : (!(0 in __l) || !Object.is(__l[0], __x))) {
             { const __v = __x; if (__v != null) __t.setAttribute('class', String(__v)); else __t.removeAttribute('class') }
           }
-          __l[0] = __x
+          __l[0] = __x }
         } }
       }
     },

--- a/packages/adapter-tests/fixtures/__snapshots__/label.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/label.client.js
@@ -9,11 +9,16 @@ export function initLabel(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `${labelClasses} ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `${labelClasses} ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["className","children","data-slot","class"])
 

--- a/packages/adapter-tests/fixtures/__snapshots__/nested-cond-toggle-list.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/nested-cond-toggle-list.client.js
@@ -30,12 +30,21 @@ export function initNestedCondToggleList(__scope, _p = {}) {
         }
         const __disposers = []
         { const __ra_s2 = qsa(__branchScope, '[bf="s2"]')
+        const __l = []
         if (__ra_s2) {
           __disposers.push(createDisposableEffect(() => {
-            { const __v = `${item().active ? 'toggle-btn on' : 'toggle-btn'}`; if (__v != null) __ra_s2.setAttribute('class', String(__v)); else __ra_s2.removeAttribute('class') }
+            { const __x = `${item().active ? 'toggle-btn on' : 'toggle-btn'}`
+            if (!(0 in __l) || !Object.is(__l[0], __x)) {
+              { const __v = __x; if (__v != null) __ra_s2.setAttribute('class', String(__v)); else __ra_s2.removeAttribute('class') }
+            }
+            __l[0] = __x }
           }))
           __disposers.push(createDisposableEffect(() => {
-            { const __v = `toggle-${item().id}`; if (__v != null) __ra_s2.setAttribute('data-testid', String(__v)); else __ra_s2.removeAttribute('data-testid') }
+            { const __x = `toggle-${item().id}`
+            if (!(1 in __l) || !Object.is(__l[1], __x)) {
+              { const __v = __x; if (__v != null) __ra_s2.setAttribute('data-testid', String(__v)); else __ra_s2.removeAttribute('data-testid') }
+            }
+            __l[1] = __x }
           }))
         } }
         __disposers.push(createDisposableEffect(() => {

--- a/packages/adapter-tests/fixtures/__snapshots__/pagination.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/pagination.client.js
@@ -39,11 +39,16 @@ export function initCheckIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -144,11 +149,16 @@ export function initChevronDownIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -249,11 +259,16 @@ export function initChevronUpIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -354,11 +369,16 @@ export function initChevronLeftIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -459,11 +479,16 @@ export function initChevronRightIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -564,11 +589,16 @@ export function initXIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -669,11 +699,16 @@ export function initPlusIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -774,11 +809,16 @@ export function initMinusIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -879,11 +919,16 @@ export function initSunIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -984,11 +1029,16 @@ export function initMoonIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1089,11 +1139,16 @@ export function initMonitorIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1194,11 +1249,16 @@ export function initCopyIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1299,11 +1359,16 @@ export function initClipboardIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1404,11 +1469,16 @@ export function initClipboardCheckIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1509,11 +1579,16 @@ export function initMenuIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1614,11 +1689,16 @@ export function initArrowLeftIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1719,11 +1799,16 @@ export function initArrowRightIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1824,11 +1909,16 @@ export function initArrowUpDownIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1906,11 +1996,16 @@ export function initEllipsisIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1944,11 +2039,16 @@ export function initGitHubIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","class","aria-hidden"])
 
@@ -1982,11 +2082,16 @@ export function initSettingsIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2020,11 +2125,16 @@ export function initGlobeIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2058,11 +2168,16 @@ export function initLogOutIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2096,11 +2211,16 @@ export function initCircleHelpIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2134,11 +2254,16 @@ export function initSearchIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2172,11 +2297,16 @@ export function initCircleCheckIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2210,11 +2340,16 @@ export function initCircleXIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2248,11 +2383,16 @@ export function initTriangleAlertIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2286,11 +2426,16 @@ export function initInfoIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2324,11 +2469,16 @@ export function initCalendarIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2362,11 +2512,16 @@ export function initGripVerticalIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2423,11 +2578,16 @@ export function initLoaderCircleIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2505,11 +2665,16 @@ export function initPanelLeftIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2576,77 +2741,180 @@ export function initIcon(__scope, _p = {}) {
   const [_s1, _s0] = $(__scope, 's1', 's0')
   const [_s11, _s10, _s9, _s8, _s7, _s6, _s5, _s4, _s3, _s2] = $c(__scope, 's11', 's10', 's9', 's8', 's7', 's6', 's5', 's4', 's3', 's2')
 
+  { const __l = []
   createEffect(() => {
     if (_s1) {
-      { const __v = sizeMap[(_p.size ?? 'md')]; if (__v != null) _s1.setAttribute('width', String(__v)); else _s1.removeAttribute('width') }
-      { const __v = sizeMap[(_p.size ?? 'md')]; if (__v != null) _s1.setAttribute('height', String(__v)); else _s1.removeAttribute('height') }
-      { const __v = (buttLinecapIcons).includes(_p.name) ? 'butt' : 'round'; if (__v != null) _s1.setAttribute('stroke-linecap', String(__v)); else _s1.removeAttribute('stroke-linecap') }
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s1.setAttribute('class', String(__v)); else _s1.removeAttribute('class') }
+      { const __x = sizeMap[(_p.size ?? 'md')]
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('width', String(__v)); else _s1.removeAttribute('width') }
+      }
+      __l[0] = __x }
+      { const __x = sizeMap[(_p.size ?? 'md')]
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('height', String(__v)); else _s1.removeAttribute('height') }
+      }
+      __l[1] = __x }
+      { const __x = (buttLinecapIcons).includes(_p.name) ? 'butt' : 'round'
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('stroke-linecap', String(__v)); else _s1.removeAttribute('stroke-linecap') }
+      }
+      __l[2] = __x }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(3 in __l) || !Object.is(__l[3], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('class', String(__v)); else _s1.removeAttribute('class') }
+      }
+      __l[3] = __x }
     }
-  })
+  }) }
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `${({"check": "M20 6 9 17l-5-5", "chevron-down": "m6 9 6 6 6-6", "chevron-up": "m18 15-6-6-6 6", "chevron-left": "m15 18-6-6 6-6", "chevron-right": "m9 18 6-6-6-6", "x": "M18 6 6 18M6 6l12 12", "plus": "M5 12h14M12 5v14", "minus": "M5 12h14", "sun": "M12 16a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41", "moon": "M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z", "monitor": "M20 3H4a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2zM8 21h8M12 17v4", "copy": "M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2M8 8h12a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V10a2 2 0 0 1 2-2z", "clipboard": "M9 2h6a1 1 0 0 1 1 1v1H8V3a1 1 0 0 1 1-1zM16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2", "clipboard-check": "M9 2h6a1 1 0 0 1 1 1v1H8V3a1 1 0 0 1 1-1zM16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2M9 14l2 2 4-4", "menu": "M4 6h16M4 12h16M4 18h16", "arrow-left": "m12 19-7-7 7-7M19 12H5", "arrow-right": "M5 12h14m-7-7 7 7-7 7", "ellipsis": "M5 12h.01M12 12h.01M19 12h.01", "arrow-up-down": "m21 16-4 4-4-4M17 20V4M3 8l4-4 4 4M7 4v16", "panel-left": "M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4M3 3h12v18H3zM9 3v18", "loader-circle": "M21 12a9 9 0 1 1-6.219-8.56"})[_p.name]}`; if (__v != null) _s0.setAttribute('d', String(__v)); else _s0.removeAttribute('d') }
+      { const __x = `${({"check": "M20 6 9 17l-5-5", "chevron-down": "m6 9 6 6 6-6", "chevron-up": "m18 15-6-6-6 6", "chevron-left": "m15 18-6-6 6-6", "chevron-right": "m9 18 6-6-6-6", "x": "M18 6 6 18M6 6l12 12", "plus": "M5 12h14M12 5v14", "minus": "M5 12h14", "sun": "M12 16a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41", "moon": "M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z", "monitor": "M20 3H4a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2zM8 21h8M12 17v4", "copy": "M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2M8 8h12a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V10a2 2 0 0 1 2-2z", "clipboard": "M9 2h6a1 1 0 0 1 1 1v1H8V3a1 1 0 0 1 1-1zM16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2", "clipboard-check": "M9 2h6a1 1 0 0 1 1 1v1H8V3a1 1 0 0 1 1-1zM16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2M9 14l2 2 4-4", "menu": "M4 6h16M4 12h16M4 18h16", "arrow-left": "m12 19-7-7 7-7M19 12H5", "arrow-right": "M5 12h14m-7-7 7 7-7 7", "ellipsis": "M5 12h.01M12 12h.01M19 12h.01", "arrow-up-down": "m21 16-4 4-4-4M17 20V4M3 8l4-4 4 4M7 4v16", "panel-left": "M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4M3 3h12v18H3zM9 3v18", "loader-circle": "M21 12a9 9 0 1 1-6.219-8.56"})[_p.name]}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('d', String(__v)); else _s0.removeAttribute('d') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s1) applyRestAttrs(_s1, _p, ["name","size","className","xmlns","width","height","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     const [__GitHubIcon_s11El] = $c(__scope, 's11')
     if (__GitHubIcon_s11El) {
-      { const __v = size; if (__v != null) __GitHubIcon_s11El.setAttribute('size', String(__v)); else __GitHubIcon_s11El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __GitHubIcon_s11El.setAttribute('class', String(__v)); else __GitHubIcon_s11El.removeAttribute('class') }
+      { const __x = size
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) __GitHubIcon_s11El.setAttribute('size', String(__v)); else __GitHubIcon_s11El.removeAttribute('size') }
+      }
+      __l[0] = __x }
+      { const __x = className
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) __GitHubIcon_s11El.setAttribute('class', String(__v)); else __GitHubIcon_s11El.removeAttribute('class') }
+      }
+      __l[1] = __x }
     }
     const [__SearchIcon_s10El] = $c(__scope, 's10')
     if (__SearchIcon_s10El) {
-      { const __v = size; if (__v != null) __SearchIcon_s10El.setAttribute('size', String(__v)); else __SearchIcon_s10El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __SearchIcon_s10El.setAttribute('class', String(__v)); else __SearchIcon_s10El.removeAttribute('class') }
+      { const __x = size
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        { const __v = __x; if (__v != null) __SearchIcon_s10El.setAttribute('size', String(__v)); else __SearchIcon_s10El.removeAttribute('size') }
+      }
+      __l[2] = __x }
+      { const __x = className
+      if (!(3 in __l) || !Object.is(__l[3], __x)) {
+        { const __v = __x; if (__v != null) __SearchIcon_s10El.setAttribute('class', String(__v)); else __SearchIcon_s10El.removeAttribute('class') }
+      }
+      __l[3] = __x }
     }
     const [__SettingsIcon_s9El] = $c(__scope, 's9')
     if (__SettingsIcon_s9El) {
-      { const __v = size; if (__v != null) __SettingsIcon_s9El.setAttribute('size', String(__v)); else __SettingsIcon_s9El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __SettingsIcon_s9El.setAttribute('class', String(__v)); else __SettingsIcon_s9El.removeAttribute('class') }
+      { const __x = size
+      if (!(4 in __l) || !Object.is(__l[4], __x)) {
+        { const __v = __x; if (__v != null) __SettingsIcon_s9El.setAttribute('size', String(__v)); else __SettingsIcon_s9El.removeAttribute('size') }
+      }
+      __l[4] = __x }
+      { const __x = className
+      if (!(5 in __l) || !Object.is(__l[5], __x)) {
+        { const __v = __x; if (__v != null) __SettingsIcon_s9El.setAttribute('class', String(__v)); else __SettingsIcon_s9El.removeAttribute('class') }
+      }
+      __l[5] = __x }
     }
     const [__GlobeIcon_s8El] = $c(__scope, 's8')
     if (__GlobeIcon_s8El) {
-      { const __v = size; if (__v != null) __GlobeIcon_s8El.setAttribute('size', String(__v)); else __GlobeIcon_s8El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __GlobeIcon_s8El.setAttribute('class', String(__v)); else __GlobeIcon_s8El.removeAttribute('class') }
+      { const __x = size
+      if (!(6 in __l) || !Object.is(__l[6], __x)) {
+        { const __v = __x; if (__v != null) __GlobeIcon_s8El.setAttribute('size', String(__v)); else __GlobeIcon_s8El.removeAttribute('size') }
+      }
+      __l[6] = __x }
+      { const __x = className
+      if (!(7 in __l) || !Object.is(__l[7], __x)) {
+        { const __v = __x; if (__v != null) __GlobeIcon_s8El.setAttribute('class', String(__v)); else __GlobeIcon_s8El.removeAttribute('class') }
+      }
+      __l[7] = __x }
     }
     const [__LogOutIcon_s7El] = $c(__scope, 's7')
     if (__LogOutIcon_s7El) {
-      { const __v = size; if (__v != null) __LogOutIcon_s7El.setAttribute('size', String(__v)); else __LogOutIcon_s7El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __LogOutIcon_s7El.setAttribute('class', String(__v)); else __LogOutIcon_s7El.removeAttribute('class') }
+      { const __x = size
+      if (!(8 in __l) || !Object.is(__l[8], __x)) {
+        { const __v = __x; if (__v != null) __LogOutIcon_s7El.setAttribute('size', String(__v)); else __LogOutIcon_s7El.removeAttribute('size') }
+      }
+      __l[8] = __x }
+      { const __x = className
+      if (!(9 in __l) || !Object.is(__l[9], __x)) {
+        { const __v = __x; if (__v != null) __LogOutIcon_s7El.setAttribute('class', String(__v)); else __LogOutIcon_s7El.removeAttribute('class') }
+      }
+      __l[9] = __x }
     }
     const [__CircleHelpIcon_s6El] = $c(__scope, 's6')
     if (__CircleHelpIcon_s6El) {
-      { const __v = size; if (__v != null) __CircleHelpIcon_s6El.setAttribute('size', String(__v)); else __CircleHelpIcon_s6El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __CircleHelpIcon_s6El.setAttribute('class', String(__v)); else __CircleHelpIcon_s6El.removeAttribute('class') }
+      { const __x = size
+      if (!(10 in __l) || !Object.is(__l[10], __x)) {
+        { const __v = __x; if (__v != null) __CircleHelpIcon_s6El.setAttribute('size', String(__v)); else __CircleHelpIcon_s6El.removeAttribute('size') }
+      }
+      __l[10] = __x }
+      { const __x = className
+      if (!(11 in __l) || !Object.is(__l[11], __x)) {
+        { const __v = __x; if (__v != null) __CircleHelpIcon_s6El.setAttribute('class', String(__v)); else __CircleHelpIcon_s6El.removeAttribute('class') }
+      }
+      __l[11] = __x }
     }
     const [__CalendarIcon_s5El] = $c(__scope, 's5')
     if (__CalendarIcon_s5El) {
-      { const __v = size; if (__v != null) __CalendarIcon_s5El.setAttribute('size', String(__v)); else __CalendarIcon_s5El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __CalendarIcon_s5El.setAttribute('class', String(__v)); else __CalendarIcon_s5El.removeAttribute('class') }
+      { const __x = size
+      if (!(12 in __l) || !Object.is(__l[12], __x)) {
+        { const __v = __x; if (__v != null) __CalendarIcon_s5El.setAttribute('size', String(__v)); else __CalendarIcon_s5El.removeAttribute('size') }
+      }
+      __l[12] = __x }
+      { const __x = className
+      if (!(13 in __l) || !Object.is(__l[13], __x)) {
+        { const __v = __x; if (__v != null) __CalendarIcon_s5El.setAttribute('class', String(__v)); else __CalendarIcon_s5El.removeAttribute('class') }
+      }
+      __l[13] = __x }
     }
     const [__GripVerticalIcon_s4El] = $c(__scope, 's4')
     if (__GripVerticalIcon_s4El) {
-      { const __v = size; if (__v != null) __GripVerticalIcon_s4El.setAttribute('size', String(__v)); else __GripVerticalIcon_s4El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __GripVerticalIcon_s4El.setAttribute('class', String(__v)); else __GripVerticalIcon_s4El.removeAttribute('class') }
+      { const __x = size
+      if (!(14 in __l) || !Object.is(__l[14], __x)) {
+        { const __v = __x; if (__v != null) __GripVerticalIcon_s4El.setAttribute('size', String(__v)); else __GripVerticalIcon_s4El.removeAttribute('size') }
+      }
+      __l[14] = __x }
+      { const __x = className
+      if (!(15 in __l) || !Object.is(__l[15], __x)) {
+        { const __v = __x; if (__v != null) __GripVerticalIcon_s4El.setAttribute('class', String(__v)); else __GripVerticalIcon_s4El.removeAttribute('class') }
+      }
+      __l[15] = __x }
     }
     const [__LoaderCircleIcon_s3El] = $c(__scope, 's3')
     if (__LoaderCircleIcon_s3El) {
-      { const __v = size; if (__v != null) __LoaderCircleIcon_s3El.setAttribute('size', String(__v)); else __LoaderCircleIcon_s3El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __LoaderCircleIcon_s3El.setAttribute('class', String(__v)); else __LoaderCircleIcon_s3El.removeAttribute('class') }
+      { const __x = size
+      if (!(16 in __l) || !Object.is(__l[16], __x)) {
+        { const __v = __x; if (__v != null) __LoaderCircleIcon_s3El.setAttribute('size', String(__v)); else __LoaderCircleIcon_s3El.removeAttribute('size') }
+      }
+      __l[16] = __x }
+      { const __x = className
+      if (!(17 in __l) || !Object.is(__l[17], __x)) {
+        { const __v = __x; if (__v != null) __LoaderCircleIcon_s3El.setAttribute('class', String(__v)); else __LoaderCircleIcon_s3El.removeAttribute('class') }
+      }
+      __l[17] = __x }
     }
     const [__PanelLeftIcon_s2El] = $c(__scope, 's2')
     if (__PanelLeftIcon_s2El) {
-      { const __v = size; if (__v != null) __PanelLeftIcon_s2El.setAttribute('size', String(__v)); else __PanelLeftIcon_s2El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __PanelLeftIcon_s2El.setAttribute('class', String(__v)); else __PanelLeftIcon_s2El.removeAttribute('class') }
+      { const __x = size
+      if (!(18 in __l) || !Object.is(__l[18], __x)) {
+        { const __v = __x; if (__v != null) __PanelLeftIcon_s2El.setAttribute('size', String(__v)); else __PanelLeftIcon_s2El.removeAttribute('size') }
+      }
+      __l[18] = __x }
+      { const __x = className
+      if (!(19 in __l) || !Object.is(__l[19], __x)) {
+        { const __v = __x; if (__v != null) __PanelLeftIcon_s2El.setAttribute('class', String(__v)); else __PanelLeftIcon_s2El.removeAttribute('class') }
+      }
+      __l[19] = __x }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('GitHubIcon', _s11, forwardProps(_p, { get size() { return size }, get className() { return className } }, ["size","className"]))
@@ -2689,11 +2957,16 @@ export function initPagination(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `mx-auto flex w-full justify-center ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `mx-auto flex w-full justify-center ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["className","children","role","aria-label","data-slot","class"])
 
@@ -2707,11 +2980,16 @@ export function initPaginationContent(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `flex flex-row items-center gap-1 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `flex flex-row items-center gap-1 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["className","children","data-slot","class"])
 
@@ -2725,11 +3003,16 @@ export function initPaginationItem(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = (_p.className ?? ''); if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = (_p.className ?? '')
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["className","children","data-slot","class"])
 
@@ -2749,15 +3032,36 @@ export function initPaginationLink(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = _p.isActive ? 'page' : undefined; if (__v != null) _s0.setAttribute('aria-current', String(__v)); else _s0.removeAttribute('aria-current') }
-      { const __v = _p.isActive; if (__v != null) _s0.setAttribute('data-active', String(__v)); else _s0.removeAttribute('data-active') }
-      { const __v = _p.id; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
-      { const __v = `inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*="size-"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] ${_p.isActive ? variantClasses.outline : variantClasses.ghost} ${({"default": "h-9 px-4 py-2 has-[>svg]:px-3", "icon": "size-9"})[size()]} ${_p.className ?? ''}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
-      { const __v = _p.href; if (__v != null) _s0.setAttribute('href', String(__v)); else _s0.removeAttribute('href') }
+      { const __x = _p.isActive ? 'page' : undefined
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('aria-current', String(__v)); else _s0.removeAttribute('aria-current') }
+      }
+      __l[0] = __x }
+      { const __x = _p.isActive
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('data-active', String(__v)); else _s0.removeAttribute('data-active') }
+      }
+      __l[1] = __x }
+      { const __x = _p.id
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
+      }
+      __l[2] = __x }
+      { const __x = `inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*="size-"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] ${_p.isActive ? variantClasses.outline : variantClasses.ghost} ${({"default": "h-9 px-4 py-2 has-[>svg]:px-3", "icon": "size-9"})[size()]} ${_p.className ?? ''}`
+      if (!(3 in __l) || !Object.is(__l[3], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[3] = __x }
+      { const __x = _p.href
+      if (!(4 in __l) || !Object.is(__l[4], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('href', String(__v)); else _s0.removeAttribute('href') }
+      }
+      __l[4] = __x }
     }
-  })
+  }) }
 
   if (_s0) _s0.addEventListener('click', _p.onClick)
 }
@@ -2793,11 +3097,16 @@ export function initPaginationPrevious(__scope, _p = {}) {
   const [_s1] = $(__scope, 's1')
   const [_s0] = $c(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s1) {
-      { const __v = `${buttonBaseClasses} ${variantClasses.ghost} ${sizeClasses.default} gap-1 px-2.5 sm:pl-2.5 ${(_p.className ?? '')}`; if (__v != null) _s1.setAttribute('class', String(__v)); else _s1.removeAttribute('class') }
+      { const __x = `${buttonBaseClasses} ${variantClasses.ghost} ${sizeClasses.default} gap-1 px-2.5 sm:pl-2.5 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('class', String(__v)); else _s1.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s1) applyRestAttrs(_s1, _p, ["className","children","aria-label","data-slot","class"])
 
@@ -2837,11 +3146,16 @@ export function initPaginationNext(__scope, _p = {}) {
   const [_s1] = $(__scope, 's1')
   const [_s0] = $c(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s1) {
-      { const __v = `${buttonBaseClasses} ${variantClasses.ghost} ${sizeClasses.default} gap-1 px-2.5 sm:pr-2.5 ${(_p.className ?? '')}`; if (__v != null) _s1.setAttribute('class', String(__v)); else _s1.removeAttribute('class') }
+      { const __x = `${buttonBaseClasses} ${variantClasses.ghost} ${sizeClasses.default} gap-1 px-2.5 sm:pr-2.5 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('class', String(__v)); else _s1.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s1) applyRestAttrs(_s1, _p, ["className","children","aria-label","data-slot","class"])
 
@@ -2871,11 +3185,16 @@ export function initPaginationEllipsis(__scope, _p = {}) {
   const [_s1] = $(__scope, 's1')
   const [_s0] = $c(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s1) {
-      { const __v = `flex size-9 items-center justify-center ${(_p.className ?? '')}`; if (__v != null) _s1.setAttribute('class', String(__v)); else _s1.removeAttribute('class') }
+      { const __x = `flex size-9 items-center justify-center ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('class', String(__v)); else _s1.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s1) applyRestAttrs(_s1, _p, ["className","aria-hidden","data-slot","class"])
 
@@ -2934,28 +3253,49 @@ export function initPaginationDynamicDemo(__scope, _p = {}) {
 
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     const [__PaginationLink_s2El] = $c(__scope, 's2')
     if (__PaginationLink_s2El) {
-      { const __v = currentPage() === 1; if (__v != null) __PaginationLink_s2El.setAttribute('isActive', String(__v)); else __PaginationLink_s2El.removeAttribute('isActive') }
+      { const __x = currentPage() === 1
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) __PaginationLink_s2El.setAttribute('isActive', String(__v)); else __PaginationLink_s2El.removeAttribute('isActive') }
+      }
+      __l[0] = __x }
     }
     const [__PaginationLink_s4El] = $c(__scope, 's4')
     if (__PaginationLink_s4El) {
-      { const __v = currentPage() === 2; if (__v != null) __PaginationLink_s4El.setAttribute('isActive', String(__v)); else __PaginationLink_s4El.removeAttribute('isActive') }
+      { const __x = currentPage() === 2
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) __PaginationLink_s4El.setAttribute('isActive', String(__v)); else __PaginationLink_s4El.removeAttribute('isActive') }
+      }
+      __l[1] = __x }
     }
     const [__PaginationLink_s6El] = $c(__scope, 's6')
     if (__PaginationLink_s6El) {
-      { const __v = currentPage() === 3; if (__v != null) __PaginationLink_s6El.setAttribute('isActive', String(__v)); else __PaginationLink_s6El.removeAttribute('isActive') }
+      { const __x = currentPage() === 3
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        { const __v = __x; if (__v != null) __PaginationLink_s6El.setAttribute('isActive', String(__v)); else __PaginationLink_s6El.removeAttribute('isActive') }
+      }
+      __l[2] = __x }
     }
     const [__PaginationLink_s8El] = $c(__scope, 's8')
     if (__PaginationLink_s8El) {
-      { const __v = currentPage() === 4; if (__v != null) __PaginationLink_s8El.setAttribute('isActive', String(__v)); else __PaginationLink_s8El.removeAttribute('isActive') }
+      { const __x = currentPage() === 4
+      if (!(3 in __l) || !Object.is(__l[3], __x)) {
+        { const __v = __x; if (__v != null) __PaginationLink_s8El.setAttribute('isActive', String(__v)); else __PaginationLink_s8El.removeAttribute('isActive') }
+      }
+      __l[3] = __x }
     }
     const [__PaginationLink_s10El] = $c(__scope, 's10')
     if (__PaginationLink_s10El) {
-      { const __v = currentPage() === 5; if (__v != null) __PaginationLink_s10El.setAttribute('isActive', String(__v)); else __PaginationLink_s10El.removeAttribute('isActive') }
+      { const __x = currentPage() === 5
+      if (!(4 in __l) || !Object.is(__l[4], __x)) {
+        { const __v = __x; if (__v != null) __PaginationLink_s10El.setAttribute('isActive', String(__v)); else __PaginationLink_s10El.removeAttribute('isActive') }
+      }
+      __l[4] = __x }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('Pagination', _s15, {})

--- a/packages/adapter-tests/fixtures/__snapshots__/popover.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/popover.client.js
@@ -59,13 +59,26 @@ export function initPopoverTrigger(__scope, _p = {}) {
 
   const [_s1, _s0] = $(__scope, 's1', 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = _p.id; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
-      _s0.disabled = !!(_p.disabled ?? false)
-      { const __v = `${popoverTriggerClasses} ${_p.className ?? ''}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = _p.id
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
+      }
+      __l[0] = __x }
+      { const __x = _p.disabled ?? false
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        _s0.disabled = !!(__x)
+      }
+      __l[1] = __x }
+      { const __x = `${popoverTriggerClasses} ${_p.className ?? ''}`
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[2] = __x }
     }
-  })
+  }) }
 
   if (_s1) (handleMount)(_s1)
   if (_s0) (handleMount)(_s0)
@@ -169,12 +182,21 @@ export function initPopoverContent(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = _p.id; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
-      { const __v = `${popoverContentBaseClasses} ${popoverContentClosedClasses} ${_p.className ?? ''}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = _p.id
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
+      }
+      __l[0] = __x }
+      { const __x = `${popoverContentBaseClasses} ${popoverContentClosedClasses} ${_p.className ?? ''}`
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[1] = __x }
     }
-  })
+  }) }
 
   if (_s0) (handleMount)(_s0)
 }
@@ -197,12 +219,21 @@ export function initPopoverClose(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = _p.id; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
-      { const __v = _p.className ?? ''; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = _p.id
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
+      }
+      __l[0] = __x }
+      { const __x = _p.className ?? ''
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[1] = __x }
     }
-  })
+  }) }
 
   if (_s0) (handleMount)(_s0)
 }
@@ -226,11 +257,16 @@ export function initPopoverPreviewDemo(__scope, _p = {}) {
   })
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     if (__scope) {
-      __scope.open = !!(open())
+      { const __x = open()
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        __scope.open = !!(__x)
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('Popover', __scope, { get open() { return open() }, onOpenChange: setOpen })
@@ -257,11 +293,16 @@ export function initPopoverBasicDemo(__scope, _p = {}) {
   })
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     if (__scope) {
-      __scope.open = !!(open())
+      { const __x = open()
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        __scope.open = !!(__x)
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('Popover', __scope, { get open() { return open() }, onOpenChange: setOpen })
@@ -308,11 +349,16 @@ export function initPopoverFormDemo(__scope, _p = {}) {
   })
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     if (__scope) {
-      __scope.open = !!(open())
+      { const __x = open()
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        __scope.open = !!(__x)
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('Popover', __scope, { get open() { return open() }, onOpenChange: setOpen })

--- a/packages/adapter-tests/fixtures/__snapshots__/portal.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/portal.client.js
@@ -17,17 +17,27 @@ export function initPortalExample(__scope, _p = {}) {
 
   const [_s0, _s1, _s2, _s3] = $(__scope, 's0', 's1', 's2', 's3')
 
+  { const __l = []
   createEffect(() => {
     if (_s1) {
-      _s1.hidden = !!(!open())
+      { const __x = !open()
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        _s1.hidden = !!(__x)
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
+  { const __l = []
   createEffect(() => {
     if (_s3) {
-      _s3.hidden = !!(!open())
+      { const __x = !open()
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        _s3.hidden = !!(__x)
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) _s0.addEventListener('click', handleOpen)
   if (_s1) _s1.addEventListener('click', handleClose)

--- a/packages/adapter-tests/fixtures/__snapshots__/props-reactivity-comparison.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/props-reactivity-comparison.client.js
@@ -58,6 +58,7 @@ export function initReactiveProps(__scope, _p = {}) {
   })
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     const [__ReactiveChild_s5El] = $c(__scope, 's5')
     if (__ReactiveChild_s5El) {
@@ -67,7 +68,7 @@ export function initReactiveProps(__scope, _p = {}) {
     if (__ReactiveChild_s6El) {
       if ('value' in __ReactiveChild_s6El) { const __val = String(doubled()); if (__ReactiveChild_s6El.value !== __val) __ReactiveChild_s6El.value = __val }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('ReactiveChild__aca6fc98', _s5, { get value() { return count() }, label: "Child A", onIncrement: () => setCount(n => n + 1) })
@@ -163,6 +164,7 @@ export function initPropsReactivityComparison(__scope, _p = {}) {
   })
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     const [__PropsStyleChild_s3El] = $c(__scope, 's3')
     if (__PropsStyleChild_s3El) {
@@ -172,7 +174,7 @@ export function initPropsReactivityComparison(__scope, _p = {}) {
     if (__DestructuredStyleChild_s4El) {
       if ('value' in __DestructuredStyleChild_s4El) { const __val = String(count()); if (__DestructuredStyleChild_s4El.value !== __val) __DestructuredStyleChild_s4El.value = __val }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('PropsStyleChild__aca6fc98', _s3, { get value() { return count() }, label: "Props Style" })

--- a/packages/adapter-tests/fixtures/__snapshots__/radio-group.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/radio-group.client.js
@@ -81,13 +81,26 @@ export function initRadioGroupItem(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      _s0.disabled = !!(_p.disabled ?? false)
-      { const __v = _p.id; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
-      { const __v = `${itemClasses} ${_p.className ?? ''}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = _p.disabled ?? false
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        _s0.disabled = !!(__x)
+      }
+      __l[0] = __x }
+      { const __x = _p.id
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
+      }
+      __l[1] = __x }
+      { const __x = `${itemClasses} ${_p.className ?? ''}`
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[2] = __x }
     }
-  })
+  }) }
 
   if (_s0) (handleMount)(_s0)
 }

--- a/packages/adapter-tests/fixtures/__snapshots__/reactive-props.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/reactive-props.client.js
@@ -58,6 +58,7 @@ export function initReactiveProps(__scope, _p = {}) {
   })
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     const [__ReactiveChild_s5El] = $c(__scope, 's5')
     if (__ReactiveChild_s5El) {
@@ -67,7 +68,7 @@ export function initReactiveProps(__scope, _p = {}) {
     if (__ReactiveChild_s6El) {
       if ('value' in __ReactiveChild_s6El) { const __val = String(doubled()); if (__ReactiveChild_s6El.value !== __val) __ReactiveChild_s6El.value = __val }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('ReactiveChild__aca6fc98', _s5, { get value() { return count() }, label: "Child A", onIncrement: () => setCount(n => n + 1) })
@@ -163,6 +164,7 @@ export function initPropsReactivityComparison(__scope, _p = {}) {
   })
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     const [__PropsStyleChild_s3El] = $c(__scope, 's3')
     if (__PropsStyleChild_s3El) {
@@ -172,7 +174,7 @@ export function initPropsReactivityComparison(__scope, _p = {}) {
     if (__DestructuredStyleChild_s4El) {
       if ('value' in __DestructuredStyleChild_s4El) { const __val = String(count()); if (__DestructuredStyleChild_s4El.value !== __val) __DestructuredStyleChild_s4El.value = __val }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('PropsStyleChild__aca6fc98', _s3, { get value() { return count() }, label: "Props Style" })

--- a/packages/adapter-tests/fixtures/__snapshots__/select-native-shared.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/select-native-shared.client.js
@@ -20,12 +20,17 @@ export function initSelectNative(__scope, _p = {}) {
     __bfw_s3('s3', escapeTextOrNode(__val))
   })
 
+  { const __l = []
   createEffect(() => {
     if (_s2) {
-      const __val = String(picked())
-      if ('value' in _s2) { if (_s2.value !== __val) _s2.value = __val } else { _s2.setAttribute('value', __val) }
+      { const __x = picked()
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        const __val = String(__x)
+        if ('value' in _s2) { if (_s2.value !== __val) _s2.value = __val } else { _s2.setAttribute('value', __val) }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s2) _s2.addEventListener('change', (e) => { setPicked(e.target.value) })
   const __lzs_l0 = [{ id: 's0', kind: 'text', path: [] }]
@@ -37,16 +42,16 @@ export function initSelectNative(__scope, _p = {}) {
       const __l = __e.last = []
       { const __t = __r[0]
       if (__t) {
-        const __x = f().id
+        { const __x = f().id
         const __val = String(__x)
         if ('value' in __t) { if (__t.value !== __val) __t.value = __val } else { __t.setAttribute('value', __val) }
-        __l[0] = __x
+        __l[0] = __x }
       } }
       { const __t = __r[0]
       if (__t) {
-        const __x = (picked()) === (f().id)
+        { const __x = (picked()) === (f().id)
         __t.selected = !!(__x)
-        __l[1] = __x
+        __l[1] = __x }
       } }
       { const __x = f().label
       __r[1]('s0', textOrNode(__x))
@@ -59,20 +64,20 @@ export function initSelectNative(__scope, _p = {}) {
       const __l = __e.last ?? (__e.last = [])
       { const __t = 0 in __r ? __r[0] : (__r[0] = qsa(__e.primaryEl, '[bf="s1"]'))
       if (__t) {
-        const __x = f().id
+        { const __x = f().id
         if (!(0 in __l) || !Object.is(__l[0], __x)) {
           const __val = String(__x)
           if ('value' in __t) { if (__t.value !== __val) __t.value = __val } else { __t.setAttribute('value', __val) }
         }
-        __l[0] = __x
+        __l[0] = __x }
       } }
       { const __t = 0 in __r ? __r[0] : (__r[0] = qsa(__e.primaryEl, '[bf="s1"]'))
       if (__t) {
-        const __x = (picked()) === (f().id)
+        { const __x = (picked()) === (f().id)
         if (!(1 in __l) || !Object.is(__l[1], __x)) {
           __t.selected = !!(__x)
         }
-        __l[1] = __x
+        __l[1] = __x }
       } }
       const __d = __r[1] ?? (__r[1] = lazySlots(__e.primaryEl, __lzs_l0))
       { const __x = f().label
@@ -87,11 +92,11 @@ export function initSelectNative(__scope, _p = {}) {
         const __l = __e.last ?? (__e.last = [])
         { const __t = 0 in __r ? __r[0] : (__r[0] = qsa(__e.primaryEl, '[bf="s1"]'))
         if (__t) {
-          const __x = (picked()) === (f().id)
+          { const __x = (picked()) === (f().id)
           if (__seed ? (__t.selected !== !!(__x)) : (!(1 in __l) || !Object.is(__l[1], __x))) {
             __t.selected = !!(__x)
           }
-          __l[1] = __x
+          __l[1] = __x }
         } }
       }
     },

--- a/packages/adapter-tests/fixtures/__snapshots__/select.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/select.client.js
@@ -39,11 +39,16 @@ export function initCheckIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -144,11 +149,16 @@ export function initChevronDownIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -249,11 +259,16 @@ export function initChevronUpIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -354,11 +369,16 @@ export function initChevronLeftIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -459,11 +479,16 @@ export function initChevronRightIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -564,11 +589,16 @@ export function initXIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -669,11 +699,16 @@ export function initPlusIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -774,11 +809,16 @@ export function initMinusIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -879,11 +919,16 @@ export function initSunIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -984,11 +1029,16 @@ export function initMoonIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1089,11 +1139,16 @@ export function initMonitorIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1194,11 +1249,16 @@ export function initCopyIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1299,11 +1359,16 @@ export function initClipboardIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1404,11 +1469,16 @@ export function initClipboardCheckIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1509,11 +1579,16 @@ export function initMenuIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1614,11 +1689,16 @@ export function initArrowLeftIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1719,11 +1799,16 @@ export function initArrowRightIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1824,11 +1909,16 @@ export function initArrowUpDownIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1906,11 +1996,16 @@ export function initEllipsisIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -1944,11 +2039,16 @@ export function initGitHubIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","class","aria-hidden"])
 
@@ -1982,11 +2082,16 @@ export function initSettingsIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2020,11 +2125,16 @@ export function initGlobeIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2058,11 +2168,16 @@ export function initLogOutIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2096,11 +2211,16 @@ export function initCircleHelpIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2134,11 +2254,16 @@ export function initSearchIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2172,11 +2297,16 @@ export function initCircleCheckIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2210,11 +2340,16 @@ export function initCircleXIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2248,11 +2383,16 @@ export function initTriangleAlertIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2286,11 +2426,16 @@ export function initInfoIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2324,11 +2469,16 @@ export function initCalendarIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2362,11 +2512,16 @@ export function initGripVerticalIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2423,11 +2578,16 @@ export function initLoaderCircleIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2505,11 +2665,16 @@ export function initPanelLeftIcon(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["size","className","xmlns","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
@@ -2576,77 +2741,180 @@ export function initIcon(__scope, _p = {}) {
   const [_s1, _s0] = $(__scope, 's1', 's0')
   const [_s11, _s10, _s9, _s8, _s7, _s6, _s5, _s4, _s3, _s2] = $c(__scope, 's11', 's10', 's9', 's8', 's7', 's6', 's5', 's4', 's3', 's2')
 
+  { const __l = []
   createEffect(() => {
     if (_s1) {
-      { const __v = sizeMap[(_p.size ?? 'md')]; if (__v != null) _s1.setAttribute('width', String(__v)); else _s1.removeAttribute('width') }
-      { const __v = sizeMap[(_p.size ?? 'md')]; if (__v != null) _s1.setAttribute('height', String(__v)); else _s1.removeAttribute('height') }
-      { const __v = (buttLinecapIcons).includes(_p.name) ? 'butt' : 'round'; if (__v != null) _s1.setAttribute('stroke-linecap', String(__v)); else _s1.removeAttribute('stroke-linecap') }
-      { const __v = `shrink-0 ${(_p.className ?? '')}`; if (__v != null) _s1.setAttribute('class', String(__v)); else _s1.removeAttribute('class') }
+      { const __x = sizeMap[(_p.size ?? 'md')]
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('width', String(__v)); else _s1.removeAttribute('width') }
+      }
+      __l[0] = __x }
+      { const __x = sizeMap[(_p.size ?? 'md')]
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('height', String(__v)); else _s1.removeAttribute('height') }
+      }
+      __l[1] = __x }
+      { const __x = (buttLinecapIcons).includes(_p.name) ? 'butt' : 'round'
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('stroke-linecap', String(__v)); else _s1.removeAttribute('stroke-linecap') }
+      }
+      __l[2] = __x }
+      { const __x = `shrink-0 ${(_p.className ?? '')}`
+      if (!(3 in __l) || !Object.is(__l[3], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('class', String(__v)); else _s1.removeAttribute('class') }
+      }
+      __l[3] = __x }
     }
-  })
+  }) }
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `${({"check": "M20 6 9 17l-5-5", "chevron-down": "m6 9 6 6 6-6", "chevron-up": "m18 15-6-6-6 6", "chevron-left": "m15 18-6-6 6-6", "chevron-right": "m9 18 6-6-6-6", "x": "M18 6 6 18M6 6l12 12", "plus": "M5 12h14M12 5v14", "minus": "M5 12h14", "sun": "M12 16a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41", "moon": "M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z", "monitor": "M20 3H4a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2zM8 21h8M12 17v4", "copy": "M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2M8 8h12a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V10a2 2 0 0 1 2-2z", "clipboard": "M9 2h6a1 1 0 0 1 1 1v1H8V3a1 1 0 0 1 1-1zM16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2", "clipboard-check": "M9 2h6a1 1 0 0 1 1 1v1H8V3a1 1 0 0 1 1-1zM16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2M9 14l2 2 4-4", "menu": "M4 6h16M4 12h16M4 18h16", "arrow-left": "m12 19-7-7 7-7M19 12H5", "arrow-right": "M5 12h14m-7-7 7 7-7 7", "ellipsis": "M5 12h.01M12 12h.01M19 12h.01", "arrow-up-down": "m21 16-4 4-4-4M17 20V4M3 8l4-4 4 4M7 4v16", "panel-left": "M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4M3 3h12v18H3zM9 3v18", "loader-circle": "M21 12a9 9 0 1 1-6.219-8.56"})[_p.name]}`; if (__v != null) _s0.setAttribute('d', String(__v)); else _s0.removeAttribute('d') }
+      { const __x = `${({"check": "M20 6 9 17l-5-5", "chevron-down": "m6 9 6 6 6-6", "chevron-up": "m18 15-6-6-6 6", "chevron-left": "m15 18-6-6 6-6", "chevron-right": "m9 18 6-6-6-6", "x": "M18 6 6 18M6 6l12 12", "plus": "M5 12h14M12 5v14", "minus": "M5 12h14", "sun": "M12 16a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41", "moon": "M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z", "monitor": "M20 3H4a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2zM8 21h8M12 17v4", "copy": "M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2M8 8h12a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V10a2 2 0 0 1 2-2z", "clipboard": "M9 2h6a1 1 0 0 1 1 1v1H8V3a1 1 0 0 1 1-1zM16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2", "clipboard-check": "M9 2h6a1 1 0 0 1 1 1v1H8V3a1 1 0 0 1 1-1zM16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2M9 14l2 2 4-4", "menu": "M4 6h16M4 12h16M4 18h16", "arrow-left": "m12 19-7-7 7-7M19 12H5", "arrow-right": "M5 12h14m-7-7 7 7-7 7", "ellipsis": "M5 12h.01M12 12h.01M19 12h.01", "arrow-up-down": "m21 16-4 4-4-4M17 20V4M3 8l4-4 4 4M7 4v16", "panel-left": "M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4M3 3h12v18H3zM9 3v18", "loader-circle": "M21 12a9 9 0 1 1-6.219-8.56"})[_p.name]}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('d', String(__v)); else _s0.removeAttribute('d') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s1) applyRestAttrs(_s1, _p, ["name","size","className","xmlns","width","height","viewBox","fill","stroke","stroke-width","stroke-linecap","stroke-linejoin","class","aria-hidden"])
 
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     const [__GitHubIcon_s11El] = $c(__scope, 's11')
     if (__GitHubIcon_s11El) {
-      { const __v = size; if (__v != null) __GitHubIcon_s11El.setAttribute('size', String(__v)); else __GitHubIcon_s11El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __GitHubIcon_s11El.setAttribute('class', String(__v)); else __GitHubIcon_s11El.removeAttribute('class') }
+      { const __x = size
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) __GitHubIcon_s11El.setAttribute('size', String(__v)); else __GitHubIcon_s11El.removeAttribute('size') }
+      }
+      __l[0] = __x }
+      { const __x = className
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) __GitHubIcon_s11El.setAttribute('class', String(__v)); else __GitHubIcon_s11El.removeAttribute('class') }
+      }
+      __l[1] = __x }
     }
     const [__SearchIcon_s10El] = $c(__scope, 's10')
     if (__SearchIcon_s10El) {
-      { const __v = size; if (__v != null) __SearchIcon_s10El.setAttribute('size', String(__v)); else __SearchIcon_s10El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __SearchIcon_s10El.setAttribute('class', String(__v)); else __SearchIcon_s10El.removeAttribute('class') }
+      { const __x = size
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        { const __v = __x; if (__v != null) __SearchIcon_s10El.setAttribute('size', String(__v)); else __SearchIcon_s10El.removeAttribute('size') }
+      }
+      __l[2] = __x }
+      { const __x = className
+      if (!(3 in __l) || !Object.is(__l[3], __x)) {
+        { const __v = __x; if (__v != null) __SearchIcon_s10El.setAttribute('class', String(__v)); else __SearchIcon_s10El.removeAttribute('class') }
+      }
+      __l[3] = __x }
     }
     const [__SettingsIcon_s9El] = $c(__scope, 's9')
     if (__SettingsIcon_s9El) {
-      { const __v = size; if (__v != null) __SettingsIcon_s9El.setAttribute('size', String(__v)); else __SettingsIcon_s9El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __SettingsIcon_s9El.setAttribute('class', String(__v)); else __SettingsIcon_s9El.removeAttribute('class') }
+      { const __x = size
+      if (!(4 in __l) || !Object.is(__l[4], __x)) {
+        { const __v = __x; if (__v != null) __SettingsIcon_s9El.setAttribute('size', String(__v)); else __SettingsIcon_s9El.removeAttribute('size') }
+      }
+      __l[4] = __x }
+      { const __x = className
+      if (!(5 in __l) || !Object.is(__l[5], __x)) {
+        { const __v = __x; if (__v != null) __SettingsIcon_s9El.setAttribute('class', String(__v)); else __SettingsIcon_s9El.removeAttribute('class') }
+      }
+      __l[5] = __x }
     }
     const [__GlobeIcon_s8El] = $c(__scope, 's8')
     if (__GlobeIcon_s8El) {
-      { const __v = size; if (__v != null) __GlobeIcon_s8El.setAttribute('size', String(__v)); else __GlobeIcon_s8El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __GlobeIcon_s8El.setAttribute('class', String(__v)); else __GlobeIcon_s8El.removeAttribute('class') }
+      { const __x = size
+      if (!(6 in __l) || !Object.is(__l[6], __x)) {
+        { const __v = __x; if (__v != null) __GlobeIcon_s8El.setAttribute('size', String(__v)); else __GlobeIcon_s8El.removeAttribute('size') }
+      }
+      __l[6] = __x }
+      { const __x = className
+      if (!(7 in __l) || !Object.is(__l[7], __x)) {
+        { const __v = __x; if (__v != null) __GlobeIcon_s8El.setAttribute('class', String(__v)); else __GlobeIcon_s8El.removeAttribute('class') }
+      }
+      __l[7] = __x }
     }
     const [__LogOutIcon_s7El] = $c(__scope, 's7')
     if (__LogOutIcon_s7El) {
-      { const __v = size; if (__v != null) __LogOutIcon_s7El.setAttribute('size', String(__v)); else __LogOutIcon_s7El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __LogOutIcon_s7El.setAttribute('class', String(__v)); else __LogOutIcon_s7El.removeAttribute('class') }
+      { const __x = size
+      if (!(8 in __l) || !Object.is(__l[8], __x)) {
+        { const __v = __x; if (__v != null) __LogOutIcon_s7El.setAttribute('size', String(__v)); else __LogOutIcon_s7El.removeAttribute('size') }
+      }
+      __l[8] = __x }
+      { const __x = className
+      if (!(9 in __l) || !Object.is(__l[9], __x)) {
+        { const __v = __x; if (__v != null) __LogOutIcon_s7El.setAttribute('class', String(__v)); else __LogOutIcon_s7El.removeAttribute('class') }
+      }
+      __l[9] = __x }
     }
     const [__CircleHelpIcon_s6El] = $c(__scope, 's6')
     if (__CircleHelpIcon_s6El) {
-      { const __v = size; if (__v != null) __CircleHelpIcon_s6El.setAttribute('size', String(__v)); else __CircleHelpIcon_s6El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __CircleHelpIcon_s6El.setAttribute('class', String(__v)); else __CircleHelpIcon_s6El.removeAttribute('class') }
+      { const __x = size
+      if (!(10 in __l) || !Object.is(__l[10], __x)) {
+        { const __v = __x; if (__v != null) __CircleHelpIcon_s6El.setAttribute('size', String(__v)); else __CircleHelpIcon_s6El.removeAttribute('size') }
+      }
+      __l[10] = __x }
+      { const __x = className
+      if (!(11 in __l) || !Object.is(__l[11], __x)) {
+        { const __v = __x; if (__v != null) __CircleHelpIcon_s6El.setAttribute('class', String(__v)); else __CircleHelpIcon_s6El.removeAttribute('class') }
+      }
+      __l[11] = __x }
     }
     const [__CalendarIcon_s5El] = $c(__scope, 's5')
     if (__CalendarIcon_s5El) {
-      { const __v = size; if (__v != null) __CalendarIcon_s5El.setAttribute('size', String(__v)); else __CalendarIcon_s5El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __CalendarIcon_s5El.setAttribute('class', String(__v)); else __CalendarIcon_s5El.removeAttribute('class') }
+      { const __x = size
+      if (!(12 in __l) || !Object.is(__l[12], __x)) {
+        { const __v = __x; if (__v != null) __CalendarIcon_s5El.setAttribute('size', String(__v)); else __CalendarIcon_s5El.removeAttribute('size') }
+      }
+      __l[12] = __x }
+      { const __x = className
+      if (!(13 in __l) || !Object.is(__l[13], __x)) {
+        { const __v = __x; if (__v != null) __CalendarIcon_s5El.setAttribute('class', String(__v)); else __CalendarIcon_s5El.removeAttribute('class') }
+      }
+      __l[13] = __x }
     }
     const [__GripVerticalIcon_s4El] = $c(__scope, 's4')
     if (__GripVerticalIcon_s4El) {
-      { const __v = size; if (__v != null) __GripVerticalIcon_s4El.setAttribute('size', String(__v)); else __GripVerticalIcon_s4El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __GripVerticalIcon_s4El.setAttribute('class', String(__v)); else __GripVerticalIcon_s4El.removeAttribute('class') }
+      { const __x = size
+      if (!(14 in __l) || !Object.is(__l[14], __x)) {
+        { const __v = __x; if (__v != null) __GripVerticalIcon_s4El.setAttribute('size', String(__v)); else __GripVerticalIcon_s4El.removeAttribute('size') }
+      }
+      __l[14] = __x }
+      { const __x = className
+      if (!(15 in __l) || !Object.is(__l[15], __x)) {
+        { const __v = __x; if (__v != null) __GripVerticalIcon_s4El.setAttribute('class', String(__v)); else __GripVerticalIcon_s4El.removeAttribute('class') }
+      }
+      __l[15] = __x }
     }
     const [__LoaderCircleIcon_s3El] = $c(__scope, 's3')
     if (__LoaderCircleIcon_s3El) {
-      { const __v = size; if (__v != null) __LoaderCircleIcon_s3El.setAttribute('size', String(__v)); else __LoaderCircleIcon_s3El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __LoaderCircleIcon_s3El.setAttribute('class', String(__v)); else __LoaderCircleIcon_s3El.removeAttribute('class') }
+      { const __x = size
+      if (!(16 in __l) || !Object.is(__l[16], __x)) {
+        { const __v = __x; if (__v != null) __LoaderCircleIcon_s3El.setAttribute('size', String(__v)); else __LoaderCircleIcon_s3El.removeAttribute('size') }
+      }
+      __l[16] = __x }
+      { const __x = className
+      if (!(17 in __l) || !Object.is(__l[17], __x)) {
+        { const __v = __x; if (__v != null) __LoaderCircleIcon_s3El.setAttribute('class', String(__v)); else __LoaderCircleIcon_s3El.removeAttribute('class') }
+      }
+      __l[17] = __x }
     }
     const [__PanelLeftIcon_s2El] = $c(__scope, 's2')
     if (__PanelLeftIcon_s2El) {
-      { const __v = size; if (__v != null) __PanelLeftIcon_s2El.setAttribute('size', String(__v)); else __PanelLeftIcon_s2El.removeAttribute('size') }
-      { const __v = className; if (__v != null) __PanelLeftIcon_s2El.setAttribute('class', String(__v)); else __PanelLeftIcon_s2El.removeAttribute('class') }
+      { const __x = size
+      if (!(18 in __l) || !Object.is(__l[18], __x)) {
+        { const __v = __x; if (__v != null) __PanelLeftIcon_s2El.setAttribute('size', String(__v)); else __PanelLeftIcon_s2El.removeAttribute('size') }
+      }
+      __l[18] = __x }
+      { const __x = className
+      if (!(19 in __l) || !Object.is(__l[19], __x)) {
+        { const __v = __x; if (__v != null) __PanelLeftIcon_s2El.setAttribute('class', String(__v)); else __PanelLeftIcon_s2El.removeAttribute('class') }
+      }
+      __l[19] = __x }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('GitHubIcon', _s11, forwardProps(_p, { get size() { return size }, get className() { return className } }, ["size","className"]))
@@ -2751,12 +3019,21 @@ export function initSelectTrigger(__scope, _p = {}) {
   const [_s1] = $(__scope, 's1')
   const [_s0] = $c(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s1) {
-      { const __v = _p.id; if (__v != null) _s1.setAttribute('id', String(__v)); else _s1.removeAttribute('id') }
-      { const __v = `flex h-9 w-full items-center justify-between rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs transition-[color,box-shadow] outline-none focus:border-ring focus:ring-ring/50 focus:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[placeholder]:text-muted-foreground ${_p.className ?? ''}`; if (__v != null) _s1.setAttribute('class', String(__v)); else _s1.removeAttribute('class') }
+      { const __x = _p.id
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('id', String(__v)); else _s1.removeAttribute('id') }
+      }
+      __l[0] = __x }
+      { const __x = `flex h-9 w-full items-center justify-between rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs transition-[color,box-shadow] outline-none focus:border-ring focus:ring-ring/50 focus:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[placeholder]:text-muted-foreground ${_p.className ?? ''}`
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('class', String(__v)); else _s1.removeAttribute('class') }
+      }
+      __l[1] = __x }
     }
-  })
+  }) }
 
   if (_s1) (handleMount)(_s1)
 
@@ -2804,11 +3081,16 @@ export function initSelectValue(__scope, _p = {}) {
     __bfw_s0('s0', escapeTextOrNode(__val))
   })
 
+  { const __l = []
   createEffect(() => {
     if (_s1) {
-      { const __v = _p.id; if (__v != null) _s1.setAttribute('id', String(__v)); else _s1.removeAttribute('id') }
+      { const __x = _p.id
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('id', String(__v)); else _s1.removeAttribute('id') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s1) (handleMount)(_s1)
 }
@@ -2982,12 +3264,21 @@ export function initSelectContent(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = _p.id; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
-      { const __v = `${selectContentBaseClasses} ${selectContentClosedClasses} ${_p.className ?? ''}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = _p.id
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
+      }
+      __l[0] = __x }
+      { const __x = `${selectContentBaseClasses} ${selectContentClosedClasses} ${_p.className ?? ''}`
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[1] = __x }
     }
-  })
+  }) }
 
   if (_s0) (handleMount)(_s0)
 }
@@ -3036,16 +3327,37 @@ export function initSelectItem(__scope, _p = {}) {
   const [_s1] = $(__scope, 's1')
   const [_s0] = $c(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s1) {
-      { const __v = _p.value; if (__v != null) _s1.setAttribute('data-value', String(__v)); else _s1.removeAttribute('data-value') }
-      { const __v = _p.id; if (__v != null) _s1.setAttribute('id', String(__v)); else _s1.removeAttribute('id') }
-      if (isDisabled()) _s1.setAttribute('aria-disabled', 'true')
-      else _s1.removeAttribute('aria-disabled')
-      { const __v = isDisabled() ? -1 : 0; if (__v != null) _s1.setAttribute('tabindex', String(__v)); else _s1.removeAttribute('tabindex') }
-      { const __v = `${selectItemBaseClasses} ${stateClasses()} ${_p.className ?? ''}`; if (__v != null) _s1.setAttribute('class', String(__v)); else _s1.removeAttribute('class') }
+      { const __x = _p.value
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('data-value', String(__v)); else _s1.removeAttribute('data-value') }
+      }
+      __l[0] = __x }
+      { const __x = _p.id
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('id', String(__v)); else _s1.removeAttribute('id') }
+      }
+      __l[1] = __x }
+      { const __x = isDisabled()
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        if (__x) _s1.setAttribute('aria-disabled', 'true')
+        else _s1.removeAttribute('aria-disabled')
+      }
+      __l[2] = __x }
+      { const __x = isDisabled() ? -1 : 0
+      if (!(3 in __l) || !Object.is(__l[3], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('tabindex', String(__v)); else _s1.removeAttribute('tabindex') }
+      }
+      __l[3] = __x }
+      { const __x = `${selectItemBaseClasses} ${stateClasses()} ${_p.className ?? ''}`
+      if (!(4 in __l) || !Object.is(__l[4], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('class', String(__v)); else _s1.removeAttribute('class') }
+      }
+      __l[4] = __x }
     }
-  })
+  }) }
 
   if (_s1) (handleMount)(_s1)
 
@@ -3061,11 +3373,16 @@ export function initSelectGroup(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = (_p.className ?? ''); if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = (_p.className ?? '')
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot","role","class"])
 
@@ -3081,11 +3398,16 @@ export function initSelectLabel(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `${selectLabelClasses} ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `${selectLabelClasses} ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["children","className","data-slot","class"])
 
@@ -3101,11 +3423,16 @@ export function initSelectSeparator(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `${selectSeparatorClasses} ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `${selectSeparatorClasses} ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["className","data-slot","role","class"])
 
@@ -3136,12 +3463,13 @@ export function initSelectBasicDemo(__scope, _p = {}) {
   })
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     const [__Select_s8El] = $c(__scope, 's8')
     if (__Select_s8El) {
       if ('value' in __Select_s8El) { const __val = String(value()); if (__Select_s8El.value !== __val) __Select_s8El.value = __val }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('Select', _s8, { get value() { return value() }, onValueChange: setValue })
@@ -3195,6 +3523,7 @@ export function initSelectFormDemo(__scope, _p = {}) {
   })
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     const [__Select_s7El] = $c(__scope, 's7')
     if (__Select_s7El) {
@@ -3208,7 +3537,7 @@ export function initSelectFormDemo(__scope, _p = {}) {
     if (__Select_s23El) {
       if ('value' in __Select_s23El) { const __val = String(experience()); if (__Select_s23El.value !== __val) __Select_s23El.value = __val }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('Select', _s7, { get value() { return framework() }, onValueChange: setFramework })
@@ -3268,12 +3597,13 @@ export function initSelectGroupedDemo(__scope, _p = {}) {
   })
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     const [__Select_s21El] = $c(__scope, 's21')
     if (__Select_s21El) {
       if ('value' in __Select_s21El) { const __val = String(timezone()); if (__Select_s21El.value !== __val) __Select_s21El.value = __val }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('Select', _s21, { get value() { return timezone() }, onValueChange: setTimezone })

--- a/packages/adapter-tests/fixtures/__snapshots__/switch.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/switch.client.js
@@ -64,21 +64,47 @@ export function initSwitch(__scope, _p = {}) {
 
   const [_s1, _s0] = $(__scope, 's1', 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s1) {
-      { const __v = `${isChecked() ? 'checked' : 'unchecked'}`; if (__v != null) _s1.setAttribute('data-state', String(__v)); else _s1.removeAttribute('data-state') }
-      { const __v = _p.id; if (__v != null) _s1.setAttribute('id', String(__v)); else _s1.removeAttribute('id') }
-      { const __v = isChecked(); if (__v != null) _s1.setAttribute('aria-checked', String(__v)); else _s1.removeAttribute('aria-checked') }
-      _s1.disabled = !!(_p.disabled ?? false)
-      { const __v = `peer inline-flex h-5 w-9 shrink-0 items-center rounded-xl p-0.5 shadow-xs transition-all outline-none disabled:cursor-not-allowed disabled:opacity-50 focus-visible:ring-ring/50 focus-visible:ring-[3px] ${trackStateClasses} ${_p.className ?? ''}`; if (__v != null) _s1.setAttribute('class', String(__v)); else _s1.removeAttribute('class') }
+      { const __x = `${isChecked() ? 'checked' : 'unchecked'}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('data-state', String(__v)); else _s1.removeAttribute('data-state') }
+      }
+      __l[0] = __x }
+      { const __x = _p.id
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('id', String(__v)); else _s1.removeAttribute('id') }
+      }
+      __l[1] = __x }
+      { const __x = isChecked()
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('aria-checked', String(__v)); else _s1.removeAttribute('aria-checked') }
+      }
+      __l[2] = __x }
+      { const __x = _p.disabled ?? false
+      if (!(3 in __l) || !Object.is(__l[3], __x)) {
+        _s1.disabled = !!(__x)
+      }
+      __l[3] = __x }
+      { const __x = `peer inline-flex h-5 w-9 shrink-0 items-center rounded-xl p-0.5 shadow-xs transition-all outline-none disabled:cursor-not-allowed disabled:opacity-50 focus-visible:ring-ring/50 focus-visible:ring-[3px] ${trackStateClasses} ${_p.className ?? ''}`
+      if (!(4 in __l) || !Object.is(__l[4], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('class', String(__v)); else _s1.removeAttribute('class') }
+      }
+      __l[4] = __x }
     }
-  })
+  }) }
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `${isChecked() ? 'checked' : 'unchecked'}`; if (__v != null) _s0.setAttribute('data-state', String(__v)); else _s0.removeAttribute('data-state') }
+      { const __x = `${isChecked() ? 'checked' : 'unchecked'}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('data-state', String(__v)); else _s0.removeAttribute('data-state') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s1) _s1.addEventListener('click', handleClick)
 }

--- a/packages/adapter-tests/fixtures/__snapshots__/tabs.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/tabs.client.js
@@ -8,12 +8,21 @@ export function initTabs(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = _p.value || _p.defaultValue; if (__v != null) _s0.setAttribute('data-value', String(__v)); else _s0.removeAttribute('data-value') }
-      { const __v = `${tabsClasses} ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = _p.value || _p.defaultValue
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('data-value', String(__v)); else _s0.removeAttribute('data-value') }
+      }
+      __l[0] = __x }
+      { const __x = `${tabsClasses} ${(_p.className ?? '')}`
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[1] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["className","value","defaultValue","children","data-slot","data-value","class"])
 
@@ -29,11 +38,16 @@ export function initTabsList(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `${tabsListClasses} ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `${tabsListClasses} ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["className","children","data-slot","role","class"])
 
@@ -86,17 +100,46 @@ export function initTabsTrigger(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = _p.selected ?? false; if (__v != null) _s0.setAttribute('aria-selected', String(__v)); else _s0.removeAttribute('aria-selected') }
-      _s0.disabled = !!(_p.disabled ?? false)
-      { const __v = `${(_p.selected ?? false) ? 'active' : 'inactive'}`; if (__v != null) _s0.setAttribute('data-state', String(__v)); else _s0.removeAttribute('data-state') }
-      { const __v = _p.value; if (__v != null) _s0.setAttribute('data-value', String(__v)); else _s0.removeAttribute('data-value') }
-      { const __v = (_p.selected ?? false) ? 0 : -1; if (__v != null) _s0.setAttribute('tabindex', String(__v)); else _s0.removeAttribute('tabindex') }
-      { const __v = _p.id; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
-      { const __v = `inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*="size-"])]:size-4 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] text-foreground data-[state=active]:bg-background data-[state=active]:shadow-sm dark:text-muted-foreground dark:data-[state=active]:text-foreground dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 ${_p.className ?? ''}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = _p.selected ?? false
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('aria-selected', String(__v)); else _s0.removeAttribute('aria-selected') }
+      }
+      __l[0] = __x }
+      { const __x = _p.disabled ?? false
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        _s0.disabled = !!(__x)
+      }
+      __l[1] = __x }
+      { const __x = `${(_p.selected ?? false) ? 'active' : 'inactive'}`
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('data-state', String(__v)); else _s0.removeAttribute('data-state') }
+      }
+      __l[2] = __x }
+      { const __x = _p.value
+      if (!(3 in __l) || !Object.is(__l[3], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('data-value', String(__v)); else _s0.removeAttribute('data-value') }
+      }
+      __l[3] = __x }
+      { const __x = (_p.selected ?? false) ? 0 : -1
+      if (!(4 in __l) || !Object.is(__l[4], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('tabindex', String(__v)); else _s0.removeAttribute('tabindex') }
+      }
+      __l[4] = __x }
+      { const __x = _p.id
+      if (!(5 in __l) || !Object.is(__l[5], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
+      }
+      __l[5] = __x }
+      { const __x = `inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*="size-"])]:size-4 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] text-foreground data-[state=active]:bg-background data-[state=active]:shadow-sm dark:text-muted-foreground dark:data-[state=active]:text-foreground dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 ${_p.className ?? ''}`
+      if (!(6 in __l) || !Object.is(__l[6], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[6] = __x }
     }
-  })
+  }) }
 
   if (_s0) _s0.addEventListener('click', _p.onClick)
   if (_s0) _s0.addEventListener('keydown', handleKeyDown)
@@ -110,14 +153,31 @@ export function initTabsContent(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `${(_p.selected ?? false) ? 'active' : 'inactive'}`; if (__v != null) _s0.setAttribute('data-state', String(__v)); else _s0.removeAttribute('data-state') }
-      { const __v = _p.value; if (__v != null) _s0.setAttribute('data-value', String(__v)); else _s0.removeAttribute('data-value') }
-      { const __v = _p.id; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
-      { const __v = `flex-1 outline-none ${(_p.selected ?? false) ? '' : 'hidden'} ${_p.className ?? ''}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `${(_p.selected ?? false) ? 'active' : 'inactive'}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('data-state', String(__v)); else _s0.removeAttribute('data-state') }
+      }
+      __l[0] = __x }
+      { const __x = _p.value
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('data-value', String(__v)); else _s0.removeAttribute('data-value') }
+      }
+      __l[1] = __x }
+      { const __x = _p.id
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
+      }
+      __l[2] = __x }
+      { const __x = `flex-1 outline-none ${(_p.selected ?? false) ? '' : 'hidden'} ${_p.className ?? ''}`
+      if (!(3 in __l) || !Object.is(__l[3], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[3] = __x }
     }
-  })
+  }) }
 
 }
 
@@ -168,27 +228,44 @@ export function initTabsBasicDemo(__scope, _p = {}) {
   })
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     if (__scope) {
       if ('value' in __scope) { const __val = String(activeTab()); if (__scope.value !== __val) __scope.value = __val }
     }
     const [__TabsTrigger_s0El] = $c(__scope, 's0')
     if (__TabsTrigger_s0El) {
-      __TabsTrigger_s0El.selected = !!(isAccountSelected())
+      { const __x = isAccountSelected()
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        __TabsTrigger_s0El.selected = !!(__x)
+      }
+      __l[0] = __x }
     }
     const [__TabsTrigger_s1El] = $c(__scope, 's1')
     if (__TabsTrigger_s1El) {
-      __TabsTrigger_s1El.selected = !!(isPasswordSelected())
+      { const __x = isPasswordSelected()
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        __TabsTrigger_s1El.selected = !!(__x)
+      }
+      __l[1] = __x }
     }
     const [__TabsContent_s3El] = $c(__scope, 's3')
     if (__TabsContent_s3El) {
-      __TabsContent_s3El.selected = !!(isAccountSelected())
+      { const __x = isAccountSelected()
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        __TabsContent_s3El.selected = !!(__x)
+      }
+      __l[2] = __x }
     }
     const [__TabsContent_s4El] = $c(__scope, 's4')
     if (__TabsContent_s4El) {
-      __TabsContent_s4El.selected = !!(isPasswordSelected())
+      { const __x = isPasswordSelected()
+      if (!(3 in __l) || !Object.is(__l[3], __x)) {
+        __TabsContent_s4El.selected = !!(__x)
+      }
+      __l[3] = __x }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('Tabs', __scope, { get value() { return activeTab() }, onValueChange: setActiveTab })
@@ -274,43 +351,76 @@ export function initTabsMultipleDemo(__scope, _p = {}) {
   })
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     if (__scope) {
       if ('value' in __scope) { const __val = String(activeTab()); if (__scope.value !== __val) __scope.value = __val }
     }
     const [__TabsTrigger_s0El] = $c(__scope, 's0')
     if (__TabsTrigger_s0El) {
-      __TabsTrigger_s0El.selected = !!(isOverviewSelected())
+      { const __x = isOverviewSelected()
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        __TabsTrigger_s0El.selected = !!(__x)
+      }
+      __l[0] = __x }
     }
     const [__TabsTrigger_s1El] = $c(__scope, 's1')
     if (__TabsTrigger_s1El) {
-      __TabsTrigger_s1El.selected = !!(isAnalyticsSelected())
+      { const __x = isAnalyticsSelected()
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        __TabsTrigger_s1El.selected = !!(__x)
+      }
+      __l[1] = __x }
     }
     const [__TabsTrigger_s2El] = $c(__scope, 's2')
     if (__TabsTrigger_s2El) {
-      __TabsTrigger_s2El.selected = !!(isReportsSelected())
+      { const __x = isReportsSelected()
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        __TabsTrigger_s2El.selected = !!(__x)
+      }
+      __l[2] = __x }
     }
     const [__TabsTrigger_s3El] = $c(__scope, 's3')
     if (__TabsTrigger_s3El) {
-      __TabsTrigger_s3El.selected = !!(isNotificationsSelected())
+      { const __x = isNotificationsSelected()
+      if (!(3 in __l) || !Object.is(__l[3], __x)) {
+        __TabsTrigger_s3El.selected = !!(__x)
+      }
+      __l[3] = __x }
     }
     const [__TabsContent_s5El] = $c(__scope, 's5')
     if (__TabsContent_s5El) {
-      __TabsContent_s5El.selected = !!(isOverviewSelected())
+      { const __x = isOverviewSelected()
+      if (!(4 in __l) || !Object.is(__l[4], __x)) {
+        __TabsContent_s5El.selected = !!(__x)
+      }
+      __l[4] = __x }
     }
     const [__TabsContent_s6El] = $c(__scope, 's6')
     if (__TabsContent_s6El) {
-      __TabsContent_s6El.selected = !!(isAnalyticsSelected())
+      { const __x = isAnalyticsSelected()
+      if (!(5 in __l) || !Object.is(__l[5], __x)) {
+        __TabsContent_s6El.selected = !!(__x)
+      }
+      __l[5] = __x }
     }
     const [__TabsContent_s7El] = $c(__scope, 's7')
     if (__TabsContent_s7El) {
-      __TabsContent_s7El.selected = !!(isReportsSelected())
+      { const __x = isReportsSelected()
+      if (!(6 in __l) || !Object.is(__l[6], __x)) {
+        __TabsContent_s7El.selected = !!(__x)
+      }
+      __l[6] = __x }
     }
     const [__TabsContent_s8El] = $c(__scope, 's8')
     if (__TabsContent_s8El) {
-      __TabsContent_s8El.selected = !!(isNotificationsSelected())
+      { const __x = isNotificationsSelected()
+      if (!(7 in __l) || !Object.is(__l[7], __x)) {
+        __TabsContent_s8El.selected = !!(__x)
+      }
+      __l[7] = __x }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('Tabs', __scope, { get value() { return activeTab() }, onValueChange: setActiveTab })
@@ -372,27 +482,44 @@ export function initTabsDisabledDemo(__scope, _p = {}) {
   })
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     if (__scope) {
       if ('value' in __scope) { const __val = String(activeTab()); if (__scope.value !== __val) __scope.value = __val }
     }
     const [__TabsTrigger_s0El] = $c(__scope, 's0')
     if (__TabsTrigger_s0El) {
-      __TabsTrigger_s0El.selected = !!(isActiveSelected())
+      { const __x = isActiveSelected()
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        __TabsTrigger_s0El.selected = !!(__x)
+      }
+      __l[0] = __x }
     }
     const [__TabsTrigger_s2El] = $c(__scope, 's2')
     if (__TabsTrigger_s2El) {
-      __TabsTrigger_s2El.selected = !!(isAnotherSelected())
+      { const __x = isAnotherSelected()
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        __TabsTrigger_s2El.selected = !!(__x)
+      }
+      __l[1] = __x }
     }
     const [__TabsContent_s4El] = $c(__scope, 's4')
     if (__TabsContent_s4El) {
-      __TabsContent_s4El.selected = !!(isActiveSelected())
+      { const __x = isActiveSelected()
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        __TabsContent_s4El.selected = !!(__x)
+      }
+      __l[2] = __x }
     }
     const [__TabsContent_s5El] = $c(__scope, 's5')
     if (__TabsContent_s5El) {
-      __TabsContent_s5El.selected = !!(isAnotherSelected())
+      { const __x = isAnotherSelected()
+      if (!(3 in __l) || !Object.is(__l[3], __x)) {
+        __TabsContent_s5El.selected = !!(__x)
+      }
+      __l[3] = __x }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('Tabs', __scope, { get value() { return activeTab() } })

--- a/packages/adapter-tests/fixtures/__snapshots__/textarea-native-shared.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/textarea-native-shared.client.js
@@ -15,12 +15,17 @@ export function initNoteBoxNative(__scope, _p = {}) {
     __bfw_s1('s1', escapeTextOrNode(__val))
   })
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      const __val = String(note())
-      if ('value' in _s0) { if (_s0.value !== __val) _s0.value = __val } else { _s0.setAttribute('value', __val) }
+      { const __x = note()
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        const __val = String(__x)
+        if ('value' in _s0) { if (_s0.value !== __val) _s0.value = __val } else { _s0.setAttribute('value', __val) }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) _s0.addEventListener('input', (e) => { setNote(e.target.value) })
 }

--- a/packages/adapter-tests/fixtures/__snapshots__/textarea-row-breakout-composite.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/textarea-row-breakout-composite.client.js
@@ -35,12 +35,15 @@ export function initTextareaRowBreakoutComposite(__scope, _p = {}) {
     upsertChild(__el, 'Tag__515bc416', 's1', { get id() { return id() } }, undefined, __scope)
     { const __e = qsa(__el, '[bf="s2"]'); if (__e) __e.addEventListener('input', () => { setValue('a</textarea><b class="broke">X</b>') }) }
     const __ra_s2 = qsa(__el, '[bf="s2"]')
+    const __l = []
     createEffect(() => {
       if (__ra_s2) {
-        {
-          const __val = String(value())
+        { const __x = value()
+        if (!(0 in __l) || !Object.is(__l[0], __x)) {
+          const __val = String(__x)
           if ('value' in __ra_s2) { if (__ra_s2.value !== __val) __ra_s2.value = __val } else { __ra_s2.setAttribute('value', __val) }
         }
+        __l[0] = __x }
       }
     })
     return __el

--- a/packages/adapter-tests/fixtures/__snapshots__/textarea-row-breakout.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/textarea-row-breakout.client.js
@@ -20,10 +20,10 @@ export function initTextareaRowBreakout(__scope, _p = {}) {
       const __l = __e.last = []
       { const __t = __r[0]
       if (__t) {
-        const __x = value()
+        { const __x = value()
         const __val = String(__x)
         if ('value' in __t) { if (__t.value !== __val) __t.value = __val } else { __t.setAttribute('value', __val) }
-        __l[0] = __x
+        __l[0] = __x }
       } }
       return __el
     },
@@ -36,12 +36,12 @@ export function initTextareaRowBreakout(__scope, _p = {}) {
         const __l = __e.last ?? (__e.last = [])
         { const __t = 0 in __r ? __r[0] : (__r[0] = qsa(__e.primaryEl, '[bf="s1"]'))
         if (__t) {
-          const __x = value()
+          { const __x = value()
           if (__seed ? (('value' in __t ? __t.value !== String(__x) : __t.getAttribute('value') !== String(__x))) : (!(0 in __l) || !Object.is(__l[0], __x))) {
             const __val = String(__x)
             if ('value' in __t) { if (__t.value !== __val) __t.value = __val } else { __t.setAttribute('value', __val) }
           }
-          __l[0] = __x
+          __l[0] = __x }
         } }
       }
     },

--- a/packages/adapter-tests/fixtures/__snapshots__/textarea.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/textarea.client.js
@@ -16,19 +16,48 @@ export function initTextarea(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input w-full min-w-0 rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-[invalid]:ring-destructive/20 dark:aria-[invalid]:ring-destructive/40 aria-[invalid]:border-destructive ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
-      { const __v = (_p.placeholder ?? ''); if (__v != null) _s0.setAttribute('placeholder', String(__v)); else _s0.removeAttribute('placeholder') }
-      const __val = String((_p.value ?? ''))
-      if ('value' in _s0) { if (_s0.value !== __val) _s0.value = __val } else { _s0.setAttribute('value', __val) }
-      _s0.disabled = !!((_p.disabled ?? false))
-      _s0.readonly = !!((_p.readonly ?? false))
-      { const __v = _p.rows; if (__v != null) _s0.setAttribute('rows', String(__v)); else _s0.removeAttribute('rows') }
-      if ((_p.error ?? false)) _s0.setAttribute('aria-invalid', 'true')
-      else _s0.removeAttribute('aria-invalid')
+      { const __x = `placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input w-full min-w-0 rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-[invalid]:ring-destructive/20 dark:aria-[invalid]:ring-destructive/40 aria-[invalid]:border-destructive ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
+      { const __x = (_p.placeholder ?? '')
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('placeholder', String(__v)); else _s0.removeAttribute('placeholder') }
+      }
+      __l[1] = __x }
+      { const __x = (_p.value ?? '')
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        const __val = String(__x)
+        if ('value' in _s0) { if (_s0.value !== __val) _s0.value = __val } else { _s0.setAttribute('value', __val) }
+      }
+      __l[2] = __x }
+      { const __x = (_p.disabled ?? false)
+      if (!(3 in __l) || !Object.is(__l[3], __x)) {
+        _s0.disabled = !!(__x)
+      }
+      __l[3] = __x }
+      { const __x = (_p.readonly ?? false)
+      if (!(4 in __l) || !Object.is(__l[4], __x)) {
+        _s0.readonly = !!(__x)
+      }
+      __l[4] = __x }
+      { const __x = _p.rows
+      if (!(5 in __l) || !Object.is(__l[5], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('rows', String(__v)); else _s0.removeAttribute('rows') }
+      }
+      __l[5] = __x }
+      { const __x = (_p.error ?? false)
+      if (!(6 in __l) || !Object.is(__l[6], __x)) {
+        if (__x) _s0.setAttribute('aria-invalid', 'true')
+        else _s0.removeAttribute('aria-invalid')
+      }
+      __l[6] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["className","placeholder","value","disabled","readonly","error","describedBy","rows","onInput","onChange","onBlur","onFocus","data-slot","class","aria-invalid"])
 

--- a/packages/adapter-tests/fixtures/__snapshots__/todo-app-ssr.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/todo-app-ssr.client.js
@@ -12,24 +12,39 @@ export function initTodoItem(__scope, _p = {}) {
     __bfw_s1('s1', escapeTextOrNode(__val))
   })
 
+  { const __l = []
   createEffect(() => {
     if (_s5) {
-      { const __v = _p.todo.done ? (_p.todo.editing ? 'completed editing' : 'completed') : (_p.todo.editing ? 'editing' : ''); if (__v != null) _s5.setAttribute('class', String(__v)); else _s5.removeAttribute('class') }
+      { const __x = _p.todo.done ? (_p.todo.editing ? 'completed editing' : 'completed') : (_p.todo.editing ? 'editing' : '')
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s5.setAttribute('class', String(__v)); else _s5.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      _s0.checked = !!(_p.todo.done)
+      { const __x = _p.todo.done
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        _s0.checked = !!(__x)
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
+  { const __l = []
   createEffect(() => {
     if (_s4) {
-      const __val = String(_p.todo.text)
-      if ('value' in _s4) { if (_s4.value !== __val) _s4.value = __val } else { _s4.setAttribute('value', __val) }
+      { const __x = _p.todo.text
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        const __val = String(__x)
+        if ('value' in _s4) { if (_s4.value !== __val) _s4.value = __val } else { _s4.setAttribute('value', __val) }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) _s0.addEventListener('change', () => { _p.onToggle() })
   if (_s2) _s2.addEventListener('dblclick', () => { _p.onStartEdit() })
@@ -165,30 +180,50 @@ export function initTodoAppSSR(__scope, _p = {}) {
     __bfw_s6('s6', escapeTextOrNode(__val))
   })
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      const __val = String(newText())
-      if ('value' in _s0) { if (_s0.value !== __val) _s0.value = __val } else { _s0.setAttribute('value', __val) }
+      { const __x = newText()
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        const __val = String(__x)
+        if ('value' in _s0) { if (_s0.value !== __val) _s0.value = __val } else { _s0.setAttribute('value', __val) }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
+  { const __l = []
   createEffect(() => {
     if (_s10) {
-      { const __v = `${filter() === 'all' ? 'selected' : ''}`; if (__v != null) _s10.setAttribute('class', String(__v)); else _s10.removeAttribute('class') }
+      { const __x = `${filter() === 'all' ? 'selected' : ''}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s10.setAttribute('class', String(__v)); else _s10.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
+  { const __l = []
   createEffect(() => {
     if (_s11) {
-      { const __v = `${filter() === 'active' ? 'selected' : ''}`; if (__v != null) _s11.setAttribute('class', String(__v)); else _s11.removeAttribute('class') }
+      { const __x = `${filter() === 'active' ? 'selected' : ''}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s11.setAttribute('class', String(__v)); else _s11.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
+  { const __l = []
   createEffect(() => {
     if (_s12) {
-      { const __v = `${filter() === 'completed' ? 'selected' : ''}`; if (__v != null) _s12.setAttribute('class', String(__v)); else _s12.removeAttribute('class') }
+      { const __x = `${filter() === 'completed' ? 'selected' : ''}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s12.setAttribute('class', String(__v)); else _s12.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   insert(__scope, 's1', () => todos().length > 0, {
     template: () => { const __slots = []; return { html: `<!--bf-cond-start:s1--><input id="toggle-all" class="toggle-all" type="checkbox" ${todos().every(t => t.done) ? 'checked' : ''} bf="s2" /><label for="toggle-all">Mark all as complete</label><!--bf-cond-end:s1-->`, slots: __slots } },
@@ -197,9 +232,14 @@ export function initTodoAppSSR(__scope, _p = {}) {
       if (_s2) _s2.addEventListener('change', handleToggleAll)
       const __disposers = []
       { const __ra_s2 = qsa(__branchScope, '[bf="s2"]')
+      const __l = []
       if (__ra_s2) {
         __disposers.push(createDisposableEffect(() => {
-          __ra_s2.checked = !!(todos().every(t => t.done))
+          { const __x = todos().every(t => t.done)
+          if (!(0 in __l) || !Object.is(__l[0], __x)) {
+            __ra_s2.checked = !!(__x)
+          }
+          __l[0] = __x }
         }))
       } }
       return () => __disposers.forEach(d => d())

--- a/packages/adapter-tests/fixtures/__snapshots__/todo-app.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/todo-app.client.js
@@ -12,24 +12,39 @@ export function initTodoItem(__scope, _p = {}) {
     __bfw_s1('s1', escapeTextOrNode(__val))
   })
 
+  { const __l = []
   createEffect(() => {
     if (_s5) {
-      { const __v = _p.todo.done ? (_p.todo.editing ? 'completed editing' : 'completed') : (_p.todo.editing ? 'editing' : ''); if (__v != null) _s5.setAttribute('class', String(__v)); else _s5.removeAttribute('class') }
+      { const __x = _p.todo.done ? (_p.todo.editing ? 'completed editing' : 'completed') : (_p.todo.editing ? 'editing' : '')
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s5.setAttribute('class', String(__v)); else _s5.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      _s0.checked = !!(_p.todo.done)
+      { const __x = _p.todo.done
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        _s0.checked = !!(__x)
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
+  { const __l = []
   createEffect(() => {
     if (_s4) {
-      const __val = String(_p.todo.text)
-      if ('value' in _s4) { if (_s4.value !== __val) _s4.value = __val } else { _s4.setAttribute('value', __val) }
+      { const __x = _p.todo.text
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        const __val = String(__x)
+        if ('value' in _s4) { if (_s4.value !== __val) _s4.value = __val } else { _s4.setAttribute('value', __val) }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) _s0.addEventListener('change', () => { _p.onToggle() })
   if (_s2) _s2.addEventListener('dblclick', () => { _p.onStartEdit() })
@@ -165,30 +180,50 @@ export function initTodoApp(__scope, _p = {}) {
     __bfw_s6('s6', todos().filter(t => !t.done).length)
   }) }
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      const __val = String(newText())
-      if ('value' in _s0) { if (_s0.value !== __val) _s0.value = __val } else { _s0.setAttribute('value', __val) }
+      { const __x = newText()
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        const __val = String(__x)
+        if ('value' in _s0) { if (_s0.value !== __val) _s0.value = __val } else { _s0.setAttribute('value', __val) }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
+  { const __l = []
   createEffect(() => {
     if (_s10) {
-      { const __v = `${filter() === 'all' ? 'selected' : ''}`; if (__v != null) _s10.setAttribute('class', String(__v)); else _s10.removeAttribute('class') }
+      { const __x = `${filter() === 'all' ? 'selected' : ''}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s10.setAttribute('class', String(__v)); else _s10.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
+  { const __l = []
   createEffect(() => {
     if (_s11) {
-      { const __v = `${filter() === 'active' ? 'selected' : ''}`; if (__v != null) _s11.setAttribute('class', String(__v)); else _s11.removeAttribute('class') }
+      { const __x = `${filter() === 'active' ? 'selected' : ''}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s11.setAttribute('class', String(__v)); else _s11.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
+  { const __l = []
   createEffect(() => {
     if (_s12) {
-      { const __v = `${filter() === 'completed' ? 'selected' : ''}`; if (__v != null) _s12.setAttribute('class', String(__v)); else _s12.removeAttribute('class') }
+      { const __x = `${filter() === 'completed' ? 'selected' : ''}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s12.setAttribute('class', String(__v)); else _s12.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   insert(__scope, 's1', () => todos().length > 0, {
     template: () => { const __slots = []; return { html: `<!--bf-cond-start:s1--><input id="toggle-all" class="toggle-all" type="checkbox" bf="s2" /><label for="toggle-all">Mark all as complete</label><!--bf-cond-end:s1-->`, slots: __slots } },
@@ -197,9 +232,14 @@ export function initTodoApp(__scope, _p = {}) {
       if (_s2) _s2.addEventListener('change', handleToggleAll)
       const __disposers = []
       { const __ra_s2 = qsa(__branchScope, '[bf="s2"]')
+      const __l = []
       if (__ra_s2) {
         __disposers.push(createDisposableEffect(() => {
-          __ra_s2.checked = !!(todos().every(t => t.done))
+          { const __x = todos().every(t => t.done)
+          if (!(0 in __l) || !Object.is(__l[0], __x)) {
+            __ra_s2.checked = !!(__x)
+          }
+          __l[0] = __x }
         }))
       } }
       return () => __disposers.forEach(d => d())

--- a/packages/adapter-tests/fixtures/__snapshots__/toggle-shared.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/toggle-shared.client.js
@@ -14,11 +14,16 @@ export function initToggleItem(__scope, _p = {}) {
     __bfw_s0('s0', escapeTextOrNode(__val))
   })
 
+  { const __l = []
   createEffect(() => {
     if (_s3) {
-      { const __v = styleToCss(`padding: 4px 12px; min-width: 60px; background: ${on() ? '#4caf50' : '#ccc'}; color: ${on() ? 'white' : 'black'}; border: none; border-radius: 4px; cursor: pointer;`); if (__v != null) _s3.setAttribute('style', __v); else _s3.removeAttribute('style') }
+      { const __x = `padding: 4px 12px; min-width: 60px; background: ${on() ? '#4caf50' : '#ccc'}; color: ${on() ? 'white' : 'black'}; border: none; border-radius: 4px; cursor: pointer;`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = styleToCss(__x); if (__v != null) _s3.setAttribute('style', __v); else _s3.removeAttribute('style') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   insert(__scope, 's2', () => on(), {
     template: () => { const __slots = []; return { html: `<!--bf-cond-start:s2-->${__bfSlot('ON', __slots)}<!--bf-cond-end:s2-->`, slots: __slots } },

--- a/packages/adapter-tests/fixtures/__snapshots__/toggle.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/toggle.client.js
@@ -54,15 +54,36 @@ export function initToggle(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `${isPressed() ? 'on' : 'off'}`; if (__v != null) _s0.setAttribute('data-state', String(__v)); else _s0.removeAttribute('data-state') }
-      { const __v = _p.id; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
-      { const __v = isPressed(); if (__v != null) _s0.setAttribute('aria-pressed', String(__v)); else _s0.removeAttribute('aria-pressed') }
-      _s0.disabled = !!(_p.disabled ?? false)
-      { const __v = classes(); if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `${isPressed() ? 'on' : 'off'}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('data-state', String(__v)); else _s0.removeAttribute('data-state') }
+      }
+      __l[0] = __x }
+      { const __x = _p.id
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('id', String(__v)); else _s0.removeAttribute('id') }
+      }
+      __l[1] = __x }
+      { const __x = isPressed()
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('aria-pressed', String(__v)); else _s0.removeAttribute('aria-pressed') }
+      }
+      __l[2] = __x }
+      { const __x = _p.disabled ?? false
+      if (!(3 in __l) || !Object.is(__l[3], __x)) {
+        _s0.disabled = !!(__x)
+      }
+      __l[3] = __x }
+      { const __x = classes()
+      if (!(4 in __l) || !Object.is(__l[4], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[4] = __x }
     }
-  })
+  }) }
 
   if (_s0) _s0.addEventListener('click', handleClick)
 }

--- a/packages/adapter-tests/fixtures/__snapshots__/tooltip.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/tooltip.client.js
@@ -62,27 +62,58 @@ export function initTooltip(__scope, _p = {}) {
     __bfw_s0('s0', escapeTextOrNode(__val))
   })
 
+  { const __l = []
   createEffect(() => {
     if (_s3) {
-      { const __v = _p.id; if (__v != null) _s3.setAttribute('id', String(__v)); else _s3.removeAttribute('id') }
-      { const __v = `${tooltipContainerClasses} ${_p.className ?? ''}`; if (__v != null) _s3.setAttribute('class', String(__v)); else _s3.removeAttribute('class') }
-      { const __v = _p.id; if (__v != null) _s3.setAttribute('aria-describedby', String(__v)); else _s3.removeAttribute('aria-describedby') }
+      { const __x = _p.id
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s3.setAttribute('id', String(__v)); else _s3.removeAttribute('id') }
+      }
+      __l[0] = __x }
+      { const __x = `${tooltipContainerClasses} ${_p.className ?? ''}`
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s3.setAttribute('class', String(__v)); else _s3.removeAttribute('class') }
+      }
+      __l[1] = __x }
+      { const __x = _p.id
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        { const __v = __x; if (__v != null) _s3.setAttribute('aria-describedby', String(__v)); else _s3.removeAttribute('aria-describedby') }
+      }
+      __l[2] = __x }
     }
-  })
+  }) }
 
+  { const __l = []
   createEffect(() => {
     if (_s2) {
-      { const __v = `${open() ? 'open' : 'closed'}`; if (__v != null) _s2.setAttribute('data-state', String(__v)); else _s2.removeAttribute('data-state') }
-      { const __v = `absolute transition-[opacity,transform] duration-fast ease-out ${({"top": "bottom-full left-1/2 -translate-x-1/2 mb-2", "right": "left-full top-1/2 -translate-y-1/2 ml-2", "bottom": "top-full left-1/2 -translate-x-1/2 mt-2", "left": "right-full top-1/2 -translate-y-1/2 mr-2"})[_p.placement ?? 'top']} z-50 rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground whitespace-nowrap ${open() ? tooltipContentOpenClasses : tooltipContentClosedClasses}`; if (__v != null) _s2.setAttribute('class', String(__v)); else _s2.removeAttribute('class') }
-      { const __v = _p.id; if (__v != null) _s2.setAttribute('id', String(__v)); else _s2.removeAttribute('id') }
+      { const __x = `${open() ? 'open' : 'closed'}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s2.setAttribute('data-state', String(__v)); else _s2.removeAttribute('data-state') }
+      }
+      __l[0] = __x }
+      { const __x = `absolute transition-[opacity,transform] duration-fast ease-out ${({"top": "bottom-full left-1/2 -translate-x-1/2 mb-2", "right": "left-full top-1/2 -translate-y-1/2 ml-2", "bottom": "top-full left-1/2 -translate-x-1/2 mt-2", "left": "right-full top-1/2 -translate-y-1/2 mr-2"})[_p.placement ?? 'top']} z-50 rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground whitespace-nowrap ${open() ? tooltipContentOpenClasses : tooltipContentClosedClasses}`
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) _s2.setAttribute('class', String(__v)); else _s2.removeAttribute('class') }
+      }
+      __l[1] = __x }
+      { const __x = _p.id
+      if (!(2 in __l) || !Object.is(__l[2], __x)) {
+        { const __v = __x; if (__v != null) _s2.setAttribute('id', String(__v)); else _s2.removeAttribute('id') }
+      }
+      __l[2] = __x }
     }
-  })
+  }) }
 
+  { const __l = []
   createEffect(() => {
     if (_s1) {
-      { const __v = `absolute w-0 h-0 border-4 ${({"top": "top-full left-1/2 -translate-x-1/2 border-t-primary border-l-transparent border-r-transparent border-b-transparent", "right": "right-full top-1/2 -translate-y-1/2 border-r-primary border-t-transparent border-b-transparent border-l-transparent", "bottom": "bottom-full left-1/2 -translate-x-1/2 border-b-primary border-l-transparent border-r-transparent border-t-transparent", "left": "left-full top-1/2 -translate-y-1/2 border-l-primary border-t-transparent border-b-transparent border-r-transparent"})[_p.placement ?? 'top']}`; if (__v != null) _s1.setAttribute('class', String(__v)); else _s1.removeAttribute('class') }
+      { const __x = `absolute w-0 h-0 border-4 ${({"top": "top-full left-1/2 -translate-x-1/2 border-t-primary border-l-transparent border-r-transparent border-b-transparent", "right": "right-full top-1/2 -translate-y-1/2 border-r-primary border-t-transparent border-b-transparent border-l-transparent", "bottom": "bottom-full left-1/2 -translate-x-1/2 border-b-primary border-l-transparent border-r-transparent border-t-transparent", "left": "left-full top-1/2 -translate-y-1/2 border-l-primary border-t-transparent border-b-transparent border-r-transparent"})[_p.placement ?? 'top']}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s1.setAttribute('class', String(__v)); else _s1.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s3) _s3.addEventListener('mouseenter', handleMouseEnter)
   if (_s3) _s3.addEventListener('mouseleave', handleMouseLeave)
@@ -107,12 +138,17 @@ export function initSlot(__scope, _p = {}) {
 
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     const [__Tag_s0El] = $c(__scope, 's0')
     if (__Tag_s0El) {
-      { const __v = ([className, (((children.props).className) || '')].filter(Boolean).join(' ')); if (__v != null) __Tag_s0El.setAttribute('class', String(__v)); else __Tag_s0El.removeAttribute('class') }
+      { const __x = ([className, (((children.props).className) || '')].filter(Boolean).join(' '))
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) __Tag_s0El.setAttribute('class', String(__v)); else __Tag_s0El.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('Tag', _s0, forwardProps(_p, { get className() { return ([className, (((children.props).className) || '')].filter(Boolean).join(' ')) } }, ["className"]))
@@ -149,22 +185,32 @@ export function initButton(__scope, _p = {}) {
   const [_s0] = $(__scope, 's0')
   const [_s1] = $c(__scope, 's1')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = `inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*="size-"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-[invalid]:ring-destructive/20 dark:aria-[invalid]:ring-destructive/40 aria-[invalid]:border-destructive touch-action-manipulation ${({"default": "bg-primary text-primary-foreground hover:bg-primary/90", "destructive": "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60", "outline": "border border-input bg-background text-foreground shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:hover:bg-input/50", "secondary": "bg-secondary text-secondary-foreground hover:bg-secondary/80", "ghost": "text-foreground hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50", "link": "text-foreground underline-offset-4 hover:underline hover:text-primary"})[(_p.variant ?? 'default')]} ${({"default": "h-9 px-4 py-2 has-[>svg]:px-3", "sm": "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5", "lg": "h-10 rounded-md px-6 has-[>svg]:px-4", "icon": "size-9", "icon-sm": "size-8", "icon-lg": "size-10"})[(_p.size ?? 'default')]} ${(_p.className ?? '')}`; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = `inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*="size-"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-[invalid]:ring-destructive/20 dark:aria-[invalid]:ring-destructive/40 aria-[invalid]:border-destructive touch-action-manipulation ${({"default": "bg-primary text-primary-foreground hover:bg-primary/90", "destructive": "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60", "outline": "border border-input bg-background text-foreground shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:hover:bg-input/50", "secondary": "bg-secondary text-secondary-foreground hover:bg-secondary/80", "ghost": "text-foreground hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50", "link": "text-foreground underline-offset-4 hover:underline hover:text-primary"})[(_p.variant ?? 'default')]} ${({"default": "h-9 px-4 py-2 has-[>svg]:px-3", "sm": "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5", "lg": "h-10 rounded-md px-6 has-[>svg]:px-4", "icon": "size-9", "icon-sm": "size-8", "icon-lg": "size-10"})[(_p.size ?? 'default')]} ${(_p.className ?? '')}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["className","variant","size","asChild","children","class"])
 
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     const [__Slot_s1El] = $c(__scope, 's1')
     if (__Slot_s1El) {
-      { const __v = `inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*="size-"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-[invalid]:ring-destructive/20 dark:aria-[invalid]:ring-destructive/40 aria-[invalid]:border-destructive touch-action-manipulation ${({"default": "bg-primary text-primary-foreground hover:bg-primary/90", "destructive": "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60", "outline": "border border-input bg-background text-foreground shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:hover:bg-input/50", "secondary": "bg-secondary text-secondary-foreground hover:bg-secondary/80", "ghost": "text-foreground hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50", "link": "text-foreground underline-offset-4 hover:underline hover:text-primary"})[variant]} ${({"default": "h-9 px-4 py-2 has-[>svg]:px-3", "sm": "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5", "lg": "h-10 rounded-md px-6 has-[>svg]:px-4", "icon": "size-9", "icon-sm": "size-8", "icon-lg": "size-10"})[size]} ${className}`; if (__v != null) __Slot_s1El.setAttribute('class', String(__v)); else __Slot_s1El.removeAttribute('class') }
+      { const __x = `inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*="size-"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-[invalid]:ring-destructive/20 dark:aria-[invalid]:ring-destructive/40 aria-[invalid]:border-destructive touch-action-manipulation ${({"default": "bg-primary text-primary-foreground hover:bg-primary/90", "destructive": "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60", "outline": "border border-input bg-background text-foreground shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:hover:bg-input/50", "secondary": "bg-secondary text-secondary-foreground hover:bg-secondary/80", "ghost": "text-foreground hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50", "link": "text-foreground underline-offset-4 hover:underline hover:text-primary"})[variant]} ${({"default": "h-9 px-4 py-2 has-[>svg]:px-3", "sm": "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5", "lg": "h-10 rounded-md px-6 has-[>svg]:px-4", "icon": "size-9", "icon-sm": "size-8", "icon-lg": "size-10"})[size]} ${className}`
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) __Slot_s1El.setAttribute('class', String(__v)); else __Slot_s1El.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('Slot', _s1, forwardProps(_p, { get className() { return `inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*="size-"])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-[invalid]:ring-destructive/20 dark:aria-[invalid]:ring-destructive/40 aria-[invalid]:border-destructive touch-action-manipulation ${({"default": "bg-primary text-primary-foreground hover:bg-primary/90", "destructive": "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60", "outline": "border border-input bg-background text-foreground shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:hover:bg-input/50", "secondary": "bg-secondary text-secondary-foreground hover:bg-secondary/80", "ghost": "text-foreground hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50", "link": "text-foreground underline-offset-4 hover:underline hover:text-primary"})[variant]} ${({"default": "h-9 px-4 py-2 has-[>svg]:px-3", "sm": "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5", "lg": "h-10 rounded-md px-6 has-[>svg]:px-4", "icon": "size-9", "icon-sm": "size-8", "icon-lg": "size-10"})[size]} ${className}` } }, ["className"]))

--- a/packages/client/__tests__/runtime/issue-2869-attr-dedup-guard.test.ts
+++ b/packages/client/__tests__/runtime/issue-2869-attr-dedup-guard.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Regression test for #2869: an eager reactive-attribute write —
+ * `emitAttrUpdate`'s generic/`class`/`style`/`dangerouslySetInnerHTML`
+ * branches, invoked from `emitReactiveAttributeUpdates` (a plain per-slot
+ * effect) or from `emitConsolidatedRowEffect` (a keyed `.map()` row's ONE
+ * fused effect covering every attr/text binding on that row) — used to
+ * rewrite the DOM unconditionally on every effect rerun, no matter which
+ * binding in that effect actually changed. `untrack()` cannot fix this on
+ * its own: it only suppresses dependency REGISTRATION for the wrapped read,
+ * not re-execution of the surrounding effect when a sibling binding
+ * legitimately changes — so an `<iframe srcdoc={untrack(...)}>` sharing a
+ * row's fused effect with an unrelated, genuinely reactive sibling binding
+ * (e.g. `data-key={item.key}`) kept reloading on every edit to that row.
+ *
+ * The fix (`emitDedupedAttrUpdate`, `packages/jsx/src/ir-to-client-js/
+ * emit-reactive.ts`) wraps every eager attribute write in an `Object.is`
+ * previous-value guard backed by a per-effect `__l` store — the same
+ * dedup contract the lazy row graph (`control-flow/stringify/lazy-row.ts`)
+ * already had, now shared by every eager site too.
+ *
+ * Test shape mirrors `issue-2716-value-expando.test.ts`: compile real
+ * repro components with `compileJSX` + `TestAdapter`, render their SSR
+ * HTML with `renderHonoComponent` + `HonoAdapter`, hydrate against
+ * `@happy-dom/global-registrator`, then dispatch DOM events / call signal
+ * setters and assert on `setAttribute` call counts and a run counter
+ * instrumenting the `untrack`-wrapped expression.
+ */
+import { describe, test, expect, beforeAll, beforeEach, afterEach } from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+import { compileJSX } from '../../../jsx/src/compiler'
+import { TestAdapter } from '../../../jsx/src/adapters/test-adapter'
+import { renderHonoComponent } from '../../../adapter-hono/src/test-render'
+import { HonoAdapter } from '../../../adapter-hono/src/adapter/hono-adapter'
+import { writeFileSync, mkdtempSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+beforeAll(() => {
+  if (typeof window === 'undefined') GlobalRegistrator.register()
+})
+
+const adapter = new TestAdapter()
+const runtimePath = join(__dirname, '../../src/runtime/index.ts')
+
+/** Compile a component's client JS with imports re-anchored to the live runtime. */
+function clientJsFor(source: string, filename: string): string {
+  const result = compileJSX(source, filename, { adapter })
+  const errors = result.errors.filter(e => e.severity === 'error')
+  if (errors.length > 0) {
+    throw new Error(`Compile errors in ${filename}:\n${errors.map(e => `${e.code}: ${e.message}`).join('\n')}`)
+  }
+  const clientJs = result.files.find(f => f.type === 'clientJs')?.content
+  if (!clientJs) throw new Error(`No client JS for ${filename}`)
+  return clientJs
+    .replace(/from\s+['"]@barefootjs\/client\/runtime['"]/g, `from '${runtimePath}'`)
+    .replace(/^import '\/\* @bf-child:\w+ \*\/'\n/gm, '')
+}
+
+async function setupHydration(source: string): Promise<{ hydrate: () => void; clientJs: string }> {
+  const dir = mkdtempSync(join(tmpdir(), 'bf-2869-'))
+  const clientJs = clientJsFor(source, 'Repro.tsx')
+  const file = join(dir, 'Repro.mjs')
+  writeFileSync(file, clientJs)
+  await import(file)
+
+  const ssrHtml = await renderHonoComponent({
+    adapter: new HonoAdapter(),
+    source,
+    props: { __instanceId: 'Repro_test' },
+  })
+  document.body.innerHTML = ssrHtml
+
+  const { rehydrateAll, flushHydration } = await import(runtimePath)
+  return {
+    clientJs,
+    hydrate: () => {
+      rehydrateAll()
+      flushHydration()
+    },
+  }
+}
+
+/** Count `setAttribute` calls per (element, name), installed AFTER hydrate
+ *  so first-run writes are never counted. Restored in `afterEach`. */
+function installAttrWriteCounter() {
+  const proto = window.Element.prototype
+  const orig = proto.setAttribute
+  const counts = new Map<Element, Map<string, number>>()
+  proto.setAttribute = function (this: Element, name: string, value: string) {
+    let m = counts.get(this)
+    if (!m) counts.set(this, (m = new Map()))
+    m.set(name, (m.get(name) ?? 0) + 1)
+    return orig.call(this, name, value)
+  }
+  return {
+    writes: (el: Element, name: string) => counts.get(el)?.get(name) ?? 0,
+    restore: () => {
+      proto.setAttribute = orig
+    },
+  }
+}
+
+const docRuns = (): number => (globalThis as unknown as { __docRuns?: number }).__docRuns ?? 0
+
+describe('#2869 — reactive attribute writes are deduped against their previous value', () => {
+  let counter: ReturnType<typeof installAttrWriteCounter> | null = null
+
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    ;(globalThis as unknown as { __docRuns?: number }).__docRuns = 0
+  })
+
+  afterEach(() => {
+    counter?.restore()
+    counter = null
+  })
+
+  test('fused keyed-row effect: an unrelated sibling change reruns the row effect but does not rewrite an unchanged untracked attribute', async () => {
+    const source = `'use client'
+import { createSignal, untrack } from '@barefootjs/client'
+
+function seedItems() {
+  return [{ id: 1, label: 'a' }, { id: 2, label: 'b' }]
+}
+
+function docFor(id: number): string {
+  globalThis.__docRuns = (globalThis.__docRuns || 0) + 1
+  return 'doc-' + id
+}
+
+export function Repro() {
+  const [items, setItems] = createSignal(seedItems())
+  return (
+    <div>
+      <button id="bump" onClick={() => setItems(items().map(it => ({ id: it.id, label: it.label + '!' })))}>bump</button>
+      <ul>
+        {items().map(item => (
+          <li key={item.id} title={item.label} data-doc={untrack(() => docFor(item.id))}>{item.label}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+`
+    const { hydrate, clientJs } = await setupHydration(source)
+    // Pin the eager path (module docstring above / issue #2869): this must
+    // exercise `emitConsolidatedRowEffect`, not the already-guarded lazy
+    // row graph. If a future eligibility widening moves this repro onto
+    // `mapArrayLazy`, fail loudly instead of passing for the wrong reason.
+    expect(clientJs).toContain('mapArray(')
+    expect(clientJs).not.toContain('mapArrayLazy(')
+
+    hydrate()
+
+    const [li1, li2] = Array.from(document.querySelectorAll('li'))
+    expect(li1.getAttribute('title')).toBe('a')
+    expect(li1.getAttribute('data-doc')).toBe('doc-1')
+    expect(li2.getAttribute('data-doc')).toBe('doc-2')
+
+    counter = installAttrWriteCounter()
+    const base = docRuns()
+
+    // Same keys, new item objects with a changed `label` — reconciles via
+    // `setItem`/`setIndex` (batched), so each row's fused effect reruns
+    // exactly once.
+    document.getElementById('bump')!.dispatchEvent(new window.Event('click', { bubbles: true }))
+
+    // The sibling binding (`title`, tracked) DID change and DID write —
+    // proof the shared row effect actually reran.
+    expect(li1.getAttribute('title')).toBe('a!')
+    expect(counter.writes(li1, 'title')).toBe(1)
+
+    // The untracked read reruns every time its surrounding effect reruns —
+    // untrack only suppresses dependency registration, not re-execution.
+    expect(docRuns()).toBe(base + 2)
+
+    // But its VALUE never changed, so the guard skips the write — this is
+    // the regression assertion; before the fix this was 1 (a `srcdoc`
+    // iframe would have reloaded here despite `untrack`).
+    expect(counter.writes(li1, 'data-doc')).toBe(0)
+    expect(counter.writes(li2, 'data-doc')).toBe(0)
+    expect(li1.getAttribute('data-doc')).toBe('doc-1')
+    expect(li2.getAttribute('data-doc')).toBe('doc-2')
+
+    // A second edit reconfirms the guard keeps holding, not just once.
+    document.getElementById('bump')!.dispatchEvent(new window.Event('click', { bubbles: true }))
+    expect(li1.getAttribute('title')).toBe('a!!')
+    expect(counter.writes(li1, 'title')).toBe(2)
+    expect(docRuns()).toBe(base + 4)
+    expect(counter.writes(li1, 'data-doc')).toBe(0)
+  })
+
+  test('non-loop reactive attrs: an unrelated sibling change reruns the effect but a changed untracked value still writes', async () => {
+    const source = `'use client'
+import { createSignal, untrack } from '@barefootjs/client'
+
+function docFor(n: number): string {
+  globalThis.__docRuns = (globalThis.__docRuns || 0) + 1
+  return 'doc-' + n
+}
+
+export function Repro() {
+  const [count, setCount] = createSignal(0)
+  const [step, setStep] = createSignal(1)
+  return (
+    <div>
+      <button id="count-btn" onClick={() => setCount(c => c + 1)}>count</button>
+      <button id="step-btn" onClick={() => setStep(s => s + 1)}>step</button>
+      <p id="target" title={String(count())} data-doc={untrack(() => docFor(step()))}>x</p>
+    </div>
+  )
+}
+`
+    const { hydrate } = await setupHydration(source)
+    hydrate()
+
+    const p = document.getElementById('target')!
+    expect(p.getAttribute('data-doc')).toBe('doc-1')
+
+    counter = installAttrWriteCounter()
+    const base = docRuns()
+
+    // Clicking `step` alone: `step()` is read only inside `untrack` in this
+    // component, so it never registered as a dependency — the effect does
+    // not rerun at all.
+    document.getElementById('step-btn')!.dispatchEvent(new window.Event('click', { bubbles: true }))
+    expect(counter.writes(p, 'title')).toBe(0)
+    expect(counter.writes(p, 'data-doc')).toBe(0)
+    expect(docRuns()).toBe(base)
+    expect(p.getAttribute('data-doc')).toBe('doc-1')
+
+    // Clicking `count`: the effect reruns (title's own dependency), so the
+    // untracked expression reruns too — and its value NOW differs (step is
+    // 2), so it DOES write. Positive control: a genuinely changed value is
+    // never suppressed by the guard.
+    document.getElementById('count-btn')!.dispatchEvent(new window.Event('click', { bubbles: true }))
+    expect(p.getAttribute('title')).toBe('1')
+    expect(counter.writes(p, 'title')).toBe(1)
+    expect(docRuns()).toBe(base + 1)
+    expect(counter.writes(p, 'data-doc')).toBe(1)
+    expect(p.getAttribute('data-doc')).toBe('doc-2')
+
+    // Clicking `count` again: the effect reruns again, `step()` is still 2
+    // so the untracked expression recomputes to the SAME 'doc-2' — the
+    // regression assertion: no second write.
+    document.getElementById('count-btn')!.dispatchEvent(new window.Event('click', { bubbles: true }))
+    expect(p.getAttribute('title')).toBe('2')
+    expect(counter.writes(p, 'title')).toBe(2)
+    expect(docRuns()).toBe(base + 2)
+    expect(counter.writes(p, 'data-doc')).toBe(1)
+  })
+})

--- a/packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap
+++ b/packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap
@@ -2550,6 +2550,99 @@ hydrate('StatementExample', { init: initStatementExample, template: (_p) => \`<d
 export function StatementExample(_p, __bfKey) { return createComponent('StatementExample', _p, __bfKey) }"
 `;
 
+exports[`docs/core/reactivity/untrack.md doc-examples L79 — (no label) 1`] = `
+"import { $, createComponent, createSignal, escapeAttr, escapeText, hydrate, lazySlots, mapArrayLazy, qsa, textOrNode, untrack } from '@barefootjs/client/runtime'
+
+var renderPreview = renderPreview ?? function(id) {
+  return \`<p>Preview for item \${id}</p>\`
+}
+
+export function initGallery(__scope, _p = {}) {
+  if (!__scope) return
+  const __scopeId = __scope.getAttribute('bf-s')
+
+  const [items, setItems] = createSignal([{ id: 1, label: 'First' }, { id: 2, label: 'Second' }])
+  const rename = () => setItems(items().map(item => ({ id: item.id, label: item.label + '!' })))
+
+  const [_s0, _s3] = $(__scope, 's0', 's3')
+
+  if (_s0) _s0.addEventListener('click', rename)
+  const __tpl_l0 = document.createElement('template')
+  __tpl_l0.innerHTML = \`<li data-key="" bf="s2"><!--bf:s1--><!--/--></li>\`
+  const __lzp_l0 = [[0]]
+  const __lzs_l0 = [{ id: 's1', kind: 'text', path: [] }]
+  const __lzsc_l0 = [{ id: 's1', kind: 'text', path: __lzp_l0[0] }]
+  mapArrayLazy(() => items(), _s3, (item) => String(item.id), {
+    createRow: (__e, __idx) => {
+      const item = () => __e.item
+      const __el = __tpl_l0.content.firstElementChild.cloneNode(true)
+      const __r = __e.refs = [__el, lazySlots(__el, __lzsc_l0)]
+      const __l = __e.last = []
+      { const __t = __r[0]
+      if (__t) {
+        { const __x = item().label
+        { const __v = __x; if (__v != null) __t.setAttribute('title', String(__v)); else __t.removeAttribute('title') }
+        __l[0] = __x }
+      } }
+      { const __t = __r[0]
+      if (__t) {
+        { const __x = untrack(() => renderPreview(item().id))
+        { const __v = __x; if (__v != null) __t.setAttribute('data-preview', String(__v)); else __t.removeAttribute('data-preview') }
+        __l[1] = __x }
+      } }
+      { const __x = item().label
+      __r[1]('s1', textOrNode(__x))
+      __l[2] = __x }
+      return __el
+    },
+    applyItem: (__e) => {
+      const item = () => __e.item
+      const __r = __e.refs ?? (__e.refs = [])
+      const __l = __e.last ?? (__e.last = [])
+      { const __t = 0 in __r ? __r[0] : (__r[0] = qsa(__e.primaryEl, '[bf="s2"]'))
+      if (__t) {
+        { const __x = item().label
+        if (!(0 in __l) || !Object.is(__l[0], __x)) {
+          { const __v = __x; if (__v != null) __t.setAttribute('title', String(__v)); else __t.removeAttribute('title') }
+        }
+        __l[0] = __x }
+      } }
+      { const __t = 0 in __r ? __r[0] : (__r[0] = qsa(__e.primaryEl, '[bf="s2"]'))
+      if (__t) {
+        { const __x = untrack(() => renderPreview(item().id))
+        if (!(1 in __l) || !Object.is(__l[1], __x)) {
+          { const __v = __x; if (__v != null) __t.setAttribute('data-preview', String(__v)); else __t.removeAttribute('data-preview') }
+        }
+        __l[1] = __x }
+      } }
+      const __d = __r[1] ?? (__r[1] = lazySlots(__e.primaryEl, __lzs_l0))
+      { const __x = item().label
+      if (!(2 in __l) || !Object.is(__l[2], __x)) __d('s1', textOrNode(__x))
+      __l[2] = __x }
+    },
+    applyOuter: (__es, __seed) => {
+      for (const __e of __es) {
+        const item = () => __e.item
+        const __r = __e.refs ?? (__e.refs = [])
+        const __l = __e.last ?? (__e.last = [])
+        { const __t = 0 in __r ? __r[0] : (__r[0] = qsa(__e.primaryEl, '[bf="s2"]'))
+        if (__t) {
+          { const __x = untrack(() => renderPreview(item().id))
+          if (__seed ? (__t.getAttribute('data-preview') !== (__x != null ? String(__x) : null)) : (!(1 in __l) || !Object.is(__l[1], __x))) {
+            { const __v = __x; if (__v != null) __t.setAttribute('data-preview', String(__v)); else __t.removeAttribute('data-preview') }
+          }
+          __l[1] = __x }
+        } }
+      }
+    },
+  }, 'l0')
+
+}
+
+hydrate('Gallery', { init: initGallery, template: (_p) => \`<div><button bf="s0">Rename all</button><ul bf="s3"><!--bf-loop:l0-->\${([{ id: 1, label: 'First' }, { id: 2, label: 'Second' }]).map((item) => \`<li data-key="\${escapeAttr(item.id)}" \${(item.label) != null ? 'title="' + escapeAttr(item.label) + '"' : ''} \${(untrack(() => renderPreview(item.id))) != null ? 'data-preview="' + escapeAttr(untrack(() => renderPreview(item.id))) + '"' : ''} bf="s2"><!--bf:s1-->\${escapeText(item.label)}<!--/--></li>\`).join('')}<!--bf-/loop:l0--></ul></div>\` })
+export function Gallery(_p, __bfKey) { return createComponent('Gallery', _p, __bfKey) }"
+`;
+
 exports[`docs/core/reactivity/props-reactivity.md doc-examples L16 — (no label) 1`] = `
 "import { createComponent, hydrate } from '@barefootjs/client/runtime'
 
@@ -2635,12 +2728,13 @@ export function initExample(__scope, _p = {}) {
   })
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     const [__Child_s0El] = $c(__scope, 's0')
     if (__Child_s0El) {
       if ('value' in __Child_s0El) { const __val = String(count()); if (__Child_s0El.value !== __val) __Child_s0El.value = __val }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('Child', _s0, { get value() { return count() } })
@@ -3253,12 +3347,17 @@ export function initExample(__scope, _p = {}) {
 
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     const [__Dialog_s9El] = $c(__scope, 's9')
     if (__Dialog_s9El) {
-      __Dialog_s9El.open = !!(open())
+      { const __x = open()
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        __Dialog_s9El.open = !!(__x)
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('Dialog', _s9, { get open() { return open() }, onOpenChange: setOpen })
@@ -3936,11 +4035,16 @@ export function initButton(__scope, _p = {}) {
 
   const [_s0] = $(__scope, 's0')
 
+  { const __l = []
   createEffect(() => {
     if (_s0) {
-      { const __v = classes; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      { const __x = classes
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s0.setAttribute('class', String(__v)); else _s0.removeAttribute('class') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
   if (_s0) applyRestAttrs(_s0, _p, ["class"])
 
@@ -4109,24 +4213,38 @@ export function initProductPage(__scope, _p = {}) {
     __bfw_s2('s2', escapeTextOrNode(__val))
   })
 
+  { const __l = []
   createEffect(() => {
     if (_s4) {
-      { const __v = _p.product.image; if (__v != null) _s4.setAttribute('src', String(__v)); else _s4.removeAttribute('src') }
+      { const __x = _p.product.image
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) _s4.setAttribute('src', String(__v)); else _s4.removeAttribute('src') }
+      }
+      __l[0] = __x }
     }
-  })
+  }) }
 
 
   // Reactive child component props
+  { const __l = []
   createEffect(() => {
     const [__ReviewStars_s5El] = $c(__scope, 's5')
     if (__ReviewStars_s5El) {
-      { const __v = product.rating; if (__v != null) __ReviewStars_s5El.setAttribute('rating', String(__v)); else __ReviewStars_s5El.removeAttribute('rating') }
+      { const __x = product.rating
+      if (!(0 in __l) || !Object.is(__l[0], __x)) {
+        { const __v = __x; if (__v != null) __ReviewStars_s5El.setAttribute('rating', String(__v)); else __ReviewStars_s5El.removeAttribute('rating') }
+      }
+      __l[0] = __x }
     }
     const [__AddToCart_s6El] = $c(__scope, 's6')
     if (__AddToCart_s6El) {
-      { const __v = product.id; if (__v != null) __AddToCart_s6El.setAttribute('productId', String(__v)); else __AddToCart_s6El.removeAttribute('productId') }
+      { const __x = product.id
+      if (!(1 in __l) || !Object.is(__l[1], __x)) {
+        { const __v = __x; if (__v != null) __AddToCart_s6El.setAttribute('productId', String(__v)); else __AddToCart_s6El.removeAttribute('productId') }
+      }
+      __l[1] = __x }
     }
-  })
+  }) }
 
   // Initialize child components with props
   initChild('ReviewStars', _s5, { get rating() { return product.rating } })

--- a/packages/jsx/src/__tests__/child-prop-fallback-wrap.test.ts
+++ b/packages/jsx/src/__tests__/child-prop-fallback-wrap.test.ts
@@ -260,7 +260,9 @@ describe('Solid-style wrap-by-default fallback for child-component props (#942)'
     // The emitted code rewrites `props.xxx` to the internal props-param
     // name (`_p.xxx`) via rewriteDestructuredPropsInExpr. Assert on the
     // emitted form — the gate's `expandedValue.includes('props.')` check
-    // still runs against the source expression before rewriting.
-    expect(clientJs).toMatch(/__v\s*=\s*_p\.title/)
+    // still runs against the source expression before rewriting. The
+    // dedup-guarded write (#2869) computes into `__x` first, then assigns
+    // `__v = __x` inside `emitAttrUpdate`'s own generic branch.
+    expect(clientJs).toMatch(/__x\s*=\s*_p\.title/)
   })
 })

--- a/packages/jsx/src/__tests__/issue-2869-attr-dedup-guard.test.ts
+++ b/packages/jsx/src/__tests__/issue-2869-attr-dedup-guard.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Codegen-shape pins for #2869: every eager reactive-attribute write must go
+ * through `emitDedupedAttrUpdate` (`emit-reactive.ts`), never `emitAttrUpdate`
+ * directly from an effect body. These are cheap shape assertions alongside
+ * the behavioral regression test in
+ * `packages/client/__tests__/runtime/issue-2869-attr-dedup-guard.test.ts`,
+ * which is the one that actually proves the fix (this file cannot observe
+ * write counts over time, only the emitted source shape).
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+function clientJsFor(source: string, options: Parameters<typeof compileJSX>[2] = { adapter }): string {
+  const result = compileJSX(source, 'Repro.tsx', options)
+  const errors = result.errors.filter(e => e.severity === 'error')
+  expect(errors).toHaveLength(0)
+  const clientJs = result.files.find(f => f.type === 'clientJs')?.content
+  if (!clientJs) throw new Error('No client JS emitted')
+  return clientJs
+}
+
+// Non-loop per-slot reactive attrs (`emitReactiveAttributeUpdates`) — two
+// attrs sharing one element, one of them wrapped in `untrack`.
+const NON_LOOP_SOURCE = `'use client'
+import { createSignal, untrack } from '@barefootjs/client'
+
+function docFor(n: number): string {
+  return 'doc-' + n
+}
+
+export function Repro() {
+  const [count, setCount] = createSignal(0)
+  const [step, setStep] = createSignal(1)
+  return (
+    <div>
+      <button class="count" onClick={() => setCount(c => c + 1)}>count</button>
+      <button class="step" onClick={() => setStep(s => s + 1)}>step</button>
+      <p class="target" title={String(count())} data-doc={untrack(() => docFor(step()))}>x</p>
+    </div>
+  )
+}
+`
+
+// Keyed \`.map()\` row whose bindings share one fused row effect
+// (\`emitConsolidatedRowEffect\`). The loop source is a module-level function
+// call (not a signal/prop/literal), so \`lazy-row-eligibility.ts\`'s §9.3(2)
+// hydration-consistency gate refuses lazy adoption and the loop takes the
+// eager \`stringifyPlainLoop\` -> \`emitConsolidatedRowEffect\` path — the
+// primary site #2869 reports. Asserted below (\`mapArray(\` present,
+// \`mapArrayLazy(\` absent) so a future eligibility widening fails this test
+// loudly instead of silently moving the repro onto the already-guarded path.
+const LOOP_SOURCE = `'use client'
+import { createSignal, untrack } from '@barefootjs/client'
+
+function seedItems() {
+  return [{ id: 1, label: 'a' }, { id: 2, label: 'b' }]
+}
+
+function docFor(id: number): string {
+  return 'doc-' + id
+}
+
+export function Repro() {
+  const [items, setItems] = createSignal(seedItems())
+  return (
+    <div>
+      <button onClick={() => setItems(items().map(it => ({ id: it.id, label: it.label + '!' })))}>bump</button>
+      <ul>
+        {items().map(item => (
+          <li key={item.id} title={item.label} data-doc={untrack(() => docFor(item.id))}>{item.label}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+`
+
+describe('#2869 — every eager reactive-attr write goes through emitDedupedAttrUpdate', () => {
+  test('non-loop reactive attrs: one shared __l store, sequential ordinals, guarded writes', () => {
+    const clientJs = clientJsFor(NON_LOOP_SOURCE)
+
+    expect(clientJs).toContain('const __l = []')
+    expect(clientJs).toContain('!(0 in __l) || !Object.is(__l[0], __x)')
+    expect(clientJs).toContain('!(1 in __l) || !Object.is(__l[1], __x)')
+    expect(clientJs).toContain('__l[0] = __x')
+    expect(clientJs).toContain('__l[1] = __x')
+
+    // Exactly one store for this element's effect — not one per attr.
+    const storeCount = clientJs.split('const __l = []').length - 1
+    expect(storeCount).toBe(1)
+  })
+
+  test('fused row effect (emitConsolidatedRowEffect): eager mapArray path, guarded per binding', () => {
+    const clientJs = clientJsFor(LOOP_SOURCE)
+
+    // Pin the eager path — the whole point of this fixture is exercising
+    // `emitConsolidatedRowEffect`, not the already-guarded lazy row graph.
+    expect(clientJs).toContain('mapArray(')
+    expect(clientJs).not.toContain('mapArrayLazy(')
+
+    expect(clientJs).toContain('const __l = []')
+    expect(clientJs).toContain('!(0 in __l) || !Object.is(__l[0], __x)')
+    expect(clientJs).toContain('!(1 in __l) || !Object.is(__l[1], __x)')
+
+    const storeCount = clientJs.split('const __l = []').length - 1
+    expect(storeCount).toBe(1)
+  })
+
+  test('profile mode keeps one createEffect per attr, still guarded', () => {
+    const clientJs = clientJsFor(LOOP_SOURCE, { adapter, profile: true })
+
+    // Granularity preserved: two attrs on the row's slot -> two createEffect
+    // calls (module docstring in reactive-effects.ts explains why profile
+    // mode cannot consolidate — the profiler needs one bfId per binding).
+    const effectCount = clientJs.split('createEffect(() => {').length - 1
+    expect(effectCount).toBeGreaterThanOrEqual(2)
+    expect(clientJs).toContain('const __l = []')
+    expect(clientJs).toContain('!(0 in __l) || !Object.is(__l[0], __x)')
+  })
+
+  test('emitAttrUpdate is never called directly from an effect-body emitter outside emit-reactive.ts', () => {
+    // Shrink-only ledger, same idea as binding-scope-ratchet.test.ts: every
+    // eager call site must go through emitDedupedAttrUpdate. lazy-row.ts's
+    // own dedup mechanism is unified onto the same helper (#2869), so this
+    // is a plain, unconditional invariant now — no allowlist needed.
+    const glob = new Bun.Glob('**/*.ts')
+    const root = new URL('../ir-to-client-js/', import.meta.url).pathname
+    const offenders: string[] = []
+    for (const file of glob.scanSync({ cwd: root })) {
+      if (file.endsWith('emit-reactive.ts')) continue
+      if (file.includes('__tests__')) continue
+      const text = require('node:fs').readFileSync(`${root}${file}`, 'utf8')
+      if (/\bemitAttrUpdate\(/.test(text)) offenders.push(file)
+    }
+    expect(offenders).toEqual([])
+  })
+})

--- a/packages/jsx/src/__tests__/nested-loop-reactive-attrs.test.ts
+++ b/packages/jsx/src/__tests__/nested-loop-reactive-attrs.test.ts
@@ -140,8 +140,10 @@ describe('reactive attributes inside a nested .map() body (#135)', () => {
     const content = result.files.find((f) => f.type === 'clientJs')!.content
 
     // `data-off` uses the truthy-check shape (no `__v != null` for this
-    // attribute) so a concrete `false` removes the attribute.
-    expect(content).toMatch(/createEffect\(\(\) => \{[\s\S]*?if \(c\(\)\.isOff\)\s*\S+\.setAttribute\('data-off',\s*''\)/)
+    // attribute) so a concrete `false` removes the attribute. The dedup
+    // guard (#2869) computes into `__x` first, so the truthy check reads
+    // `__x`, not `c().isOff` inline.
+    expect(content).toMatch(/createEffect\(\(\) => \{[\s\S]*?const __x = c\(\)\.isOff[\s\S]*?if \(__x\)\s*\S+\.setAttribute\('data-off',\s*''\)/)
     // aria-* keeps the explicit "true" value per WAI-ARIA.
     expect(content).toContain("setAttribute('aria-pressed', 'true')")
   })
@@ -233,8 +235,11 @@ describe('reactive attributes inside a nested .map() body (#135)', () => {
     // and the inner-loop reactive `createEffect` (must be `task().id`
     // to subscribe to the per-item accessor). The bug we're locking
     // down is purely in the createEffect emission, so scope to that.
+    // The object literal now sits in the dedup guard's `const __x = {...}`
+    // temp (#2869) — `styleToCss` reads it back as `styleToCss(__x)`, not
+    // the object literal inline.
     const effectMatch = content.match(
-      /createEffect\(\(\) => \{[\s\S]*?styleToCss\(\{[\s\S]*?\}\)[\s\S]*?__ta_s\d+\.setAttribute\('style'/,
+      /createEffect\(\(\) => \{[\s\S]*?const __x = \{[\s\S]*?\}[\s\S]*?styleToCss\(__x\)[\s\S]*?__ta_s\d+\.setAttribute\('style'/,
     )
     expect(effectMatch).not.toBeNull()
     const effectBody = effectMatch![0]
@@ -282,8 +287,11 @@ describe('reactive attributes inside a nested .map() body (#135)', () => {
     const result = compileJSX(source, 'G.tsx', { adapter })
     expect(result.errors).toHaveLength(0)
     const content = result.files.find((f) => f.type === 'clientJs')!.content
+    // The object literal now sits in the dedup guard's `const __x = {...}`
+    // temp (#2869) — `styleToCss` reads it back as `styleToCss(__x)`, not
+    // the object literal inline.
     const effectMatch = content.match(
-      /createEffect\(\(\) => \{[\s\S]*?styleToCss\(\{[\s\S]*?\}\)[\s\S]*?__ta_s\d+\.setAttribute\('style'/,
+      /createEffect\(\(\) => \{[\s\S]*?const __x = \{[\s\S]*?\}[\s\S]*?styleToCss\(__x\)[\s\S]*?__ta_s\d+\.setAttribute\('style'/,
     )
     expect(effectMatch).not.toBeNull()
     const effectBody = effectMatch![0]

--- a/packages/jsx/src/__tests__/style-css-var-reactive.test.ts
+++ b/packages/jsx/src/__tests__/style-css-var-reactive.test.ts
@@ -113,7 +113,10 @@ describe('reactive CSS custom properties (#135)', () => {
 
     // Both reactive sinks live in the init body — one assigning the DOM
     // `disabled` property, the other writing the `aria-busy` attribute.
-    expect(content).toMatch(/\.disabled\s*=\s*!!\(busy\(\)\)/)
+    // The write reads a dedup-guarded temp (`__x`, #2869), not `busy()`
+    // inline — the computed value is still `busy()`'s result either way.
+    expect(content).toMatch(/const __x = busy\(\)/)
+    expect(content).toMatch(/\.disabled\s*=\s*!!\(__x\)/)
     expect(content).toContain("setAttribute('aria-busy'")
   })
 })

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/inner-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/inner-loop.ts
@@ -33,7 +33,7 @@
 
 import { keyAttrName, mapArrayKeyArgs, profileBindingId, varSlotId } from '../../utils.ts'
 import { emitComponentAndEventSetup } from '../shared.ts'
-import { emitAttrUpdate } from '../../emit-reactive.ts'
+import { emitDedupedAttrUpdate, DEDUP_STORE_DECL } from '../../emit-reactive.ts'
 import { emitMultiRootTemplateCloneLines, namespaceWrapForTemplate } from './template-parse.ts'
 import { emitLoopChildRefs } from './loop.ts'
 import { claimPlanLiteral, claimWriterVarName, type ClaimSlotSpec } from './claim-plan.ts'
@@ -132,11 +132,13 @@ function emitReactive(lines: string[], inner: InnerLoopPlan, indent: string, pc:
       lines.push(`${indent}  createEffect(() => { ${writer}('${text.slotId}', String(${text.wrappedExpression})) }${profileBindingId(pc, text.slotId)})`)
     }
   }
+  if (emit.reactiveAttrs.length > 0) lines.push(`${indent}  ${DEDUP_STORE_DECL}`)
+  let attrOrdinal = 0
   for (const attr of emit.reactiveAttrs) {
     const targetVar = `__ta_${attr.slotId.replace(/[^a-zA-Z0-9]/g, '_')}`
     lines.push(`${indent}  { const ${targetVar} = qsa(__innerEl${uid}, '[bf="${attr.slotId}"]')`)
     lines.push(`${indent}  if (${targetVar}) createEffect(() => {`)
-    for (const stmt of emitAttrUpdate(targetVar, attr.attrName, attr.wrappedExpression, attr.meta)) {
+    for (const stmt of emitDedupedAttrUpdate(targetVar, attr.attrName, attr.wrappedExpression, attr.meta, attrOrdinal++)) {
       lines.push(`${indent}    ${stmt}`)
     }
     lines.push(`${indent}  }${profileBindingId(pc, attr.slotId)}) }`)

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/insert.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/insert.ts
@@ -29,7 +29,7 @@
  */
 
 import { emitRefCall, varSlotId } from '../../utils.ts'
-import { emitAttrUpdate } from '../../emit-reactive.ts'
+import { emitDedupedAttrUpdate, DEDUP_STORE_DECL } from '../../emit-reactive.ts'
 import type { InsertPlan, InsertArm, ArmBody, ScopeRef } from '../plan/types.ts'
 import { stringifyBranchLoops } from './branch-loop.ts'
 import { emitListenerLine } from './event-listener.ts'
@@ -163,10 +163,12 @@ function emitArmBody(
     const v = varSlotId(slotId)
     const elVar = `__ra_${v}`
     lines.push(`${indent}{ const ${elVar} = qsa(__branchScope, '[bf="${slotId}"]')`)
+    lines.push(`${indent}${DEDUP_STORE_DECL}`)
     lines.push(`${indent}if (${elVar}) {`)
+    let ordinal = 0
     for (const attr of attrs) {
       lines.push(`${indent}  __disposers.push(createDisposableEffect(() => {`)
-      for (const stmt of emitAttrUpdate(elVar, attr.attrName, attr.expression, attr)) {
+      for (const stmt of emitDedupedAttrUpdate(elVar, attr.attrName, attr.expression, attr, ordinal++)) {
         lines.push(`${indent}    ${stmt}`)
       }
       lines.push(`${indent}  }${bindingBfId(slotId)}))`)

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/lazy-row.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/lazy-row.ts
@@ -60,7 +60,7 @@
  */
 
 import { isBooleanAttr } from '../../../html-constants.ts'
-import { emitAttrUpdate } from '../../emit-reactive.ts'
+import { emitDedupedAttrUpdate, dedupGuard } from '../../emit-reactive.ts'
 import { toHtmlAttrName } from '../../utils.ts'
 import type { SkeletonSlotPaths } from '../../html-template.ts'
 import { claimPlanLiteral, type ClaimSlotSpec } from './claim-plan.ts'
@@ -458,11 +458,13 @@ function emitConditional(
   lines.push(`${ind}} }`)
 }
 
-/** `entry.last`-backed dedup test. `in` (not a truthiness check) so a
- *  legitimately `undefined` value still records and still writes once. */
-function dedupGuard(ordinal: number): string {
-  return `!(${ordinal} in __l) || !Object.is(__l[${ordinal}], __x)`
-}
+// `dedupGuard` (the `entry.last`-backed dedup test) and the actual guarded
+// write now live in `emit-reactive.ts` as `emitDedupedAttrUpdate` (#2869) —
+// shared with every eager reactive-attr emission site. This module's only
+// remaining substrate-specific piece is WHERE `__l` comes from: the
+// reconciler's `entry.last` (see the per-mode `applyItem`/`applyOuter`
+// callers below), not a closure-local `const __l = []`, because those are
+// separate invocations with no shared closure of their own to own it.
 
 function emitAttrBinding(
   lines: string[],
@@ -474,21 +476,16 @@ function emitAttrBinding(
   // plain read. An ADOPTED row starts with an EMPTY `refs` array and each
   // binding claims its OWN slot on first use — see `elementAccess`.
   const target = mode === 'create' ? `__r[${a.refIndex}]` : elementAccess(a)
-  lines.push(`${ind}{ const __t = ${target}`)
-  lines.push(`${ind}if (__t) {`)
-  lines.push(`${ind}  const __x = ${a.wrappedExpression}`)
   const guard = mode === 'create'
     ? null
     : mode === 'item'
       ? dedupGuard(a.ordinal)
       : `__seed ? (${seedDiffersExpr('__t', a)}) : (${dedupGuard(a.ordinal)})`
-  const writeIndent = guard ? `${ind}    ` : `${ind}  `
-  if (guard) lines.push(`${ind}  if (${guard}) {`)
-  for (const stmt of emitAttrUpdate('__t', a.attrName, '__x', a.meta)) {
-    lines.push(`${writeIndent}${stmt}`)
+  lines.push(`${ind}{ const __t = ${target}`)
+  lines.push(`${ind}if (__t) {`)
+  for (const stmt of emitDedupedAttrUpdate('__t', a.attrName, a.wrappedExpression, a.meta, a.ordinal, guard)) {
+    lines.push(`${ind}  ${stmt}`)
   }
-  if (guard) lines.push(`${ind}  }`)
-  lines.push(`${ind}  __l[${a.ordinal}] = __x`)
   lines.push(`${ind}} }`)
 }
 

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/loop-child-arm.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/loop-child-arm.ts
@@ -13,7 +13,7 @@
 
 import { varSlotId, DATA_BF_PH, keyAttrName, mapArrayKeyArgs, profileBindingId } from '../../utils.ts'
 import { emitComponentAndEventSetup } from '../shared.ts'
-import { emitAttrUpdate } from '../../emit-reactive.ts'
+import { emitDedupedAttrUpdate, DEDUP_STORE_DECL } from '../../emit-reactive.ts'
 import { namespaceWrapForTemplate } from './template-parse.ts'
 import { emitListenerLine } from './event-listener.ts'
 import { nameForRegistryRef } from '../../component-scope.ts'
@@ -51,10 +51,12 @@ export function stringifyBranchReactiveAttrs(
   for (const slot of plan) {
     const varName = `__ra_${varSlotId(slot.slotId)}`
     lines.push(`${indent}{ const ${varName} = qsa(__branchScope, '[bf="${slot.slotId}"]')`)
+    lines.push(`${indent}${DEDUP_STORE_DECL}`)
     lines.push(`${indent}if (${varName}) {`)
+    let ordinal = 0
     for (const attr of slot.attrs) {
       lines.push(`${indent}  __disposers.push(createDisposableEffect(() => {`)
-      for (const stmt of emitAttrUpdate(varName, attr.attrName, attr.wrappedExpression, attr.meta)) {
+      for (const stmt of emitDedupedAttrUpdate(varName, attr.attrName, attr.wrappedExpression, attr.meta, ordinal++)) {
         lines.push(`${indent}    ${stmt}`)
       }
       lines.push(`${indent}  }${profileBindingId(pc, slot.slotId)}))`)

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/loop.ts
@@ -30,7 +30,7 @@
  */
 
 import { emitRefCall, varSlotId, profileBindingId } from '../../utils.ts'
-import { emitAttrUpdate } from '../../emit-reactive.ts'
+import { emitDedupedAttrUpdate, DEDUP_STORE_DECL } from '../../emit-reactive.ts'
 import { stringifyReactiveEffects } from './reactive-effects.ts'
 import { emitTemplateCloneInline, emitLoopItemElementSetup, emitHoistedTemplateDecl, hoistedCloneExpr, namespaceWrapForTemplate, multiRootNamespaceWrapForTemplate, wrapHtmlForNamespace } from './template-parse.ts'
 import { buildSkeletonPathPlan, type SkeletonPathPlan } from './skeleton-paths.ts'
@@ -452,13 +452,15 @@ export function stringifyStaticLoop(lines: string[], plan: StaticLoopPlan): void
     lines.push(`      }`)
   }
   lines.push(`      if (__iterEl) {`)
+  if (attrsBySlot.length > 0) lines.push(`        ${DEDUP_STORE_DECL}`)
+  let ordinal = 0
   for (const [slotId, attrs] of attrsBySlot) {
     const varName = `__t_${varSlotId(slotId)}`
     lines.push(`        const ${varName} = qsa(__iterEl, '[bf="${slotId}"]')`)
     lines.push(`        if (${varName}) {`)
     for (const attr of attrs) {
       lines.push(`          createEffect(() => {`)
-      for (const stmt of emitAttrUpdate(varName, attr.attrName, attr.expression, attr)) {
+      for (const stmt of emitDedupedAttrUpdate(varName, attr.attrName, attr.expression, attr, ordinal++)) {
         lines.push(`            ${stmt}`)
       }
       lines.push(`          }${profileBindingId(pc, slotId)})`)

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/reactive-effects.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/reactive-effects.ts
@@ -32,7 +32,7 @@
  */
 
 import { varSlotId, profileBindingId } from '../../utils.ts'
-import { emitAttrUpdate } from '../../emit-reactive.ts'
+import { emitDedupedAttrUpdate, DEDUP_STORE_DECL } from '../../emit-reactive.ts'
 import { stringifyLoopChildArm } from './loop-child-arm.ts'
 import { claimPlanLiteral, claimWriterVarName, type ClaimSlotSpec } from './claim-plan.ts'
 import type {
@@ -160,7 +160,9 @@ function emitAttrSlotsGranular(
     const varName = `__ra_${varSlotId(slot.slotId)}`
     const lookupExpr = attrLookupExpr(slot.slotId, varName, elVar, lookup, elementIndexBySlot)
     lines.push(`${indent}{ const ${varName} = ${lookupExpr}`)
+    lines.push(`${indent}${DEDUP_STORE_DECL}`)
     lines.push(`${indent}if (${varName}) {`)
+    let ordinal = 0
     for (const attr of slot.attrs) {
       lines.push(`${indent}  createEffect(() => {`)
       // Profile mode keeps one effect per attr, so an attr reading a preamble
@@ -171,7 +173,7 @@ function emitAttrSlotsGranular(
       if (attr.readsPreamble && mapPreambleWrapped) {
         lines.push(`${indent}    ${mapPreambleWrapped}`)
       }
-      for (const stmt of emitAttrUpdate(varName, attr.attrName, attr.wrappedExpression, attr.meta)) {
+      for (const stmt of emitDedupedAttrUpdate(varName, attr.attrName, attr.wrappedExpression, attr.meta, ordinal++)) {
         lines.push(`${indent}    ${stmt}`)
       }
       lines.push(`${indent}  }${bindingBfId(slot.slotId)})`)
@@ -233,11 +235,14 @@ function attrLookupExpr(
  * dispatches per-slot on `kind`), so a row pays for at most one `lazySlots`
  * closure + one claim `Map` instead of one per category.
  *
- * Every attr's write statements are wrapped in their own `{ }` block (not
- * just each slot's) — `emitAttrUpdate`'s 'value'-attr shape emits a bare
- * `const __val = …` with no block of its own, and merging multiple attrs
- * into one function body (previously each had its own arrow-function scope)
- * would let two 'value' attrs in the same row effect collide on `__val`.
+ * Every attr write goes through `emitDedupedAttrUpdate` (#2869): a
+ * self-contained `{ }` block (so two 'value' attrs in the same row effect
+ * can't collide on `emitAttrUpdate`'s bare `const __val`) behind a
+ * previous-value guard on the row's ONE `__l` store, ordinals sequential
+ * across every slot in the row. Without the guard, fusing bindings into one
+ * effect meant a change to ANY binding rewrote ALL of them on every rerun —
+ * `untrack()` on one binding's read couldn't stop a sibling binding's
+ * legitimate change from re-triggering this effect and re-writing it anyway.
  */
 function emitConsolidatedRowEffect(
   lines: string[],
@@ -258,6 +263,11 @@ function emitConsolidatedRowEffect(
     const varName = `__ra_${varSlotId(slot.slotId)}`
     lines.push(`${indent}const ${varName} = ${attrLookupExpr(slot.slotId, varName, elVar, lookup, elementIndexBySlot)}`)
   }
+  // Row-wide dedup store (#2869) — one `__l`, shared by every attr write
+  // below via a sequential ordinal, so a sibling binding's legitimate
+  // rerun of this shared effect can't force an unchanged binding to
+  // rewrite too.
+  if (attrSlots.length > 0) lines.push(`${indent}${DEDUP_STORE_DECL}`)
 
   // 2. ONE claimed-slot writer covering outer texts (kind 'text') and
   //    preamble regions (kind 'markup') — mixed-kind plans are supported by
@@ -293,15 +303,14 @@ function emitConsolidatedRowEffect(
   if (mapPreambleWrapped && (preambleRegions.length > 0 || attrsReadPreamble(attrSlots))) {
     lines.push(`${indent}  ${mapPreambleWrapped}`)
   }
+  let ordinal = 0
   for (const slot of attrSlots) {
     const varName = `__ra_${varSlotId(slot.slotId)}`
     lines.push(`${indent}  if (${varName}) {`)
     for (const attr of slot.attrs) {
-      lines.push(`${indent}    {`)
-      for (const stmt of emitAttrUpdate(varName, attr.attrName, attr.wrappedExpression, attr.meta)) {
-        lines.push(`${indent}      ${stmt}`)
+      for (const stmt of emitDedupedAttrUpdate(varName, attr.attrName, attr.wrappedExpression, attr.meta, ordinal++)) {
+        lines.push(`${indent}    ${stmt}`)
       }
-      lines.push(`${indent}    }`)
     }
     lines.push(`${indent}  }`)
   }

--- a/packages/jsx/src/ir-to-client-js/emit-reactive.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-reactive.ts
@@ -85,6 +85,9 @@ function emitChildValueMirrorStatements(target: string, expression: string): str
  * Generate JS statements to update a DOM attribute reactively.
  * Centralizes the attribute-type dispatch (value, class, boolean, presence, generic)
  * so that new AttrMeta flags are handled in one place.
+ *
+ * Per-kind WRITE dispatch only — an effect body must never call this
+ * directly, only through `emitDedupedAttrUpdate` below (#2869).
  */
 export function emitAttrUpdate(target: string, attrName: string, expression: string, meta: AttrMeta): string[] {
   const htmlName = toHtmlAttrName(attrName)
@@ -124,6 +127,81 @@ export function emitAttrUpdate(target: string, attrName: string, expression: str
   return [
     `{ const __v = ${expression}; if (__v != null) ${target}.setAttribute('${htmlName}', String(__v)); else ${target}.removeAttribute('${htmlName}') }`,
   ]
+}
+
+/**
+ * Last-value store every deduped attribute write in one emitting block
+ * shares — `const __l = []`, declared ONCE in the block that creates the
+ * effect(s), so the effect closure (a stable object across its own reruns)
+ * captures it and no other effect can see it. Each binding owns a fixed
+ * numeric ordinal into it. The lazy row graph (`control-flow/stringify/
+ * lazy-row.ts`) declares the same `__l` from the reconciler's `entry.last`
+ * instead — `applyItem` / `applyOuter` are separate invocations with no
+ * closure of their own to own the array — but the guard, the temp name,
+ * the ordinal scheme and the record-after-write rule below are shared with
+ * it (#2869).
+ */
+export const DEDUP_STORE_DECL = 'const __l = []'
+
+/**
+ * `__l`-backed dedup test. `in` (not a truthiness check) so a legitimately
+ * `undefined` value still records and still writes once; `!(N in __l)` on
+ * the first run is what makes the first write unconditional — the same
+ * "dedup, no trust-first-run" contract `claim-slots.ts` documents for
+ * 'markup' slots. Moved here from `control-flow/stringify/lazy-row.ts`
+ * so the eager paths below and the lazy row graph share one guard (#2869).
+ */
+export function dedupGuard(ordinal: number): string {
+  return `!(${ordinal} in __l) || !Object.is(__l[${ordinal}], __x)`
+}
+
+/**
+ * The ONLY way an effect body should write a reactive attribute (#2869).
+ * Wraps `emitAttrUpdate`'s per-kind write in a previous-value guard:
+ * compute once into `__x`, write only when `guard` holds, then record
+ * `__x` into `__l[ordinal]` whether or not the write happened, so the
+ * stored value always tracks the latest computation. Without this, every
+ * rerun of a shared effect — a keyed row's fused effect (#2869's report),
+ * or even a plain per-slot effect covering two attrs on one element — rewrote
+ * every attribute in it on every rerun, no matter which binding actually
+ * changed. `untrack()` cannot fix this on its own: it only suppresses
+ * dependency REGISTRATION for the read inside it, not re-execution of the
+ * surrounding effect when an unrelated sibling binding legitimately changes
+ * — so an `<iframe srcdoc={untrack(...)}>` kept reloading every time a
+ * sibling attribute in the same row effect changed.
+ *
+ * Self-contained block: `__x` (and `emitAttrUpdate`'s own `__v` / bare
+ * `const __val`) never leak into the caller's scope, so several bindings
+ * can sit in one effect body without a wrapper block of their own.
+ *
+ * Compares the RAW value, exactly like the lazy-row path always has: an
+ * object-valued `style` / `dangerouslySetInnerHTML` is a fresh object per
+ * run and simply keeps writing as before (no regression, no gain — a
+ * follow-up could compare the coerced value instead).
+ *
+ * `guard` is overridable for the lazy row graph's `__seed`-run DOM
+ * read-compare (`__seed ? <DOM read-compare> : <dedupGuard>`) and `null`
+ * for its `createRow` (fresh clone: write unconditionally, still record).
+ */
+export function emitDedupedAttrUpdate(
+  target: string,
+  attrName: string,
+  expression: string,
+  meta: AttrMeta,
+  ordinal: number,
+  guard: string | null = dedupGuard(ordinal),
+): string[] {
+  const write = emitAttrUpdate(target, attrName, '__x', meta)
+  const lines = [`{ const __x = ${expression}`]
+  if (guard) {
+    lines.push(`if (${guard}) {`)
+    for (const stmt of write) lines.push(`  ${stmt}`)
+    lines.push(`}`)
+  } else {
+    lines.push(...write)
+  }
+  lines.push(`__l[${ordinal}] = __x }`)
+  return lines
 }
 
 /**
@@ -494,20 +572,22 @@ export function emitReactiveAttributeUpdates(lines: string[], ctx: ClientJsConte
 
     for (const [slotId, attrs] of attrsBySlot) {
       const v = varSlotId(slotId)
+      lines.push(`  { ${DEDUP_STORE_DECL}`)
       lines.push(`  createEffect(() => {`)
       lines.push(`    if (_${v}) {`)
+      let ordinal = 0
       for (const attr of attrs) {
         // Catalogued-lowering MUST run before the bare-prop-name rewrite:
         // the matcher needs the source-form receiver (a bare identifier or
         // `props.x`), the exact two shapes `resolveReceiverType` supports —
         // same ordering `jsx-to-ir.ts`'s static-template path documents.
         const expression = rewriteDestructuredPropsInExpr(lower(attr.expression), ctx)
-        for (const stmt of emitAttrUpdate(`_${v}`, attr.attrName, expression, attr)) {
+        for (const stmt of emitDedupedAttrUpdate(`_${v}`, attr.attrName, expression, attr, ordinal++)) {
           lines.push(`      ${stmt}`)
         }
       }
       lines.push(`    }`)
-      lines.push(`  }${bindingIdArg(ctx, slotId)})`)
+      lines.push(`  }${bindingIdArg(ctx, slotId)}) }`)
       lines.push('')
     }
   }
@@ -580,6 +660,7 @@ export function emitReactiveChildProps(lines: string[], ctx: ClientJsContext): v
   if (ctx.reactiveChildProps.length > 0) {
     lines.push('')
     lines.push(`  // Reactive child component props`)
+    lines.push(`  { ${DEDUP_STORE_DECL}`)
     lines.push(`  createEffect(() => {`)
 
     const propsByComponent = new Map<string, typeof ctx.reactiveChildProps>()
@@ -591,6 +672,7 @@ export function emitReactiveChildProps(lines: string[], ctx: ClientJsContext): v
       propsByComponent.get(key)!.push(prop)
     }
 
+    let ordinal = 0
     for (const [, props] of propsByComponent) {
       const first = props[0]
       // The component's own `comment: true` root child IS `__scope` — query
@@ -609,10 +691,11 @@ export function emitReactiveChildProps(lines: string[], ctx: ClientJsContext): v
         // `value` is the CHILD-ROOT MIRROR case, not a developer-authored
         // attribute — route it through the no-SSR-fallback helper instead
         // of `emitAttrUpdate`'s generic (attribute-fallback) dispatch;
-        // see `emitChildValueMirrorStatements`'s docstring (#2716).
+        // see `emitChildValueMirrorStatements`'s docstring (#2716). It has
+        // its own DOM-compare and consumes no dedup ordinal (#2869).
         const stmts = toHtmlAttrName(prop.attrName) === 'value'
           ? emitChildValueMirrorStatements(varName, prop.expression)
-          : emitAttrUpdate(varName, prop.attrName, prop.expression, prop)
+          : emitDedupedAttrUpdate(varName, prop.attrName, prop.expression, prop, ordinal++)
         for (const stmt of stmts) {
           lines.push(`      ${stmt}`)
         }
@@ -620,6 +703,6 @@ export function emitReactiveChildProps(lines: string[], ctx: ClientJsContext): v
       lines.push(`    }`)
     }
 
-    lines.push(`  }${bindingIdArg(ctx, ctx.reactiveChildProps[0]?.slotId ?? undefined)})`)
+    lines.push(`  }${bindingIdArg(ctx, ctx.reactiveChildProps[0]?.slotId ?? undefined)}) }`)
   }
 }


### PR DESCRIPTION
## Summary

Fixes #2869.

An eager reactive-attribute write (`emitAttrUpdate`'s generic/`class`/`style`/`dangerouslySetInnerHTML` branches) rewrote the DOM unconditionally on every `createEffect` rerun, no matter which binding in that effect actually changed. This bites hardest in a keyed `.map()` row, where multiple bindings are fused into ONE shared `createEffect` for perf (`emitConsolidatedRowEffect`): a sibling binding's legitimate change reruns the whole row effect and rewrites every attribute in it, including ones whose own computed value never changed.

`untrack()` cannot prevent this on its own — it only suppresses dependency *registration* for the wrapped read, not *re-execution* of the surrounding effect when a sibling binding legitimately changes. So an `<iframe srcdoc={untrack(() => doc)}>` sharing a row's fused effect with an unrelated reactive sibling (e.g. `data-key={item.key}`) kept reloading on every unrelated update to that row.

The lazy row graph (`control-flow/stringify/lazy-row.ts`) already had exactly this guard — an `Object.is` comparison against a per-row last-value store — just not applied to the plain-loop consolidated-row-effect path or to the ordinary (non-loop) reactive-attribute effects.

- Extracts the guard into a shared `emitDedupedAttrUpdate` / `dedupGuard` / `DEDUP_STORE_DECL` in `emit-reactive.ts`.
- Routes **every** eager reactive-attribute emission site through it (there were 8, not just the loop path): `emitReactiveAttributeUpdates`, `emitReactiveChildProps`, `emitAttrSlotsGranular` (profile mode), `emitConsolidatedRowEffect`, `stringifyBranchReactiveAttrs`, the branch-arm `insert()` path, the inner-loop path, and the static-loop materialize path.
- `lazy-row.ts`'s own `emitAttrBinding` now calls the same shared helper instead of duplicating the guard logic — the only remaining substrate-specific piece is *where* its `__l` store comes from (the reconciler's `entry.last`, since `applyItem`/`applyOuter` are separate invocations with no shared closure of their own).
- Documents `untrack`'s actual contract in `docs/core/reactivity/untrack.md` (stops dependency registration for the wrapped read, not re-execution of the surrounding effect).

Only client JS *behavior* changes (write frequency inside an already-running effect) — SSR/CSR template HTML is byte-identical before and after, confirmed by running `generate-expected-html.ts` and diffing (only `.client.js` snapshots changed, no `.html` files).

## Design

The fix shape (which sites to guard, the shared-helper structure, the `untrack.md` doc patch, and the test plan) was designed by Fable (`claude-fable-5-1`) before implementation, per this repo's convention of separating design from implementation.

## Test plan

- [x] `packages/client/__tests__/runtime/issue-2869-attr-dedup-guard.test.ts` — new behavioral regression test. Compiles real repro components (a fused keyed-row effect and a plain non-loop effect, both with an `untrack`-wrapped sibling binding) and hydrates them against `@happy-dom/global-registrator`, asserting `setAttribute` call counts before/after triggering a sibling update. Fails on `main`, passes with this fix.
- [x] `packages/jsx/src/__tests__/issue-2869-attr-dedup-guard.test.ts` — new codegen-shape pins, plus a shrink-only ledger asserting no eager emission site calls `emitAttrUpdate` directly outside `emit-reactive.ts`.
- [x] Updated 3 pre-existing codegen-shape test pins (`style-css-var-reactive.test.ts`, `child-prop-fallback-wrap.test.ts`, `nested-loop-reactive-attrs.test.ts`) that asserted the old unguarded write shape — behavior unchanged, only the intermediate temp-variable shape changed.
- [x] Regenerated `packages/jsx/src/__tests__/__snapshots__/doc-examples.test.ts.snap` and reviewed the diff (every hunk is either the new guard wrapper around an unchanged write, or the new `untrack.md` example).
- [x] Ran `packages/adapter-tests/scripts/generate-expected-html.ts` and confirmed only `.client.js` fixture snapshots changed (no `.html` diffs) — the fixture-drift check CLAUDE.md requires before merging.
- [x] Full suite: `bun test packages/jsx packages/client packages/test packages/adapter-tests packages/router` — 6553 pass, 0 fail.
- [x] `bun test ui/components/` — 1240 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GGEdZGGtKh3hy1DfMcn59A

---
_Generated by [Claude Code](https://claude.ai/code/session_01GGEdZGGtKh3hy1DfMcn59A)_