### PR TITLE
fix: re-run the .map() preamble inside loop-row branch arms

### DIFF
--- a/.changeset/preamble-branch-arm-rerun-2596.md
+++ b/.changeset/preamble-branch-arm-rerun-2596.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Fix a `.map()` callback preamble local (e.g. `const cls = row.done ? 'a' : 'b'`) going stale inside a loop row's branch conditional: a reactive attribute reading the local, or a nested conditional's own condition reading it, used to freeze at whatever value the local had on the row's last full render instead of refreshing on a same-key data update — silently diverging from a sibling binding that read the underlying data directly. Both are now fixed by re-running the row's preamble inside the branch's own effect / condition getter, matching how this was already handled everywhere else (`emitAttrSlotsGranular`, `emitConsolidatedRowEffect`, the outer conditional's own condition getter).

--- a/packages/client/__tests__/runtime/preamble-branch-attr-staleness.test.ts
+++ b/packages/client/__tests__/runtime/preamble-branch-attr-staleness.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Regression probe, NOT yet filed as a GitHub issue: found while discussing
+ * whether `insert.ts`'s branch-arm reactive-attr handling and
+ * `loop-child-arm.ts`'s `stringifyBranchReactiveAttrs` should share one
+ * implementation (#2869 follow-up conversation). They turned out to answer
+ * DIFFERENT questions — `ReactiveAttrEffect` (the type `stringifyBranchReactiveAttrs`
+ * consumes) carries a `readsPreamble?: boolean` field that `ArmReactiveAttr`
+ * (`insert.ts`'s equivalent, for top-level non-loop conditionals) structurally
+ * cannot have, because there is no `.map()` preamble outside a loop.
+ *
+ * Tracing where `readsPreamble` is actually set (`reactivity.ts`'s
+ * `collectBranchReactiveAttrs`, guarding the exact "#2447" scenario this test
+ * reproduces: `const cls = row.done ? … ; class={cls}`) proved it CAN be true
+ * for an attribute inside a loop-row's branch conditional. But
+ * `stringifyLoopChildArm` / `stringifyBranchReactiveAttrs`
+ * (`control-flow/stringify/loop-child-arm.ts`) never receive a
+ * `mapPreambleWrapped` string to inject — unlike every other `readsPreamble`
+ * consumer (`emitAttrSlotsGranular`, `emitConsolidatedRowEffect`, and the
+ * condition itself in `emitOuterConditional`, which explicitly reruns the
+ * preamble inside its `insert()` condition getter but never threads it down
+ * into the arm bodies it hands to `stringifyLoopChildArm`).
+ *
+ * Net effect: a reactive attribute that lives INSIDE a loop row's branch
+ * conditional and reads a `.map()` preamble local closes over whatever that
+ * local was on the row's LAST FULL RENDER (creation, or same-key remount) and
+ * never sees a same-key `setItem` update again — even though a genuinely
+ * reactive sibling in the SAME branch (a plain `{row().field}` text
+ * expression, which reads the live per-item accessor directly instead of
+ * through a preamble local) updates correctly. The result is a silent
+ * DOM/text divergence: the visible text says one thing, a class/attribute
+ * derived from the same data says another.
+ *
+ * This test pins TODAY's (broken) behavior so it doesn't regress further and
+ * so a real fix has a green target to flip. It is not skipped/failing — the
+ * bug is real but low severity (stale class/attr, not a crash), so there is
+ * no CI-blocking reason to mark it red before a fix is scoped. Once fixed,
+ * flip `expect(target.className).toBe('tier-gold')` to `.toBe('tier-silver')`
+ * and delete this docstring's "pins TODAY's behavior" framing.
+ */
+import { describe, test, expect, beforeAll } from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+import { compileJSX } from '../../../jsx/src/compiler'
+import { TestAdapter } from '../../../jsx/src/adapters/test-adapter'
+import { renderHonoComponent } from '../../../adapter-hono/src/test-render'
+import { HonoAdapter } from '../../../adapter-hono/src/adapter/hono-adapter'
+import { writeFileSync, mkdtempSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+beforeAll(() => {
+  if (typeof window === 'undefined') GlobalRegistrator.register()
+})
+
+const adapter = new TestAdapter()
+const runtimePath = join(__dirname, '../../src/runtime/index.ts')
+
+// `visible` is a signal (not a literal) so the ternary compiles to a real
+// `insert()` branch instead of being resolved away at build time, but it is
+// never toggled in this test — the branch never swaps, isolating the
+// preamble-staleness question from branch-swap behavior (a swap would
+// re-invoke `bindEvents`, a separate code path not under test here).
+function reproSource(): string {
+  return `'use client'
+import { createSignal } from '@barefootjs/client'
+
+type Row = { id: number; tier: string }
+
+export function List() {
+  const [visible] = createSignal(true)
+  const [rows, setRows] = createSignal<Row[]>([{ id: 1, tier: 'gold' }])
+  const bump = () => setRows(prev => prev.map(r => ({ ...r, tier: 'silver' })))
+  return (
+    <div>
+      <button id="bump" onClick={bump}>bump</button>
+      <ul>
+        {rows().map(row => {
+          const cls = 'tier-' + row.tier
+          return (
+            <li key={row.id}>
+              {visible() ? <span class={cls} id="target">{row.tier}</span> : <span>x</span>}
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}
+`
+}
+
+function clientJsFor(source: string, filename: string): string {
+  const result = compileJSX(source, filename, { adapter })
+  const errors = result.errors.filter(e => e.severity === 'error')
+  if (errors.length > 0) {
+    throw new Error(`Compile errors in ${filename}:\n${errors.map(e => `${e.code}: ${e.message}`).join('\n')}`)
+  }
+  const clientJs = result.files.find(f => f.type === 'clientJs')?.content
+  if (!clientJs) throw new Error(`No client JS for ${filename}`)
+  return clientJs.replace(/from\s+['"]@barefootjs\/client\/runtime['"]/g, `from '${runtimePath}'`)
+}
+
+async function setupHydration(): Promise<{ hydrate: () => void }> {
+  const dir = mkdtempSync(join(tmpdir(), 'bf-preamble-branch-'))
+  const source = reproSource()
+  writeFileSync(join(dir, 'List.mjs'), clientJsFor(source, 'List.tsx'))
+  await import(join(dir, 'List.mjs'))
+
+  const ssrHtml = await renderHonoComponent({
+    adapter: new HonoAdapter(),
+    source,
+    props: { __instanceId: 'List_test' },
+  })
+  document.body.innerHTML = ssrHtml
+
+  const { rehydrateAll, flushHydration } = await import(runtimePath)
+  return {
+    hydrate: () => {
+      rehydrateAll()
+      flushHydration()
+    },
+  }
+}
+
+describe('preamble local inside a loop-row branch conditional does not refresh on same-key update', () => {
+  test('sibling text (live accessor) updates; class (preamble local) stays stale', async () => {
+    const { hydrate } = await setupHydration()
+    hydrate()
+
+    const target = document.getElementById('target') as HTMLElement
+    expect(target.className).toBe('tier-gold')
+    expect(target.textContent).toBe('gold')
+
+    document.getElementById('bump')!.dispatchEvent(new window.Event('click', { bubbles: true }))
+
+    // Correct: the branch's own live accessor read (`{row().tier}`) is not a
+    // preamble local, so it updates on the same-key `setItem` reconcile.
+    expect(target.textContent).toBe('silver')
+
+    // BUG (pinned, not yet fixed): `cls` was computed once, in the `.map()`
+    // preamble, at row creation — nothing re-runs that computation on a
+    // same-key update inside this branch-arm path, so the class silently
+    // disagrees with the text it's describing. If this assertion ever
+    // fails, the gap traced in this file's docstring has been fixed —
+    // update this test to assert 'tier-silver' instead of deleting it.
+    expect(target.className).toBe('tier-gold')
+  })
+})

--- a/packages/client/__tests__/runtime/preamble-branch-attr-staleness.test.ts
+++ b/packages/client/__tests__/runtime/preamble-branch-attr-staleness.test.ts
@@ -9,9 +9,12 @@
  * cannot have, because there is no `.map()` preamble outside a loop.
  *
  * Tracing where `readsPreamble` is actually set (`reactivity.ts`'s
- * `collectBranchReactiveAttrs`, guarding the exact "#2447" scenario this test
- * reproduces: `const cls = row.done ? … ; class={cls}`) proved it CAN be true
- * for an attribute inside a loop-row's branch conditional. But
+ * `collectLoopChildReactiveAttrs`, called for the branch-arm case from
+ * `collect-elements.ts` with `stopAtReactiveConditionals: true` — NOT the
+ * separate, top-level-only `collectBranchReactiveAttrs` that feeds
+ * `insert.ts`'s `ArmBody` instead — guarding the exact "#2447" scenario this
+ * test reproduces: `const cls = row.done ? … ; class={cls}`) proved it CAN be
+ * true for an attribute inside a loop-row's branch conditional. But
  * `stringifyLoopChildArm` / `stringifyBranchReactiveAttrs`
  * (`control-flow/stringify/loop-child-arm.ts`) never receive a
  * `mapPreambleWrapped` string to inject — unlike every other `readsPreamble`

--- a/packages/client/__tests__/runtime/preamble-branch-attr-staleness.test.ts
+++ b/packages/client/__tests__/runtime/preamble-branch-attr-staleness.test.ts
@@ -1,44 +1,35 @@
 /**
- * Regression probe, NOT yet filed as a GitHub issue: found while discussing
- * whether `insert.ts`'s branch-arm reactive-attr handling and
- * `loop-child-arm.ts`'s `stringifyBranchReactiveAttrs` should share one
- * implementation (#2869 follow-up conversation). They turned out to answer
- * DIFFERENT questions — `ReactiveAttrEffect` (the type `stringifyBranchReactiveAttrs`
- * consumes) carries a `readsPreamble?: boolean` field that `ArmReactiveAttr`
- * (`insert.ts`'s equivalent, for top-level non-loop conditionals) structurally
- * cannot have, because there is no `.map()` preamble outside a loop.
+ * Regression test found while discussing (post-#2869) whether `insert.ts`'s
+ * branch-arm reactive-attr handling and `loop-child-arm.ts`'s
+ * `stringifyBranchReactiveAttrs` should share one implementation. They
+ * turned out to answer DIFFERENT questions — `ReactiveAttrEffect` (the type
+ * `stringifyBranchReactiveAttrs` consumes) carries a `readsPreamble?: boolean`
+ * field that `ArmReactiveAttr` (`insert.ts`'s equivalent, for top-level
+ * non-loop conditionals) structurally cannot have, because there is no
+ * `.map()` preamble outside a loop.
  *
- * Tracing where `readsPreamble` is actually set (`reactivity.ts`'s
- * `collectLoopChildReactiveAttrs`, called for the branch-arm case from
- * `collect-elements.ts` with `stopAtReactiveConditionals: true` — NOT the
- * separate, top-level-only `collectBranchReactiveAttrs` that feeds
- * `insert.ts`'s `ArmBody` instead — guarding the exact "#2447" scenario this
- * test reproduces: `const cls = row.done ? … ; class={cls}`) proved it CAN be
- * true for an attribute inside a loop-row's branch conditional. But
- * `stringifyLoopChildArm` / `stringifyBranchReactiveAttrs`
- * (`control-flow/stringify/loop-child-arm.ts`) never receive a
- * `mapPreambleWrapped` string to inject — unlike every other `readsPreamble`
- * consumer (`emitAttrSlotsGranular`, `emitConsolidatedRowEffect`, and the
- * condition itself in `emitOuterConditional`, which explicitly reruns the
- * preamble inside its `insert()` condition getter but never threads it down
- * into the arm bodies it hands to `stringifyLoopChildArm`).
+ * `readsPreamble` is set by `reactivity.ts`'s `collectLoopChildReactiveAttrs`
+ * (called for the branch-arm case from `collect-elements.ts` with
+ * `stopAtReactiveConditionals: true` — NOT the separate, top-level-only
+ * `collectBranchReactiveAttrs` that feeds `insert.ts`'s `ArmBody` instead)
+ * for exactly the "#2447" scenario this test reproduces: `const cls =
+ * row.done ? … ; class={cls}`. But `stringifyLoopChildArm` /
+ * `stringifyBranchReactiveAttrs` (`control-flow/stringify/loop-child-arm.ts`)
+ * used to never receive a `mapPreambleWrapped` string to inject — unlike
+ * every other `readsPreamble` consumer (`emitAttrSlotsGranular`,
+ * `emitConsolidatedRowEffect`, and the condition itself in
+ * `emitOuterConditional`, which reruns the preamble inside its `insert()`
+ * condition getter). `buildArmAttrsPlan`
+ * (`control-flow/plan/build-loop-child-arm.ts`) also dropped the
+ * `readsPreamble` flag on the way from `LoopChildReactiveAttr` to
+ * `ReactiveAttrEffect` — two gaps, not one.
  *
- * Net effect: a reactive attribute that lives INSIDE a loop row's branch
- * conditional and reads a `.map()` preamble local closes over whatever that
- * local was on the row's LAST FULL RENDER (creation, or same-key remount) and
- * never sees a same-key `setItem` update again — even though a genuinely
- * reactive sibling in the SAME branch (a plain `{row().field}` text
- * expression, which reads the live per-item accessor directly instead of
- * through a preamble local) updates correctly. The result is a silent
- * DOM/text divergence: the visible text says one thing, a class/attribute
- * derived from the same data says another.
- *
- * This test pins TODAY's (broken) behavior so it doesn't regress further and
- * so a real fix has a green target to flip. It is not skipped/failing — the
- * bug is real but low severity (stale class/attr, not a crash), so there is
- * no CI-blocking reason to mark it red before a fix is scoped. Once fixed,
- * flip `expect(target.className).toBe('tier-gold')` to `.toBe('tier-silver')`
- * and delete this docstring's "pins TODAY's behavior" framing.
+ * Fixed by threading `mapPreambleWrapped` through `stringifyLoopChildArm` →
+ * `stringifyBranchReactiveAttrs` (and `stringifyLoopChildConditional`'s own
+ * condition getter, via the shared `conditionGetterExpr` helper — a nested
+ * conditional's own condition had the identical gap, #2596 one level
+ * deeper), and forwarding `readsPreamble` in `buildArmAttrsPlan` /
+ * `buildLoopChildConditionalsPlan`.
  */
 import { describe, test, expect, beforeAll } from 'bun:test'
 import { GlobalRegistrator } from '@happy-dom/global-registrator'
@@ -124,8 +115,8 @@ async function setupHydration(): Promise<{ hydrate: () => void }> {
   }
 }
 
-describe('preamble local inside a loop-row branch conditional does not refresh on same-key update', () => {
-  test('sibling text (live accessor) updates; class (preamble local) stays stale', async () => {
+describe('preamble local inside a loop-row branch conditional refreshes on same-key update', () => {
+  test('sibling text and preamble-derived class both update', async () => {
     const { hydrate } = await setupHydration()
     hydrate()
 
@@ -135,16 +126,13 @@ describe('preamble local inside a loop-row branch conditional does not refresh o
 
     document.getElementById('bump')!.dispatchEvent(new window.Event('click', { bubbles: true }))
 
-    // Correct: the branch's own live accessor read (`{row().tier}`) is not a
+    // The branch's own live accessor read (`{row().tier}`) is not a
     // preamble local, so it updates on the same-key `setItem` reconcile.
     expect(target.textContent).toBe('silver')
 
-    // BUG (pinned, not yet fixed): `cls` was computed once, in the `.map()`
-    // preamble, at row creation — nothing re-runs that computation on a
-    // same-key update inside this branch-arm path, so the class silently
-    // disagrees with the text it's describing. If this assertion ever
-    // fails, the gap traced in this file's docstring has been fixed —
-    // update this test to assert 'tier-silver' instead of deleting it.
-    expect(target.className).toBe('tier-gold')
+    // Fixed: the arm's attr effect re-runs the preamble (`const cls =
+    // 'tier-' + row().tier`) before reading `cls`, so the class no longer
+    // disagrees with the text describing the same data.
+    expect(target.className).toBe('tier-silver')
   })
 })

--- a/packages/jsx/src/__tests__/preamble-branch-arm-rerun.test.ts
+++ b/packages/jsx/src/__tests__/preamble-branch-arm-rerun.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Codegen-shape pins for the loop-row branch-arm preamble gap (#2596/#2447
+ * follow-up, found while discussing #2869's aftermath). Companion to the
+ * behavioral test in
+ * `packages/client/__tests__/runtime/preamble-branch-attr-staleness.test.ts`,
+ * which is the one that actually proves the fix works end to end — this
+ * file pins the exact emitted shape so a future refactor of
+ * `stringifyLoopChildArm`/`stringifyBranchReactiveAttrs`/
+ * `stringifyLoopChildConditional` can't silently drop the preamble re-run
+ * again.
+ *
+ * Two sites were fixed together: a reactive ATTRIBUTE inside a loop row's
+ * branch conditional that reads a `.map()` preamble local (case a), and a
+ * NESTED conditional's own CONDITION expression doing the same (case b,
+ * #2596 one nesting level deeper than the already-fixed outer-conditional
+ * case pinned by `preamble-conditional-reactivity.test.ts`). Case c is the
+ * negative control: no preamble local in play, so nothing should be
+ * injected.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+
+const adapter = new TestAdapter()
+
+function clientJsFor(source: string, filename: string): string {
+  const result = compileJSX(source, filename, { adapter })
+  expect(result.errors).toHaveLength(0)
+  const clientJs = result.files.find(f => f.type === 'clientJs')?.content
+  if (!clientJs) throw new Error('No client JS emitted')
+  return clientJs
+}
+
+describe('#2596/#2447 follow-up — preamble re-run inside a loop-row branch arm', () => {
+  test('(a) an attribute inside a branch arm re-runs the preamble before reading it', () => {
+    const source = `'use client'
+import { createSignal } from '@barefootjs/client'
+type Row = { id: number; tier: string }
+export function List() {
+  const [visible] = createSignal(true)
+  const [rows] = createSignal<Row[]>([{ id: 1, tier: 'gold' }])
+  return (
+    <ul>
+      {rows().map(row => {
+        const cls = 'tier-' + row.tier
+        return (
+          <li key={row.id}>
+            {visible() ? <span class={cls} id="target">{row.tier}</span> : <span>x</span>}
+          </li>
+        )
+      })}
+    </ul>
+  )
+}
+`
+    const js = clientJsFor(source, 'List.tsx')
+
+    // Pin the eager per-row mapArray path (not lazy-row, not relevant here
+    // but keeps this fixture stable if eligibility ever widens).
+    expect(js).toContain('mapArray(')
+
+    // The outer conditional's own getter is NOT preamble-guarded (`visible`
+    // is a plain signal, no preamble read) — stays bare.
+    expect(js).toContain("insert(__el, 's0', () => visible(), {")
+
+    // The arm's attr effect re-runs the preamble before reading `cls`.
+    const disposerStart = js.indexOf('const __disposers = []')
+    const disposerEnd = js.indexOf('return () => __disposers.forEach')
+    const arm = js.slice(disposerStart, disposerEnd)
+    const preambleAt = arm.indexOf("const cls = 'tier-' + row().tier;")
+    const readAt = arm.indexOf('const __x = cls')
+    expect(preambleAt).toBeGreaterThanOrEqual(0)
+    expect(readAt).toBeGreaterThan(preambleAt)
+  })
+
+  test('(b) a nested conditional inside a branch arm re-runs the preamble in its own condition getter', () => {
+    const source = `'use client'
+import { createSignal } from '@barefootjs/client'
+type Row = { id: number; tier: string }
+export function List() {
+  const [visible] = createSignal(true)
+  const [selected] = createSignal(1)
+  const [rows] = createSignal<Row[]>([{ id: 1, tier: 'gold' }])
+  return (
+    <ul>
+      {rows().map(row => {
+        const cls = 'tier-' + row.tier
+        const on = selected() === row.id
+        return (
+          <li key={row.id}>
+            {visible() ? <div><span>{cls}</span>{on ? <em id="yes">yes</em> : <em id="no">no</em>}</div> : <span>x</span>}
+          </li>
+        )
+      })}
+    </ul>
+  )
+}
+`
+    const js = clientJsFor(source, 'List2.tsx')
+
+    expect(js).toMatch(
+      /insert\(__branchScope, 's\d+', \(\) => \{ const cls = 'tier-' \+ row\(\)\.tier; const on = selected\(\) === row\(\)\.id;; return \(on\) \}, \{/,
+    )
+  })
+
+  test('(c) negative control — no preamble local in play, nothing injected', () => {
+    const source = `'use client'
+import { createSignal } from '@barefootjs/client'
+type Row = { id: number; tier: string }
+export function List() {
+  const [visible] = createSignal(true)
+  const [rows] = createSignal<Row[]>([{ id: 1, tier: 'gold' }])
+  return (
+    <ul>
+      {rows().map(row => (
+        <li key={row.id}>
+          {visible() ? <span class={row.tier} id="target">{row.tier}</span> : <span>x</span>}
+        </li>
+      ))}
+    </ul>
+  )
+}
+`
+    const js = clientJsFor(source, 'List3.tsx')
+
+    expect(js).not.toContain('const cls =')
+    // The attr effect still exists and still writes — just with no
+    // preamble re-run ahead of it, since there is nothing to re-run.
+    const disposerStart = js.indexOf('const __disposers = []')
+    const disposerEnd = js.indexOf('return () => __disposers.forEach')
+    const arm = js.slice(disposerStart, disposerEnd)
+    expect(arm).toContain("setAttribute('class'")
+  })
+})

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/build-loop-child-arm.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/build-loop-child-arm.ts
@@ -416,6 +416,7 @@ export function buildLoopChildConditionalsPlan(
         loopIndex,
         condId: cond.slotId,
       }),
+      ...(cond.readsPreamble && { readsPreamble: true }),
     })
   }
   return plans
@@ -450,6 +451,7 @@ export function buildArmAttrsPlan(
         attrName: attr.attrName,
         wrappedExpression: wrap(attr.expression),
         meta: pickAttrMeta(attr),
+        ...(attr.readsPreamble && { readsPreamble: true }),
       })),
     })
   }

--- a/packages/jsx/src/ir-to-client-js/control-flow/plan/loop-child-arm.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/plan/loop-child-arm.ts
@@ -213,4 +213,11 @@ export interface LoopChildConditionalPlan {
   whenFalseTemplateHtml: string
   whenTrueArm: LoopChildArmPlan
   whenFalseArm: LoopChildArmPlan
+  /**
+   * `wrappedCondition` reads a `.map()` callback preamble local (#2596,
+   * same field as `NestedConditionalPlan.readsPreamble` one level up) —
+   * the stringifier must run the row's preamble inside the getter passed
+   * to `insert()`; the local isn't otherwise in scope there.
+   */
+  readsPreamble?: boolean
 }

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/inner-loop.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/inner-loop.ts
@@ -137,7 +137,13 @@ function emitReactive(lines: string[], inner: InnerLoopPlan, indent: string, pc:
   // ternary. Mirrors `stringifyBranchInnerLoops`'s identical call for a
   // branch-scoped inner loop's own conditionals.
   if (emit.conditionals.length > 0) {
-    stringifyLoopChildConditionals(lines, emit.conditionals, `${indent}  `, pc)
+    // This inner loop's own preamble (`preludeStatements` above) is not a
+    // single re-runnable string like the outer row's `mapPreambleWrapped`,
+    // so there is nothing correct to thread here — `readsPreamble &&
+    // mapPreambleWrapped`'s guard downstream makes this `undefined` a
+    // no-op, exactly as before this fix (inner-loop preambles are out of
+    // scope — see PR notes on #2596 follow-up).
+    stringifyLoopChildConditionals(lines, emit.conditionals, `${indent}  `, pc, undefined)
   }
   // Imperative ref callbacks fire on every renderItem invocation, which
   // means every mount: SSR hydration, initial CSR creation, and same-key

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/loop-child-arm.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/loop-child-arm.ts
@@ -46,7 +46,9 @@ export function stringifyBranchReactiveAttrs(
   lines: string[],
   plan: readonly ReactiveAttrSlot[],
   indent: string,
-  pc?: string,
+  pc: string | undefined,
+  /** The row's preamble re-run statement, when this scope has one (#2596/#2447) — see `conditionGetterExpr`'s docstring for the shared contract. */
+  mapPreambleWrapped: string | undefined,
 ): void {
   for (const slot of plan) {
     const varName = `__ra_${varSlotId(slot.slotId)}`
@@ -56,6 +58,12 @@ export function stringifyBranchReactiveAttrs(
     let ordinal = 0
     for (const attr of slot.attrs) {
       lines.push(`${indent}  __disposers.push(createDisposableEffect(() => {`)
+      // One effect per attr, so an attr reading a preamble local needs the
+      // declarations inside ITS OWN effect — same rule, same line, as
+      // `emitAttrSlotsGranular` (reactive-effects.ts, #2447 follow-up).
+      if (attr.readsPreamble && mapPreambleWrapped) {
+        lines.push(`${indent}    ${mapPreambleWrapped}`)
+      }
       for (const stmt of emitDedupedAttrUpdate(varName, attr.attrName, attr.wrappedExpression, attr.meta, ordinal++)) {
         lines.push(`${indent}    ${stmt}`)
       }
@@ -181,7 +189,13 @@ export function stringifyBranchInnerLoops(
       }
     }
     if (inner.nestedConditionals.length > 0) {
-      stringifyLoopChildConditionals(lines, inner.nestedConditionals, `${indent}  `, pc)
+      // An inner loop's own conditionals are classified against the INNER
+      // loop's preamble names, not the outer row's — `BranchInnerLoop`
+      // carries no re-runnable preamble string for that scope, so there is
+      // nothing correct to inject here. The `readsPreamble && mapPreambleWrapped`
+      // guard downstream makes this `undefined` a no-op, exactly as before
+      // this fix (inner-loop preambles are out of scope — see PR notes).
+      stringifyLoopChildConditionals(lines, inner.nestedConditionals, `${indent}  `, pc, undefined)
     }
     lines.push(`${indent}  return __bel${uid}`)
     // #2753 Shape B: see the identical comment in `inner-loop.ts` —
@@ -202,11 +216,32 @@ export function stringifyLoopChildConditionals(
   lines: string[],
   conditionals: readonly LoopChildConditionalPlan[],
   indent: string,
-  pc?: string,
+  pc: string | undefined,
+  /** The row's preamble re-run statement, when this scope has one (#2596/#2447). */
+  mapPreambleWrapped: string | undefined,
 ): void {
   for (const cond of conditionals) {
-    stringifyLoopChildConditional(lines, cond, indent, pc)
+    stringifyLoopChildConditional(lines, cond, indent, pc, mapPreambleWrapped)
   }
+}
+
+/**
+ * The `() => cond` getter handed to `insert()`. A condition flagged
+ * `readsPreamble` (#2596) re-runs the row preamble INSIDE the getter —
+ * `insert()` re-invokes this closure on every dependency change to decide
+ * the branch, and a preamble local is a plain per-row `const`, not a signal
+ * `insert()` can see through on its own. ONE implementation for both the
+ * outer (`emitOuterConditional`, reactive-effects.ts) and nested
+ * (`stringifyLoopChildConditional`, here) levels so the two can't drift.
+ */
+export function conditionGetterExpr(
+  wrappedCondition: string,
+  readsPreamble: boolean | undefined,
+  mapPreambleWrapped: string | undefined,
+): string {
+  return readsPreamble && mapPreambleWrapped
+    ? `() => { ${mapPreambleWrapped}; return (${wrappedCondition}) }`
+    : `() => ${wrappedCondition}`
 }
 
 function stringifyLoopChildConditional(
@@ -214,21 +249,22 @@ function stringifyLoopChildConditional(
   cond: LoopChildConditionalPlan,
   indent: string,
   pc: string | undefined,
+  mapPreambleWrapped: string | undefined,
 ): void {
   const armIndent = `${indent}    `
   // Body-form arrows wire `__bfSlot` captures into the runtime so live
   // `Node` returns from Child-position interpolations are spliced into
   // the parsed fragment instead of being stringified by the surrounding
   // template literal (#1213).
-  lines.push(`${indent}insert(${cond.scopeVar}, '${cond.slotId}', () => ${cond.wrappedCondition}, {`)
+  lines.push(`${indent}insert(${cond.scopeVar}, '${cond.slotId}', ${conditionGetterExpr(cond.wrappedCondition, cond.readsPreamble, mapPreambleWrapped)}, {`)
   lines.push(`${indent}  template: () => { const __slots = []; return { html: \`${cond.whenTrueTemplateHtml}\`, slots: __slots } },`)
   lines.push(`${indent}  bindEvents: (__branchScope, { isFirstRun: __bfFirstRun = false } = {}) => {`)
-  stringifyLoopChildArm(lines, cond.whenTrueArm, armIndent, pc)
+  stringifyLoopChildArm(lines, cond.whenTrueArm, armIndent, pc, mapPreambleWrapped)
   lines.push(`${indent}  }`)
   lines.push(`${indent}}, {`)
   lines.push(`${indent}  template: () => { const __slots = []; return { html: \`${cond.whenFalseTemplateHtml}\`, slots: __slots } },`)
   lines.push(`${indent}  bindEvents: (__branchScope, { isFirstRun: __bfFirstRun = false } = {}) => {`)
-  stringifyLoopChildArm(lines, cond.whenFalseArm, armIndent, pc)
+  stringifyLoopChildArm(lines, cond.whenFalseArm, armIndent, pc, mapPreambleWrapped)
   lines.push(`${indent}  }`)
   lines.push(`${indent}}${profileBindingId(pc, cond.slotId)})`)
 }
@@ -246,6 +282,8 @@ export function stringifyLoopChildArm(
   arm: LoopChildArmPlan,
   armIndent: string,
   pc: string | undefined,
+  /** The row's preamble re-run statement, when this scope has one (#2596/#2447) — forwarded to this arm's own reactive attrs and nested conditionals. */
+  mapPreambleWrapped: string | undefined,
 ): void {
   stringifyBranchEventBindings(lines, arm.events, armIndent)
   stringifyBranchChildComponentInits(lines, arm.childComponents, armIndent)
@@ -261,7 +299,7 @@ export function stringifyLoopChildArm(
   if (!hasDisposables) return
 
   lines.push(`${armIndent}const __disposers = []`)
-  stringifyBranchReactiveAttrs(lines, arm.attrs, armIndent, pc)
+  stringifyBranchReactiveAttrs(lines, arm.attrs, armIndent, pc, mapPreambleWrapped)
 
   // Nested conditionals: each inner `insert()` is wrapped in its own
   // disposable effect so disposing THIS entry cascades to whatever
@@ -269,7 +307,7 @@ export function stringifyLoopChildArm(
   // conditional's nested-conditional handling in stringify/insert.ts).
   for (const cond of arm.nestedConditionals) {
     lines.push(`${armIndent}__disposers.push(createDisposableEffect(() => {`)
-    stringifyLoopChildConditional(lines, cond, `${armIndent}  `, pc)
+    stringifyLoopChildConditional(lines, cond, `${armIndent}  `, pc, mapPreambleWrapped)
     lines.push(`${armIndent}}))`)
   }
 

--- a/packages/jsx/src/ir-to-client-js/control-flow/stringify/reactive-effects.ts
+++ b/packages/jsx/src/ir-to-client-js/control-flow/stringify/reactive-effects.ts
@@ -33,7 +33,7 @@
 
 import { varSlotId, profileBindingId } from '../../utils.ts'
 import { emitDedupedAttrUpdate, DEDUP_STORE_DECL } from '../../emit-reactive.ts'
-import { stringifyLoopChildArm } from './loop-child-arm.ts'
+import { stringifyLoopChildArm, conditionGetterExpr } from './loop-child-arm.ts'
 import { claimPlanLiteral, claimWriterVarName, type ClaimSlotSpec } from './claim-plan.ts'
 import type {
   NestedConditionalPlan,
@@ -103,7 +103,11 @@ export interface StringifyReactiveEffectsOptions {
    * The loop callback's pre-return preamble (already wrapped with the loop
    * param accessor), re-run once per row-effect tick — BEFORE any preamble
    * region read — so `preambleRegions`' `valueExpr`s see freshly recomputed
-   * locals. Only meaningful alongside `preambleRegions`.
+   * locals. Also consumed by every OTHER `readsPreamble` site in this row's
+   * scope: row-level attrs (`emitAttrSlotsGranular`/`emitConsolidatedRowEffect`),
+   * outer condition getters (`emitOuterConditional`), and — forwarded
+   * through `stringifyLoopChildArm` (#2596 follow-up) — that row's branch
+   * arms' own reactive attrs and nested condition getters.
    */
   mapPreambleWrapped?: string
 }
@@ -363,18 +367,16 @@ function emitOuterConditional(
   // scope here (it's a plain per-row `const`, not a signal `insert()` can see
   // through on its own). Same treatment as `readsPreamble` attrs
   // (`emitAttrUpdate`'s callers) get ahead of their own write.
-  const conditionGetter = cond.readsPreamble && mapPreambleWrapped
-    ? `() => { ${mapPreambleWrapped}; return (${cond.wrappedCondition}) }`
-    : `() => ${cond.wrappedCondition}`
+  const conditionGetter = conditionGetterExpr(cond.wrappedCondition, cond.readsPreamble, mapPreambleWrapped)
   lines.push(`${indent}insert(${elVar}, '${cond.slotId}', ${conditionGetter}, {`)
   lines.push(`${indent}  template: () => { const __slots = []; return { html: \`${cond.whenTrueTemplateHtml}\`, slots: __slots } },`)
   lines.push(`${indent}  bindEvents: (__branchScope, { isFirstRun: __bfFirstRun = false } = {}) => {`)
-  stringifyLoopChildArm(lines, cond.whenTrueArm, armIndent, pc)
+  stringifyLoopChildArm(lines, cond.whenTrueArm, armIndent, pc, mapPreambleWrapped)
   lines.push(`${indent}  }`)
   lines.push(`${indent}}, {`)
   lines.push(`${indent}  template: () => { const __slots = []; return { html: \`${cond.whenFalseTemplateHtml}\`, slots: __slots } },`)
   lines.push(`${indent}  bindEvents: (__branchScope, { isFirstRun: __bfFirstRun = false } = {}) => {`)
-  stringifyLoopChildArm(lines, cond.whenFalseArm, armIndent, pc)
+  stringifyLoopChildArm(lines, cond.whenFalseArm, armIndent, pc, mapPreambleWrapped)
   lines.push(`${indent}  }`)
   lines.push(`${indent}}${profileBindingId(pc, cond.slotId)})`)
 }


### PR DESCRIPTION
## Summary

Found while discussing (post-#2872) whether `insert.ts`'s branch-arm reactive-attr handling and `loop-child-arm.ts`'s `stringifyBranchReactiveAttrs` should share one implementation. Tracing the types turned up a real bug, not just an asymmetry:

`ReactiveAttrEffect` (the type `stringifyBranchReactiveAttrs` consumes) carries a `readsPreamble?: boolean` flag — set by `reactivity.ts`'s `collectLoopChildReactiveAttrs` (called for the branch-arm case with `stopAtReactiveConditionals: true`) for exactly the shape its own comment documents: `const cls = row.done ? … ; class={cls}`. But `stringifyLoopChildArm` / `stringifyBranchReactiveAttrs` never received a `mapPreambleWrapped` string to re-run before reading `cls` — unlike every other `readsPreamble` consumer (`emitAttrSlotsGranular`, `emitConsolidatedRowEffect`, and the outer conditional's own condition getter in `emitOuterConditional`).

**Confirmed via a happy-dom hydration probe**: a same-key row update refreshes a plain `{row().field}` text sibling correctly, but a class/attribute derived from a `.map()` preamble local inside the same row's branch conditional stayed frozen at whatever it was on the row's last full render — a silent divergence from a sibling binding reading the underlying data directly.

An audit (design by Fable, `claude-fable-5-1`) found the gap had **three** structural pieces, not one:
1. Plan layer: `buildArmAttrsPlan` dropped `readsPreamble` on the way from `LoopChildReactiveAttr` to the arm-attrs plan.
2. Stringify layer: `stringifyLoopChildArm` → `stringifyBranchReactiveAttrs` never threaded `mapPreambleWrapped` down to where `readsPreamble`-flagged attrs are emitted.
3. A **second, independent** instance of the same class of bug: `LoopChildConditionalPlan` (a *nested* conditional's own condition, one level inside a branch arm) was missing `readsPreamble` entirely — so a nested conditional's condition expression reading a preamble local had the identical staleness bug.

## What changed

- `LoopChildConditionalPlan` gains `readsPreamble?: boolean` (mirrors `NestedConditionalPlan.readsPreamble` one level up); `buildLoopChildConditionalsPlan`/`buildArmAttrsPlan` now forward the flag instead of dropping it.
- `stringifyLoopChildArm` / `stringifyBranchReactiveAttrs` / `stringifyLoopChildConditional` all gained a `mapPreambleWrapped: string | undefined` parameter, threaded through to where a `readsPreamble`-flagged attr effect or condition getter needs it.
- New shared helper `conditionGetterExpr()` in `loop-child-arm.ts`, used by both `emitOuterConditional` (outer, row-level conditional) and `stringifyLoopChildConditional` (nested, branch-scoped conditional) to build the `() => cond` getter, with or without a preamble re-run — so the two paths can't drift apart again on this logic (per the repo's "one decision, one implementation" convention).
- Left untouched, by design: branch-scoped inner-loop (`stringifyBranchInnerLoops`) and top-level inner-loop (`stringifyInnerLoops`) preambles — their preamble isn't a single re-runnable string like the outer row's, so there's nothing correct to thread there yet; both call sites now carry an explicit comment saying so.

**Relation to #2871** (already merged, in this PR's base): unrelated bug, same neighborhood. #2871 fixes `classifyReactivity` never recognizing an index-*only* expression as reactive at all (missing classification). This bug is different: the attribute/condition *is* correctly classified reactive, and does get an effect, but the effect never re-ran the preamble computation the expression depends on — a wiring gap downstream of correct classification.

## Test plan

- [x] `packages/client/__tests__/runtime/preamble-branch-attr-staleness.test.ts` — happy-dom hydration test; drives a same-key row update and asserts the class now updates (`'tier-silver'`), previously stuck at `'tier-gold'`.
- [x] `packages/jsx/src/__tests__/preamble-branch-arm-rerun.test.ts` — codegen-shape pins for (a) a reactive attribute inside a branch arm, (b) a nested conditional's own condition, and (c) a negative control (no preamble local in play — nothing injected).
- [x] `bun run packages/adapter-tests/scripts/generate-expected-html.ts` — zero diff; this is a client-JS-behavioral fix only, no SSR/CSR template output changes.
- [x] `.changeset/preamble-branch-arm-rerun-2596.md` added (`@barefootjs/jsx` patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GGEdZGGtKh3hy1DfMcn59A