### PR TITLE
Fix #2863: Go adapter ternary/operand template-literal branch emits invalid syntax

### DIFF
--- a/.changeset/go-ternary-template-literal-2863.md
+++ b/.changeset/go-ternary-template-literal-2863.md
@@ -1,0 +1,7 @@
+---
+"@barefootjs/go-template": patch
+---
+
+Fix #2863: a ternary (or `+`/`||`/`??` operand, or a `queryHref`-style helper argument) whose branch was a multi-part template literal (e.g. `` event.endTime ? `${event.time}–${event.endTime}` : event.time ``) emitted invalid Go template syntax — nested `{{…}}` action delimiters inside another action's pipeline argument list (`(bf_ternary … {{.Time}}–{{.EndTime}} …)`). `bf build` succeeded, but the generated `.tmpl` file failed `html/template.Parse` at Go application startup with `unexpected "{" in operand`.
+
+The Go adapter's ternary/operand lowering now folds a template literal used in this VALUE position into a single Go pipeline value via a left-folded `bf_concat_str` chain (the same runtime helper already used for JS string-concatenation `+`), instead of routing it through the TEXT-position `templateLiteral()` emitter (mixed literal text plus `{{…}}` action wraps), which is only safe when spliced directly into markup. A per-row child-component prop reading a multi-part template literal — previously refused outright with `BF101` — now lowers faithfully through the same path instead.

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -376,6 +376,101 @@ describe('GoTemplateAdapter - bf_ternary value-position lowering (#2335)', () =>
   test('emits no {{if}} action fragment for a value-position ternary', () => {
     expect(render("flag ? 'a' : 'b'")).not.toContain('{{if')
   })
+
+  // #2863: a multi-part template literal (mixed literal text and MULTIPLE
+  // interpolations) as a ternary BRANCH used to lower through the TEXT-
+  // position `templateLiteral()` path (`{{.Start}}-{{.End}}`), nesting raw
+  // `{{`/`}}` delimiters inside `bf_ternary`'s own argument list — a
+  // `html/template` parse error ("unexpected \"{\" in operand") at Go
+  // application startup, even though `bf build` itself succeeded. It must
+  // instead fold to one pipeline value, chained through the same
+  // `bf_concat_str` runtime helper JS string-concat `+` already uses (#2168).
+  test('a multi-part template-literal branch folds to a bf_concat_str chain, not a raw fragment (#2863)', () => {
+    expect(render('end ? `${start}-${end}` : start')).toBe(
+      '{{(bf_ternary (bf_truthy .End) (bf_concat_str (bf_concat_str .Start "-") .End) .Start)}}',
+    )
+  })
+
+  test('a template-literal branch never leaks a raw {{ or }} into the surrounding action (#2863)', () => {
+    const out = render('end ? `${start}-${end}` : start')
+    const inner = out.slice(2, -2) // strip the outer {{ }} the whole expression is wrapped in
+    expect(inner).not.toContain('{{')
+    expect(inner).not.toContain('}}')
+  })
+
+  test('a single-part template-literal branch reduces to the bare value, no bf_concat_str wrap (#2863)', () => {
+    expect(render('end ? `${start}` : end')).toBe('{{(bf_ternary (bf_truthy .End) .Start .End)}}')
+  })
+
+  test('static text in a template-literal branch is an escaped Go string literal (#2863)', () => {
+    expect(render('end ? `say "hi" ${start}` : end')).toBe(
+      '{{(bf_ternary (bf_truthy .End) (bf_concat_str "say \\"hi\\" " .Start) .End)}}',
+    )
+  })
+
+  test('a nested ternary inside a template-literal branch still lowers to bf_ternary, not {{if}} (#2863)', () => {
+    const out = render('end ? `x ${flag ? \'a\' : \'b\'}` : end')
+    expect(out).toBe(
+      '{{(bf_ternary (bf_truthy .End) (bf_concat_str "x " (bf_ternary (bf_truthy .Flag) "a" "b")) .End)}}',
+    )
+    expect(out).not.toContain('{{if')
+  })
+})
+
+// #2863 follow-up: the same value-position leak existed for a `+`/`||`
+// operand and a registered-lowering (`queryHref`) argument, not just a
+// `bf_ternary` branch — every such position funnels through the Go
+// adapter's shared `lowerValueOperand` door (`expr/url-builder.ts`).
+describe('GoTemplateAdapter - value-position template literal in other operand positions (#2863)', () => {
+  const adapter = new GoTemplateAdapter()
+  const render = (expr: string) => adapter.renderExpression({ expr } as IRExpression)
+
+  test('a template-literal operand of `+` folds through bf_concat_str, not a raw fragment', () => {
+    const out = render('`${a}-${b}` + a')
+    const inner = out.slice(2, -2)
+    expect(inner).not.toContain('{{')
+    expect(inner).toContain('bf_concat_str')
+  })
+
+  test('a template-literal operand of `||` folds through bf_concat_str, not a raw fragment', () => {
+    const out = render('a || `${a}-${b}`')
+    const inner = out.slice(2, -2)
+    expect(inner).not.toContain('{{')
+  })
+
+  // The issue's exact repro shape: a local, expression-bodied helper arrow
+  // (`eventTime`) whose body is the ternary+template-literal, called from a
+  // `.map()` row. A ternary written DIRECTLY inline in JSX instead compiles
+  // to a text-position `IRConditional` (`{{if}}…{{else}}…{{end}}`, correct
+  // and unaffected by this bug) — the buggy VALUE-position path is only
+  // reached once `inlineLocalHelperCall` substitutes the helper's body into
+  // the `eventTime(event)` call site and the Go adapter re-parses the
+  // result as a plain expression, not a JSX conditional.
+  test('the issue #2863 repro: a local-helper ternary+template-literal inlined in a .map() row lowers to valid Go source', () => {
+    const { template } = compileAndGenerate(`
+'use client'
+import { createSignal } from '@barefootjs/client'
+type Event = { id: string; time: string; endTime: string }
+type Dashboard = { events: Event[] }
+const empty: Dashboard = { events: [] }
+export function Schedule() {
+  const [data] = createSignal<Dashboard>(empty)
+  const eventTime = (event: Event) =>
+    event.endTime ? \`\${event.time}–\${event.endTime}\` : event.time
+  return (
+    <ol>
+      {data().events.map((event) => (
+        <li key={event.id}><time>{eventTime(event)}</time></li>
+      ))}
+    </ol>
+  )
+}
+`)
+    expect(template).toContain(
+      '(bf_ternary (bf_truthy .EndTime) (bf_concat_str (bf_concat_str .Time "–") .EndTime) .Time)',
+    )
+    expect(template).not.toContain('{{.Time}}–{{.EndTime}}')
+  })
 })
 
 // #2335 item 2 (correctness): a ternary used as a boolean CONDITION used to
@@ -4701,11 +4796,14 @@ export function CompositeRowChildComponent(props: { items: Item[] }) {
   })
 
   // A multi-part template literal (mixed literal text and interpolation,
-  // `` `#${row.id} ${row.label}` ``) has no single-pipeline-value reduction
-  // the way a single-part ternary does — refuse it loudly (BF101) instead
-  // of silently emitting the stale constructor-only value (the #2445 bug
-  // this whole fix exists to close).
-  test('a multi-part template-literal per-row prop is refused with BF101, not silently stale', () => {
+  // `` `#${row.id} ${row.label}` ``) folds through the shared value-operand
+  // door (#2863) — a left-folded `bf_concat_str` chain — instead of being
+  // refused (BF101) the way it used to be here (this call site had no
+  // reduction for the multi-part case before #2863, only a single-part
+  // unwrap). It must still NOT silently emit the stale constructor-only
+  // value (the #2445 bug this whole fix exists to close) — it now emits the
+  // correct live per-row value instead.
+  test('a multi-part template-literal per-row prop folds through bf_concat_str, not silently stale (#2445, #2863)', () => {
     const result = compileJSX(`
 'use client'
 import { createSignal } from '@barefootjs/client'
@@ -4726,9 +4824,11 @@ export function CompositeRowChildComponent(props: { items: Item[] }) {
   )
 }
 `.trimStart(), 'test.tsx', { adapter: new GoTemplateAdapter(), outputIR: false })
-    expect((result.errors ?? []).some(e => e.code === 'BF101')).toBe(true)
+    expect(result.errors ?? []).toEqual([])
     const template = result.files.find(f => f.type === 'markedTemplate')!.content
-    expect(template).not.toContain('bf_with_props')
+    expect(template).toContain(
+      '{{template "Badge" (bf_with_props $.BadgeSlot0 "Text" (bf_concat_str (bf_concat_str (bf_concat_str "#" .ID) " ") .Label))}}',
+    )
   })
 
   // A prop whose expression `convertExpressionToGo` itself refuses (an

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -473,6 +473,66 @@ export function Schedule() {
   })
 })
 
+// #2863 (pullfrog review on #2877): three more argument/operand positions
+// that reach a template literal without going through `lowerValueOperand`/
+// `emitOperand` — verified to reproduce the identical `unexpected "{" in
+// operand` class of bug before this fix, via a standalone script driving
+// `html/template.Parse` on the pre-fix output.
+describe('GoTemplateAdapter - value-position template literal in condition/array-method/index positions (#2863 follow-up)', () => {
+  // `renderConditionExpr`'s own `binary`/`unary`/`logical` recursion is a
+  // SEPARATE walker from the generic `emit()` dispatcher (it threads a
+  // `preamble` string `emitOperand` doesn't track) — reached whenever a
+  // ternary/`&&`/`||`/`!` TEST is a comparison against (or otherwise
+  // contains) a template literal, since `lowerTernaryTest`/`lowerUrlGuard`'s
+  // "bool-shape" branch routes through `convertConditionToGo` instead of
+  // `lowerValueOperand`.
+  test('a ternary TEST comparing to a template literal folds through bf_concat_str inside the {{if}}', () => {
+    const { template } = compileAndGenerate(`
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function T() {
+  const [x] = createSignal('x')
+  const [y] = createSignal('y')
+  const [z] = createSignal('z')
+  return <span>{(x() === \`\${y()}-\${z()}\`) ? 'a' : 'b'}</span>
+}
+`)
+    expect(template).toContain('{{if eq .X (bf_concat_str (bf_concat_str .Y "-") .Z)}}')
+  })
+
+  // `arrayMethod()`'s per-method cases (`join`, `includes`, `indexOf`, …) all
+  // lower their receiver/args via the dispatcher's plain `emit`, not
+  // `emitOperand` — no ternary or helper-inlining needed to reach the bug.
+  test('Array.join with a template-literal separator folds through bf_concat_str', () => {
+    const { template } = compileAndGenerate(`
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function T() {
+  const [items] = createSignal<string[]>([])
+  const [y] = createSignal('y')
+  const [z] = createSignal('z')
+  return <span>{items().join(\`\${y()}-\${z()}\`)}</span>
+}
+`)
+    expect(template).toContain('bf_join (.Items) (bf_concat_str (bf_concat_str .Y "-") .Z)')
+  })
+
+  // `indexAccess()` lowers both the object and the index via plain `emit`.
+  test('a computed index-access with a template-literal key folds through bf_concat_str', () => {
+    const { template } = compileAndGenerate(`
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function T() {
+  const [obj] = createSignal<Record<string, string>>({})
+  const [y] = createSignal('y')
+  const [z] = createSignal('z')
+  return <span>{obj()[\`\${y()}-\${z()}\`]}</span>
+}
+`)
+    expect(template).toContain('bf_get .Obj (bf_concat_str (bf_concat_str .Y "-") .Z)')
+  })
+})
+
 // #2335 item 2 (correctness): a ternary used as a boolean CONDITION used to
 // return only its lowered `test`, silently discarding both branches. It now
 // lowers faithfully to `(bf_ternary …)`, truthiness-checked by the enclosing

--- a/packages/adapter-go-template/src/adapter/expr/url-builder.ts
+++ b/packages/adapter-go-template/src/adapter/expr/url-builder.ts
@@ -10,13 +10,14 @@
 import {
   type LoweringNode,
   type ParsedExpr,
+  type TemplatePart,
   parseExpression,
   stringifyParsedExpr,
   isValidHelperId,
 } from '@barefootjs/jsx'
 
 import type { GoEmitContext } from '../emit-context.ts'
-import { wrapIfMultiToken } from '../lib/go-emit.ts'
+import { escapeGoString, wrapIfMultiToken } from '../lib/go-emit.ts'
 
 /**
  * Logical helper id → Go template helper name. `bf_<helper>` is a formula,
@@ -61,7 +62,7 @@ function lowerUrlGuard(ctx: GoEmitContext, g: ParsedExpr): string {
   if (isBoolShape) {
     return ctx.convertConditionToGo(stringifyParsedExpr(g), g).condition
   }
-  const valueGo = wrapIfMultiToken(ctx.convertExpressionToGo(stringifyParsedExpr(g), undefined, g))
+  const valueGo = lowerValueOperand(ctx, g)
   return `ne ${valueGo} ""`
 }
 
@@ -91,20 +92,62 @@ export function lowerTernary(
   alternate: ParsedExpr,
 ): string {
   const t = lowerTernaryTest(ctx, test)
-  return `(bf_ternary ${t} ${lowerTernaryOperand(ctx, consequent)} ${lowerTernaryOperand(ctx, alternate)})`
+  return `(bf_ternary ${t} ${lowerValueOperand(ctx, consequent)} ${lowerValueOperand(ctx, alternate)})`
 }
 
 /**
- * A ternary branch in value position: a nested ternary recurses to another
- * `bf_ternary`; anything else lowers to its Go value (parenthesised when
- * multi-token so it stays one argument). String branches become quoted,
- * html/template-escaped values — not the bare unquoted text the old `{{if}}`
- * fragment path emitted — which is exactly right for the value positions this
- * is reached for.
+ * Lower a template literal to ONE Go pipeline VALUE (#2863): a left fold of
+ * `bf_concat_str` over the parts — static text as an escaped Go string
+ * literal, each interpolation as its own value operand. The TEXT-position
+ * form (`GoTemplateAdapter.templateLiteral()`: literal text interleaved with
+ * `{{…}}` actions) is only legal where the result is spliced directly into
+ * markup; inside another action's argument list (a `bf_ternary` branch, a
+ * helper-call arg, a `bf_query` guard value, …) Go rejects nested `{{`/`}}`
+ * delimiters ("unexpected \"{\" in operand"). This is the Go twin of the
+ * concatenation every other DSL adapter already emits for the same nested
+ * shape (e.g. Jinja/Twig `bf.string(a) ~ '–' ~ bf.string(b)`) — Go was the
+ * lone outlier because `text/template` has no expression-level string
+ * concatenation operator of its own, only this runtime helper (already used
+ * by `binary()`'s string-typed `+`, #2168).
+ *
+ * A single-part literal (`` `${x}` `` alone) reduces to that one value with
+ * no `bf_concat_str` wrapper — mirrors the sibling single-part unwrap at the
+ * child-prop call site. An all-static literal (already reduced to a plain
+ * `literal` ParsedExpr by the parser in practice, but handled here too)
+ * folds to one escaped string.
  */
-function lowerTernaryOperand(ctx: GoEmitContext, n: ParsedExpr): string {
+export function lowerTemplateLiteralValue(ctx: GoEmitContext, parts: readonly TemplatePart[]): string {
+  const terms: string[] = []
+  for (const part of parts) {
+    if (part.type === 'string') {
+      if (part.value !== '') terms.push(`"${escapeGoString(part.value)}"`)
+    } else {
+      terms.push(lowerValueOperand(ctx, part.expr))
+    }
+  }
+  if (terms.length === 0) return '""'
+  return terms.slice(1).reduce((acc, t) => `(bf_concat_str ${acc} ${t})`, terms[0])
+}
+
+/**
+ * The single door for "this ParsedExpr sits in Go pipeline ARGUMENT
+ * position" — a `bf_ternary` branch, a ternary/guard test's value form, a
+ * helper-call arg, a `bf_query` base/guard/value. A nested ternary recurses
+ * to another `bf_ternary`; a template literal folds through
+ * `lowerTemplateLiteralValue` (#2863) rather than the generic expression
+ * path, which would otherwise return the TEXT-position mixed
+ * literal-text-plus-`{{…}}`-actions form; anything else lowers to its Go
+ * value (parenthesised when multi-token so it stays one argument). String
+ * branches become quoted, html/template-escaped values — not the bare
+ * unquoted text the old `{{if}}` fragment path emitted — which is exactly
+ * right for the value positions this is reached for.
+ */
+export function lowerValueOperand(ctx: GoEmitContext, n: ParsedExpr): string {
   if (n.kind === 'conditional') {
     return lowerTernary(ctx, n.test, n.consequent, n.alternate)
+  }
+  if (n.kind === 'template-literal') {
+    return wrapIfMultiToken(lowerTemplateLiteralValue(ctx, n.parts))
   }
   return wrapIfMultiToken(ctx.convertExpressionToGo(stringifyParsedExpr(n), undefined, n))
 }
@@ -120,7 +163,7 @@ function lowerTernaryOperand(ctx: GoEmitContext, n: ParsedExpr): string {
  * counterpart of `lowerUrlGuard`'s string-only `ne <value> ""`.
  */
 function lowerTernaryTest(ctx: GoEmitContext, test: ParsedExpr): string {
-  const go = wrapIfMultiToken(ctx.convertExpressionToGo(stringifyParsedExpr(test), undefined, test))
+  const go = lowerValueOperand(ctx, test)
   const isBoolShape =
     (test.kind === 'binary' && BOOL_COMPARISON_OPS.has(test.op)) ||
     (test.kind === 'unary' && test.op === '!') ||
@@ -280,22 +323,14 @@ function ternaryHasQueryBranch(
 function renderLoweringNode(ctx: GoEmitContext, node: LoweringNode): string | null {
   const helper = goHelperName(node.helper)
   if (!helper) return null
-  const lowerExpr = (n: ParsedExpr): string =>
-    ctx.convertExpressionToGo(stringifyParsedExpr(n), undefined, n)
-  // A `conditional` in ARGUMENT position lowers to the pipeline-position
-  // `(bf_ternary …)` form via the shared `lowerTernary` (#2335) — the same
-  // form the ParsedExpr `conditional()` emitter and the condition-expression
-  // emitter produce. Routing it here explicitly (rather than leaning on the
-  // generic `lowerExpr`, whose `conditional()` dispatch now reaches the very
-  // same helper) keeps the arg lowering self-contained and its intent local;
-  // `lowerTernary` itself right-folds a nested chain (the #2324 union stage's
-  // locale→pattern table) into `(bf_ternary <cond> <a> (bf_ternary …))`.
-  const lowerArg = (n: ParsedExpr): string =>
-    n.kind === 'conditional'
-      ? lowerTernary(ctx, n.test, n.consequent, n.alternate)
-      : wrapIfMultiToken(lowerExpr(n))
+  // Every argument here is Go pipeline ARGUMENT position — a `conditional`
+  // lowers to `(bf_ternary …)`, a `template-literal` folds through
+  // `bf_concat_str` (#2863) rather than leaking the TEXT-position
+  // `{{…}}`-actions form into this call's argument list, anything else takes
+  // the generic value path. `lowerValueOperand` is the one shared door every
+  // such position in this file now goes through.
   if (node.kind === 'helper-call') {
-    const args = node.args.map(a => lowerArg(a))
+    const args = node.args.map(a => lowerValueOperand(ctx, a))
     return [helper, ...args].join(' ')
   }
   // guard-list — `queryHref`-shaped. Inclusion mirrors the client exactly, where
@@ -304,12 +339,12 @@ function renderLoweringNode(ctx: GoEmitContext, node: LoweringNode): string | nu
   //   - plain `key: v` (guard null)        → `(true) "key" v`
   //   - conditional `key: cond ? a : <omit>` → `(<cond>) "key" a`, where the
   //     non-empty check is done by bf_query, not folded into the guard.
-  const parts: string[] = [wrapIfMultiToken(lowerExpr(node.base))]
+  const parts: string[] = [lowerValueOperand(ctx, node.base)]
   for (const t of node.triples) {
     const includeGo = t.guard === null ? 'true' : lowerUrlGuard(ctx, t.guard)
     parts.push(`(${includeGo})`)
     parts.push(JSON.stringify(t.key))
-    parts.push(wrapIfMultiToken(lowerExpr(t.value)))
+    parts.push(lowerValueOperand(ctx, t.value))
   }
   return `${helper} ${parts.join(' ')}`
 }

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -5180,7 +5180,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // arithmetic index lowers correctly. A multi-token operand
     // (`bf_add $i 1`) must be parenthesised or Go parses it as extra
     // `bf_get` arguments.
-    return `bf_get ${wrapIfMultiToken(emit(object))} ${wrapIfMultiToken(emit(index))}`
+    return `bf_get ${wrapIfMultiToken(this.emitOperand(object, emit))} ${wrapIfMultiToken(this.emitOperand(index, emit))}`
   }
 
   /**
@@ -5623,8 +5623,16 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     method: ArrayMethod,
     object: ParsedExpr,
     args: ParsedExpr[],
-    emit: (e: ParsedExpr) => string,
+    rawEmit: (e: ParsedExpr) => string,
   ): string {
+    // Every `emit(...)` call below lowers an ARGUMENT position (the
+    // receiver or a `.method(...)` arg) that feeds a prefix-call Go form
+    // (`bf_join (...) ...`, `bf_replace ... ... ...`, …) — shadow the
+    // dispatcher's own `emit` with `emitOperand` (#2863) so a
+    // template-literal receiver/argument (e.g. `items.join(\`${a}-${b}\`)`)
+    // folds through `bf_concat_str` instead of leaking the TEXT-position
+    // `templateLiteral()` form into another action's argument list.
+    const emit = (e: ParsedExpr): string => this.emitOperand(e, rawEmit)
     // `bf_join` etc. are registered in the runtime FuncMap. The exhaustive
     // switch on `method` mirrors the IR-level discriminator — adding a new
     // `ArrayMethod` variant becomes a TS compile error until every adapter
@@ -7176,7 +7184,12 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       }
 
       case 'template-literal':
-        return plain(this.renderParsedExpr(expr))
+        // #2863 follow-up: fold to one Go value (`bf_concat_str` chain) via
+        // the same door as the `conditional` case just above, instead of
+        // `renderParsedExpr`'s TEXT-position `templateLiteral()` form —
+        // which would leak raw `{{…}}` into THIS condition-expression's own
+        // pipeline position (e.g. `(a === \`${x}-${y}\`) ? … : …`).
+        return plain(lowerTemplateLiteralValue(this.emitCtx, expr.parts))
 
       case 'arrow':
         // A standalone arrow has no Go condition form (callbacks reach the

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -130,7 +130,7 @@ import { analyzeBakeableStaticChildLoop, scalarToGoLiteral, type BakedStaticChil
 import { analyzeBakeableStaticElementLoop } from "./analysis/static-element-loop-bake.ts"
 import type { GoEmitContext } from "./emit-context.ts"
 import { inlineLocalHelperCall } from "./expr/helper-inline.ts"
-import { lowerRegisteredAttrCall, lowerRegisteredCall, lowerRegisteredCallNode, lowerTernary } from "./expr/url-builder.ts"
+import { lowerRegisteredAttrCall, lowerRegisteredCall, lowerRegisteredCallNode, lowerTemplateLiteralValue, lowerTernary, lowerValueOperand } from "./expr/url-builder.ts"
 import {
   convertInitialValue,
   jsLiteralToGo,
@@ -5183,9 +5183,32 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     return `bf_get ${wrapIfMultiToken(emit(object))} ${wrapIfMultiToken(emit(index))}`
   }
 
+  /**
+   * A `binary`/`logical`/`unary` operand that feeds a prefix-call Go form
+   * (`bf_mul a b`, `and a b`, `not a`, …), which cannot host a raw `{{…}}`
+   * action the way the generic `emit` dispatcher's `templateLiteral()` would
+   * produce for a template-literal operand (#2863). ONLY a template literal
+   * is special-cased here, folded through `bf_concat_str` (the same door
+   * `lowerValueOperand` uses for a ternary branch / helper-call arg /
+   * query-guard value); every other kind still goes through the caller's own
+   * `emit` closure unchanged. This matters: routing every operand through
+   * `lowerValueOperand`'s `convertExpressionToGo` fallback (rather than only
+   * the one broken kind) would ALSO pick up `convertExpressionToGo`'s own
+   * string-keyed fast paths — e.g. inlining a bare identifier bound to a
+   * local literal const — which `emit`'s AST-walk `identifier()` dispatch
+   * does not do, a real behavioral divergence for that shape (caught by the
+   * #2236 loop-param-shadowing regression pins).
+   */
+  private emitOperand(n: ParsedExpr, emit: (e: ParsedExpr) => string): string {
+    if (n.kind === 'template-literal') {
+      return wrapIfMultiToken(lowerTemplateLiteralValue(this.emitCtx, n.parts))
+    }
+    return emit(n)
+  }
+
   binary(op: string, left: ParsedExpr, right: ParsedExpr, emit: (e: ParsedExpr) => string): string {
-    const l = emit(left)
-    const r = emit(right)
+    const l = this.emitOperand(left, emit)
+    const r = this.emitOperand(right, emit)
     // Every Go form below is a prefix function call (`bf_mul a b`, `gt a b`,
     // `eq a b`), so a COMPOUND operand must be parenthesised or the template
     // parser folds its tokens into the call's argument list — e.g.
@@ -5268,7 +5291,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   }
 
   unary(op: string, argument: ParsedExpr, emit: (e: ParsedExpr) => string): string {
-    const arg = emit(argument)
+    const arg = this.emitOperand(argument, emit)
     // `not` is a Go template prefix builtin like `and`/`or` (see `logical()`
     // below) — a multi-token argument (e.g. `or a b`) must be parenthesised
     // or it degrades into extra sibling args of `not` itself (#2758: `not
@@ -5291,8 +5314,8 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // `and`/`or`. This makes `searchParams().get(k) ?? d` lower to
     // `or (.SearchParams.Get "sort") "none"` instead of the broken
     // `or .SearchParams.Get "sort" "none"`.
-    const wrapLeft = wrapIfMultiToken(emit(left))
-    const wrapRight = wrapIfMultiToken(emit(right))
+    const wrapLeft = wrapIfMultiToken(this.emitOperand(left, emit))
+    const wrapRight = wrapIfMultiToken(this.emitOperand(right, emit))
     if (op === '&&') return `and ${wrapLeft} ${wrapRight}`
     // `??` on a nillable prop needs true JS nullish semantics (#2248): Go's
     // `or` is truthiness-based, so `{{or .Label "Default"}}` falls back on a
@@ -6682,34 +6705,23 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         }
         continue
       }
-      // A ternary / single-interpolation template literal with STRING-typed
-      // branches (`row.on ? "yes" : "no"`, `${row.x}` alone) parses to a
-      // ParsedExpr `template-literal` whose sole part is non-string —
-      // `templateLiteral()` wraps that one dynamic part's already-bare
-      // pipeline value (e.g. `(bf_ternary ...)`, #2335) in a bare `{{...}}`
-      // shell meant for TEXT-position embedding. A multi-part template
-      // literal (mixed literal text and interpolation) has no such reduction
-      // and stays refused below. Unwrap the single-part case back to the
-      // bare pipeline value this call site (a function ARGUMENT position,
-      // not a text position) needs.
-      const singlePartTemplateLiteral =
-        exprOut.parsed?.kind === 'template-literal' &&
-        exprOut.parsed.parts.length === 1 &&
-        exprOut.parsed.parts[0].type !== 'string' &&
-        go.startsWith('{{') &&
-        go.endsWith('}}')
-      if (singlePartTemplateLiteral) {
-        go = go.slice(2, -2)
-      }
-      // Skip the fragment re-check for the just-unwrapped single-part case —
-      // `kind` is still (accurately) `template-literal`, which would
-      // otherwise re-trip `isTemplateFragment`'s `kind === 'template-literal'`
-      // branch on the ALREADY-unwrapped bare value.
-      if (!singlePartTemplateLiteral && this.isTemplateFragment(go, exprOut.parsed?.kind)) {
-        // A genuine multi-part `{{if}}...{{end}}`-shaped fragment can't be a
-        // bare pipeline argument — refuse loudly rather than silently
-        // dropping the prop (the #2445 bug was exactly a silent drop one
-        // level up).
+      // A ternary or template literal (`row.on ? "yes" : "no"`, `` `#${row.id}
+      // ${row.label}` ``) in this ARGUMENT position (a `bf_with_props`/
+      // `bf_reprops` value, not a text position) must lower through the
+      // shared value-operand door (#2863/#2335) — `convertExpressionToGo`'s
+      // generic path returns `templateLiteral()`'s TEXT-position mixed
+      // literal-text-plus-`{{…}}`-actions form for a template literal, which
+      // is not a legal bare pipeline argument (multi-part) or needed an
+      // ad-hoc single-part unwrap here (this replaces both). Recompute from
+      // the already-validated `exprOut.parsed` tree rather than trying to
+      // unwrap or refuse the text-position string after the fact.
+      if (exprOut.parsed?.kind === 'template-literal' || exprOut.parsed?.kind === 'conditional') {
+        go = lowerValueOperand(this.emitCtx, exprOut.parsed)
+      } else if (this.isTemplateFragment(go, exprOut.parsed?.kind)) {
+        // A genuine `{{if}}...{{end}}`-shaped (or other `{{`-leading action)
+        // fragment can't be a bare pipeline argument — refuse loudly rather
+        // than silently dropping the prop (the #2445 bug was exactly a
+        // silent drop one level up).
         this.state.errors.push({
           code: 'BF101',
           severity: 'error',

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -5816,6 +5816,17 @@
         "condition"
       ]
     },
+    "ternary-template-literal-branch": {
+      "kinds": [
+        "conditional",
+        "identifier",
+        "template-literal"
+      ],
+      "axes": [],
+      "contexts": [
+        "attribute"
+      ]
+    },
     "text-escape": {
       "kinds": [
         "call",
@@ -6128,14 +6139,14 @@
     "arrow": 72,
     "binary": 99,
     "call": 257,
-    "conditional": 30,
-    "identifier": 359,
+    "conditional": 31,
+    "identifier": 360,
     "index-access": 14,
     "literal": 286,
     "logical": 49,
     "member": 203,
     "object-literal": 78,
-    "template-literal": 30,
+    "template-literal": 31,
     "unary": 27,
     "unsupported": 47
   },

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -416,6 +416,7 @@ import { fixture as nestedLoopTripleDepth } from './nested-loop-triple-depth'
 import { fixture as nestedLoopRefConst } from './nested-loop-ref-const'
 import { fixture as nestedLoopIndependentSignal } from './nested-loop-independent-signal'
 import { fixture as keyedLoopPureIndexReorder } from './keyed-loop-pure-index-reorder'
+import { fixture as ternaryTemplateLiteralBranch } from './ternary-template-literal-branch'
 import { fixture as nestedLoopOuterIndexReorder } from './nested-loop-outer-index-reorder'
 import { fixture as svgInnerLoop } from './svg-inner-loop'
 import { fixture as siblingLoopsKeyIsolation } from './sibling-loops-key-isolation'
@@ -911,6 +912,7 @@ export const jsxFixtures: JSXFixture[] = [
   nestedLoopRefConst,
   nestedLoopIndependentSignal,
   keyedLoopPureIndexReorder,
+  ternaryTemplateLiteralBranch,
   nestedLoopOuterIndexReorder,
   svgInnerLoop,
   siblingLoopsKeyIsolation,

--- a/packages/adapter-tests/fixtures/ternary-template-literal-branch.ts
+++ b/packages/adapter-tests/fixtures/ternary-template-literal-branch.ts
@@ -1,0 +1,37 @@
+import { createFixture } from '../src/types'
+
+/**
+ * A ternary whose CONSEQUENT is a multi-part template literal, in ATTRIBUTE
+ * position (#2863). The Go adapter's ternary-branch lowering used to route
+ * a template-literal operand through the TEXT-position `templateLiteral()`
+ * emitter — mixed literal text plus `{{…}}` action wraps, meant for direct
+ * markup embedding — nesting raw `{{`/`}}` delimiters inside `bf_ternary`'s
+ * own pipeline argument list. `bf build` succeeded, but the generated
+ * template failed `html/template.Parse` at Go application startup
+ * ("unexpected \"{\" in operand"). Every other adapter already handled this
+ * shape correctly (a native ternary + string concatenation); only Go's
+ * markup-language template restriction exposed the gap.
+ *
+ * A ternary written directly as a JSX TEXT child instead compiles to a
+ * text-position `IRConditional` (an `{{if}}…{{else}}…{{end}}` reactive
+ * swap) — a different, already-correct code path unaffected by this bug —
+ * so attribute position is the shape that actually exercises the fix.
+ *
+ * `props.a` carries an HTML-special character to pin escaping parity: the
+ * template-literal's dynamic parts must still be escaped exactly once (by
+ * the enclosing attribute context), not zero or twice.
+ */
+export const fixture = createFixture({
+  id: 'ternary-template-literal-branch',
+  description: 'A ternary consequent that is a multi-part template literal, in attribute position (#2863)',
+  source: `
+export function TernaryTemplateLiteralBranch({ ok, a, b }: { ok: boolean; a: string; b: string }) {
+  return <span title={ok ? \`\${a}–\${b}\` : a}>x</span>
+}
+`,
+  props: { ok: true, a: '9<b>&"\'', b: '10' },
+  expectedHtml: `
+    <span bf-s="test" bf="s0" title="9&lt;b&gt;&amp;&quot;&#39;–10">x</span>
+  `,
+  dataPoints: [{ name: 'alternate-branch', props: { ok: false, a: '9', b: '10' } }],
+})

--- a/packages/adapter-tests/generated-data-points.json
+++ b/packages/adapter-tests/generated-data-points.json
@@ -3129,6 +3129,64 @@
       }
     }
   ],
+  "ternary-template-literal-branch": [
+    {
+      "name": "gen:ok:false",
+      "props": {
+        "ok": false,
+        "a": "9<b>&\"'",
+        "b": "10"
+      }
+    },
+    {
+      "name": "gen:a:empty",
+      "props": {
+        "ok": true,
+        "a": "",
+        "b": "10"
+      }
+    },
+    {
+      "name": "gen:a:markup",
+      "props": {
+        "ok": true,
+        "a": "<b>&\"'</b>",
+        "b": "10"
+      }
+    },
+    {
+      "name": "gen:a:multibyte",
+      "props": {
+        "ok": true,
+        "a": "日本語",
+        "b": "10"
+      }
+    },
+    {
+      "name": "gen:b:empty",
+      "props": {
+        "ok": true,
+        "a": "9<b>&\"'",
+        "b": ""
+      }
+    },
+    {
+      "name": "gen:b:markup",
+      "props": {
+        "ok": true,
+        "a": "9<b>&\"'",
+        "b": "<b>&\"'</b>"
+      }
+    },
+    {
+      "name": "gen:b:multibyte",
+      "props": {
+        "ok": true,
+        "a": "9<b>&\"'",
+        "b": "日本語"
+      }
+    }
+  ],
   "text-escape": [
     {
       "name": "gen:label:empty",

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-conformance section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. This answers, per fixture and per adapter, whether the construct WORKS — not just whether it compiles. A construct works either as written (✓) or with a documented `/* @client */` comment (✓†, a verified, supported escape — most refusals have one). Fixtures absent from the table below work on every adapter — most as written, some via that documented escape; the headline says how many of each. Listed fixtures need attention somewhere: a bare diagnostic code is still-open debt with no escape yet, a code led by ✗ owes no escape at all (by design), and ≠ means the fixture compiles clean but its rendered output diverges from the reference.",
-    "totalFixtures": 381,
+    "totalFixtures": 382,
     "fixtures": {
       "date-method-uncatalogued": {
         "blade": {

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -2102,15 +2102,15 @@
       }
     },
     "conditional": {
-      "total": 30,
+      "total": 31,
       "cells": {
         "hono": {
-          "pass": 30,
-          "total": 30
+          "pass": 31,
+          "total": 31
         },
         "blade": {
-          "pass": 28,
-          "total": 30,
+          "pass": 29,
+          "total": 31,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
@@ -2123,8 +2123,8 @@
           ]
         },
         "erb": {
-          "pass": 28,
-          "total": 30,
+          "pass": 29,
+          "total": 31,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
@@ -2137,8 +2137,8 @@
           ]
         },
         "go-template": {
-          "pass": 28,
-          "total": 30,
+          "pass": 29,
+          "total": 31,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
@@ -2151,8 +2151,8 @@
           ]
         },
         "jinja": {
-          "pass": 28,
-          "total": 30,
+          "pass": 29,
+          "total": 31,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
@@ -2165,8 +2165,8 @@
           ]
         },
         "minijinja": {
-          "pass": 28,
-          "total": 30,
+          "pass": 29,
+          "total": 31,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
@@ -2179,8 +2179,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 28,
-          "total": 30,
+          "pass": 29,
+          "total": 31,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
@@ -2193,8 +2193,8 @@
           ]
         },
         "twig": {
-          "pass": 28,
-          "total": 30,
+          "pass": 29,
+          "total": 31,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
@@ -2207,8 +2207,8 @@
           ]
         },
         "xslate": {
-          "pass": 28,
-          "total": 30,
+          "pass": 29,
+          "total": 31,
           "gaps": [
             {
               "fixture": "flatmap-typeof-projection",
@@ -2227,18 +2227,18 @@
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L175"
       },
       "example": {
-        "fixture": "query-href-ternary-undefined",
-        "description": "queryHref(base, {…}) as a ternary consequent with an undefined alternate omits the attribute or lowers through the query helper",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/query-href-ternary-undefined.ts",
-        "code": "ok ? queryHref(base, { tag: tag }) : undefined"
+        "fixture": "ternary-template-literal-branch",
+        "description": "A ternary consequent that is a multi-part template literal, in attribute position (#2863)",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/ternary-template-literal-branch.ts",
+        "code": "ok ? `${a}–${b}` : a"
       }
     },
     "identifier": {
-      "total": 359,
+      "total": 360,
       "cells": {
         "hono": {
-          "pass": 355,
-          "total": 359,
+          "pass": 356,
+          "total": 360,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2267,8 +2267,8 @@
           ]
         },
         "blade": {
-          "pass": 339,
-          "total": 359,
+          "pass": 340,
+          "total": 360,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2369,8 +2369,8 @@
           ]
         },
         "erb": {
-          "pass": 340,
-          "total": 359,
+          "pass": 341,
+          "total": 360,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2465,8 +2465,8 @@
           ]
         },
         "go-template": {
-          "pass": 337,
-          "total": 359,
+          "pass": 338,
+          "total": 360,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2579,8 +2579,8 @@
           ]
         },
         "jinja": {
-          "pass": 339,
-          "total": 359,
+          "pass": 340,
+          "total": 360,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2681,8 +2681,8 @@
           ]
         },
         "minijinja": {
-          "pass": 339,
-          "total": 359,
+          "pass": 340,
+          "total": 360,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2783,8 +2783,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 340,
-          "total": 359,
+          "pass": 341,
+          "total": 360,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2879,8 +2879,8 @@
           ]
         },
         "twig": {
-          "pass": 339,
-          "total": 359,
+          "pass": 340,
+          "total": 360,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2981,8 +2981,8 @@
           ]
         },
         "xslate": {
-          "pass": 339,
-          "total": 359,
+          "pass": 340,
+          "total": 360,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4840,15 +4840,15 @@
       }
     },
     "template-literal": {
-      "total": 30,
+      "total": 31,
       "cells": {
         "hono": {
-          "pass": 30,
-          "total": 30
+          "pass": 31,
+          "total": 31
         },
         "blade": {
-          "pass": 29,
-          "total": 30,
+          "pass": 30,
+          "total": 31,
           "gaps": [
             {
               "fixture": "tag-cloud",
@@ -4857,8 +4857,8 @@
           ]
         },
         "erb": {
-          "pass": 29,
-          "total": 30,
+          "pass": 30,
+          "total": 31,
           "gaps": [
             {
               "fixture": "tag-cloud",
@@ -4867,8 +4867,8 @@
           ]
         },
         "go-template": {
-          "pass": 29,
-          "total": 30,
+          "pass": 30,
+          "total": 31,
           "gaps": [
             {
               "fixture": "tag-cloud",
@@ -4877,8 +4877,8 @@
           ]
         },
         "jinja": {
-          "pass": 29,
-          "total": 30,
+          "pass": 30,
+          "total": 31,
           "gaps": [
             {
               "fixture": "tag-cloud",
@@ -4887,8 +4887,8 @@
           ]
         },
         "minijinja": {
-          "pass": 29,
-          "total": 30,
+          "pass": 30,
+          "total": 31,
           "gaps": [
             {
               "fixture": "tag-cloud",
@@ -4897,8 +4897,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 29,
-          "total": 30,
+          "pass": 30,
+          "total": 31,
           "gaps": [
             {
               "fixture": "tag-cloud",
@@ -4907,8 +4907,8 @@
           ]
         },
         "twig": {
-          "pass": 29,
-          "total": 30,
+          "pass": 30,
+          "total": 31,
           "gaps": [
             {
               "fixture": "tag-cloud",
@@ -4917,8 +4917,8 @@
           ]
         },
         "xslate": {
-          "pass": 29,
-          "total": 30,
+          "pass": 30,
+          "total": 31,
           "gaps": [
             {
               "fixture": "tag-cloud",


### PR DESCRIPTION
Fixes #2863.

## Root cause

A ternary (or a `+`/`||`/`??` operand, or a `queryHref`-style helper argument) whose branch was a **multi-part** template literal (mixed literal text and 2+ interpolations, e.g. `` event.endTime ? `${event.time}–${event.endTime}` : event.time ``) lowered through the Go adapter's TEXT-position `templateLiteral()` emitter — mixed literal text plus `{{…}}` action wraps, meant for direct markup embedding. That output was then used as-is inside another action's pipeline argument list:

```
{{(bf_ternary (bf_truthy .EndTime) {{.Time}}–{{.EndTime}} .Time)}}
```

`bf build` succeeds, but the generated `.tmpl` file fails `html/template.Parse` at Go application startup with `unexpected "{" in operand` — nested `{{`/`}}` delimiters aren't legal inside another action's operand list.

The bug is broader than the reported ternary shape: the same leak affects a `+`/`||`/`??` operand and a registered-lowering (`queryHref`) argument that is a template literal, and a pre-existing (already-guarded-against-single-part-only) gap at the per-row child-component prop site (#2445).

## Fix

- New `lowerTemplateLiteralValue` + `lowerValueOperand` (`expr/url-builder.ts`) — the shared door for "this `ParsedExpr` sits in Go pipeline ARGUMENT position." A template literal now folds to a left-folded `bf_concat_str` chain (the same runtime helper already used for JS string-concatenation `+`, #2168) instead of leaking the TEXT-position form. Wired into `lowerTernary`'s branches/test, `lowerUrlGuard`, and `renderLoweringNode`'s helper-call/guard-list arguments.
- `binary()`/`logical()`/`unary()` only special-case the `template-literal` kind (via a narrow `emitOperand` wrapper) and otherwise keep using the existing `emit()` dispatcher unchanged — routing every operand through the generic value path would also pick up `convertExpressionToGo`'s own bare-identifier-const-inlining fast path, a real behavioral divergence the existing `#2236` regression pins caught during verification (see below).
- The per-row child-component prop site (#2445) is unified onto the same door: a multi-part template-literal prop, previously refused outright with `BF101`, now lowers faithfully instead of being refused.

## Tests

- `packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts`: new tests in the `#2335` `bf_ternary value-position lowering` describe block (multi-part branch, single-part reduction, static-text escaping, nested ternary inside a branch, the issue's exact local-helper-in-`.map()` repro) plus a new `#2863` describe block for `+`/`||` operands. Updated the pre-existing `#2445` test to assert the new (correct) `bf_concat_str` lowering instead of the old BF101 refusal.
- New real-backend cross-adapter conformance fixture `packages/adapter-tests/fixtures/ternary-template-literal-branch.ts` (attribute-position ternary+template-literal, with an HTML-special-character prop to pin escaping parity, plus an alternate-branch data point).

## Verification

- `bunx tsgo --noEmit`: clean.
- `bun test packages/adapter-go-template`: 2002 pass, 0 fail.
- `bun test packages/adapter-tests`: green, including the new fixture.
- `bun test packages/compat` (`support-matrix.test.ts` / `coverage-map.test.ts`): green after regenerating `ui/compat.lock.json`, `ui/support-matrix.lock.json`, and `packages/adapter-tests/coverage-map.json`.
- **Real Go execution** (not just string assertions): confirmed with `go1.25.6` (`GOTOOLCHAIN=go1.25.6`) that the fixed template actually parses via `html/template.Parse` and executes correctly against the real runtime `FuncMap()`, including an HTML-escaping-parity check. (Note for reviewers: this sandbox's default `go` resolves to 1.24.7, and `test-render.ts`'s `isGoAvailable()` check forces `GOTOOLCHAIN=local`, so real Go rendering is silently skipped locally unless `GOTOOLCHAIN` is pinned to `go1.25.6\` as above — CI's `setup-go` uses 1.25 so this isn't an issue there.)

## Process note

Design for this fix was delegated to a Fable agent given the root-cause investigation had already been done; I implemented and verified its recommendation directly, including catching and correcting a real regression its recommended `binary`/`logical`/`unary` refactor would have introduced (surfaced by the pre-existing `#2236` loop-param-shadowing regression suite, not by the design review itself).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CY5iUP55yXRFBazeKmJfDu

---
_Generated by [Claude Code](https://claude.ai/code/session_01CY5iUP55yXRFBazeKmJfDu)_