### PR TITLE
Drop stale closed-issue citations from compat pins (#2710)

### DIFF
--- a/.changeset/drop-stale-issue-pins-2710.md
+++ b/.changeset/drop-stale-issue-pins-2710.md
@@ -1,0 +1,13 @@
+---
+"@barefootjs/hono": patch
+"@barefootjs/rust": patch
+"@barefootjs/mojolicious": patch
+"@barefootjs/xslate": patch
+"@barefootjs/twig": patch
+"@barefootjs/erb": patch
+"@barefootjs/blade": patch
+"@barefootjs/go-template": patch
+"@barefootjs/jinja": patch
+---
+
+Drop the `issue:` citation on the `jsx-element-prop-ternary` / `jsx-element-prop-array` (BF021) and `namespace-import-primitive` (BF013) conformance pins. Both refusals were tracked by #2667 and #2771, which are now closed — the loud refusal is confirmed to be the permanent, intended behavior for both (not a tracked capability gap), so the stale closed-issue links no longer serve a purpose. No behavior change; comment/metadata only.

--- a/packages/adapter-blade/src/conformance-pins.ts
+++ b/packages/adapter-blade/src/conformance-pins.ts
@@ -61,18 +61,24 @@ export const conformancePins: ConformancePins = {
   // nested-in-a-predicate form above is refused.
   'date-method-uncatalogued': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2356' }],
   'rich-prop-client-read': [{ code: 'BF049', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2648' }],
-  // #2667: a ternary/array LITERALLY WRAPPING JSX at a non-children prop
+  // A ternary or array literal LITERALLY WRAPPING JSX at a non-children prop
   // position (e.g. `header={cond ? <a/> : <b/>}`) is refused ahead of
   // `adapter.generate()` in the shared jsx-to-ir.ts phase, so it is pinned
   // identically on every adapter (including Hono) — same reasoning as
-  // `rich-prop-client-read` above.
-  'jsx-element-prop-ternary': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2667' }],
-  'jsx-element-prop-array': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2667' }],
-  // #2771: a reactive primitive invoked through a namespace import
+  // `rich-prop-client-read` above. This is the permanent, intended behavior
+  // (formerly tracked as #2667, closed): the issue's own acceptance criteria
+  // treated a loud refusal as fully resolving the silent-divergence bug, so
+  // no open issue tracks further work here.
+  'jsx-element-prop-ternary': [{ code: 'BF021', severity: 'error' }],
+  'jsx-element-prop-array': [{ code: 'BF021', severity: 'error' }],
+  // A reactive primitive invoked through a namespace import
   // (`import * as bf from '@barefootjs/client'`, `bf.createSignal(...)`)
   // that the analyzer's checker-less fast path cannot recognize refuses
   // loudly (BF013) instead of silently dropping the declaration — fired
   // in the shared analyzer pass ahead of any adapter's `adapter.generate()`,
-  // so all nine adapters (including Hono) pin this identically.
-  'namespace-import-primitive': [{ code: 'BF013', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2771' }],
+  // so all nine adapters (including Hono) pin this identically. A compile
+  // that supplies a shared `ts.Program` (e.g. via `@barefootjs/vite`)
+  // resolves the primitive normally and never reaches this refusal (formerly
+  // tracked as #2771, closed) — no open issue tracks further work.
+  'namespace-import-primitive': [{ code: 'BF013', severity: 'error' }],
 }

--- a/packages/adapter-erb/src/conformance-pins.ts
+++ b/packages/adapter-erb/src/conformance-pins.ts
@@ -53,18 +53,24 @@ export const conformancePins: ConformancePins = {
   'filter-nested-find-predicate': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2320' }],
   'date-method-uncatalogued': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2356' }],
   'rich-prop-client-read': [{ code: 'BF049', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2648' }],
-  // #2667: a ternary/array LITERALLY WRAPPING JSX at a non-children prop
+  // A ternary or array literal LITERALLY WRAPPING JSX at a non-children prop
   // position (e.g. `header={cond ? <a/> : <b/>}`) is refused ahead of
   // `adapter.generate()` in the shared jsx-to-ir.ts phase, so it is pinned
   // identically on every adapter (including Hono) — same reasoning as
-  // `rich-prop-client-read` above.
-  'jsx-element-prop-ternary': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2667' }],
-  'jsx-element-prop-array': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2667' }],
-  // #2771: a reactive primitive invoked through a namespace import
+  // `rich-prop-client-read` above. This is the permanent, intended behavior
+  // (formerly tracked as #2667, closed): the issue's own acceptance criteria
+  // treated a loud refusal as fully resolving the silent-divergence bug, so
+  // no open issue tracks further work here.
+  'jsx-element-prop-ternary': [{ code: 'BF021', severity: 'error' }],
+  'jsx-element-prop-array': [{ code: 'BF021', severity: 'error' }],
+  // A reactive primitive invoked through a namespace import
   // (`import * as bf from '@barefootjs/client'`, `bf.createSignal(...)`)
   // that the analyzer's checker-less fast path cannot recognize refuses
   // loudly (BF013) instead of silently dropping the declaration — fired
   // in the shared analyzer pass ahead of any adapter's `adapter.generate()`,
-  // so all nine adapters (including Hono) pin this identically.
-  'namespace-import-primitive': [{ code: 'BF013', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2771' }],
+  // so all nine adapters (including Hono) pin this identically. A compile
+  // that supplies a shared `ts.Program` (e.g. via `@barefootjs/vite`)
+  // resolves the primitive normally and never reaches this refusal (formerly
+  // tracked as #2771, closed) — no open issue tracks further work.
+  'namespace-import-primitive': [{ code: 'BF013', severity: 'error' }],
 }

--- a/packages/adapter-go-template/src/conformance-pins.ts
+++ b/packages/adapter-go-template/src/conformance-pins.ts
@@ -52,13 +52,16 @@ export const conformancePins: ConformancePins = {
   'filter-nested-find-predicate': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2320' }],
   'date-method-uncatalogued': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2356' }],
   'rich-prop-client-read': [{ code: 'BF049', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2648' }],
-  // #2667: a ternary/array LITERALLY WRAPPING JSX at a non-children prop
+  // A ternary or array literal LITERALLY WRAPPING JSX at a non-children prop
   // position (e.g. `header={cond ? <a/> : <b/>}`) is refused ahead of
   // `adapter.generate()` in the shared jsx-to-ir.ts phase, so it is pinned
   // identically on every adapter (including Hono) — same reasoning as
-  // `rich-prop-client-read` above.
-  'jsx-element-prop-ternary': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2667' }],
-  'jsx-element-prop-array': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2667' }],
+  // `rich-prop-client-read` above. This is the permanent, intended behavior
+  // (formerly tracked as #2667, closed): the issue's own acceptance criteria
+  // treated a loud refusal as fully resolving the silent-divergence bug, so
+  // no open issue tracks further work here.
+  'jsx-element-prop-ternary': [{ code: 'BF021', severity: 'error' }],
+  'jsx-element-prop-array': [{ code: 'BF021', severity: 'error' }],
   // `jsx-element-prop-fragment-conditional` (#2703) is NOT pinned here — it
   // renders correctly since `queueDynamicPropDefine` (go-template-adapter.ts)
   // extended the reserved `children` slot's `bf_with_children`/`bf_tmpl`
@@ -88,11 +91,14 @@ export const conformancePins: ConformancePins = {
     severity: 'error',
     issue: 'https://github.com/piconic-ai/barefootjs/issues/2700',
   }],
-  // #2771: a reactive primitive invoked through a namespace import
+  // A reactive primitive invoked through a namespace import
   // (`import * as bf from '@barefootjs/client'`, `bf.createSignal(...)`)
   // that the analyzer's checker-less fast path cannot recognize refuses
   // loudly (BF013) instead of silently dropping the declaration — fired
   // in the shared analyzer pass ahead of any adapter's `adapter.generate()`,
-  // so all nine adapters (including Hono) pin this identically.
-  'namespace-import-primitive': [{ code: 'BF013', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2771' }],
+  // so all nine adapters (including Hono) pin this identically. A compile
+  // that supplies a shared `ts.Program` (e.g. via `@barefootjs/vite`)
+  // resolves the primitive normally and never reaches this refusal (formerly
+  // tracked as #2771, closed) — no open issue tracks further work.
+  'namespace-import-primitive': [{ code: 'BF013', severity: 'error' }],
 }

--- a/packages/adapter-hono/src/conformance-pins.ts
+++ b/packages/adapter-hono/src/conformance-pins.ts
@@ -14,18 +14,24 @@ import type { ConformancePins } from '@barefootjs/jsx'
 export const conformancePins: ConformancePins = {
   'date-method-uncatalogued': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2356' }],
   'rich-prop-client-read': [{ code: 'BF049', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2648' }],
-  // #2667: a ternary/array LITERALLY WRAPPING JSX at a non-children prop
+  // A ternary or array literal LITERALLY WRAPPING JSX at a non-children prop
   // position (e.g. `header={cond ? <a/> : <b/>}`) is refused ahead of
   // `adapter.generate()` in the shared jsx-to-ir.ts phase, so it is pinned
   // identically on every adapter (including Hono) — same reasoning as
-  // `rich-prop-client-read` above.
-  'jsx-element-prop-ternary': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2667' }],
-  'jsx-element-prop-array': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2667' }],
-  // #2771: a reactive primitive invoked through a namespace import
+  // `rich-prop-client-read` above. This is the permanent, intended behavior
+  // (formerly tracked as #2667, closed): the issue's own acceptance criteria
+  // treated a loud refusal as fully resolving the silent-divergence bug, so
+  // no open issue tracks further work here.
+  'jsx-element-prop-ternary': [{ code: 'BF021', severity: 'error' }],
+  'jsx-element-prop-array': [{ code: 'BF021', severity: 'error' }],
+  // A reactive primitive invoked through a namespace import
   // (`import * as bf from '@barefootjs/client'`, `bf.createSignal(...)`)
   // that the analyzer's checker-less fast path cannot recognize refuses
   // loudly (BF013) instead of silently dropping the declaration — fired
   // in the shared analyzer pass ahead of any adapter's `adapter.generate()`,
-  // so all nine adapters (including Hono) pin this identically.
-  'namespace-import-primitive': [{ code: 'BF013', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2771' }],
+  // so all nine adapters (including Hono) pin this identically. A compile
+  // that supplies a shared `ts.Program` (e.g. via `@barefootjs/vite`)
+  // resolves the primitive normally and never reaches this refusal (formerly
+  // tracked as #2771, closed) — no open issue tracks further work.
+  'namespace-import-primitive': [{ code: 'BF013', severity: 'error' }],
 }

--- a/packages/adapter-jinja/src/conformance-pins.ts
+++ b/packages/adapter-jinja/src/conformance-pins.ts
@@ -60,18 +60,24 @@ export const conformancePins: ConformancePins = {
   // above is refused.
   'date-method-uncatalogued': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2356' }],
   'rich-prop-client-read': [{ code: 'BF049', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2648' }],
-  // #2667: a ternary/array LITERALLY WRAPPING JSX at a non-children prop
+  // A ternary or array literal LITERALLY WRAPPING JSX at a non-children prop
   // position (e.g. `header={cond ? <a/> : <b/>}`) is refused ahead of
   // `adapter.generate()` in the shared jsx-to-ir.ts phase, so it is pinned
   // identically on every adapter (including Hono) — same reasoning as
-  // `rich-prop-client-read` above.
-  'jsx-element-prop-ternary': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2667' }],
-  'jsx-element-prop-array': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2667' }],
-  // #2771: a reactive primitive invoked through a namespace import
+  // `rich-prop-client-read` above. This is the permanent, intended behavior
+  // (formerly tracked as #2667, closed): the issue's own acceptance criteria
+  // treated a loud refusal as fully resolving the silent-divergence bug, so
+  // no open issue tracks further work here.
+  'jsx-element-prop-ternary': [{ code: 'BF021', severity: 'error' }],
+  'jsx-element-prop-array': [{ code: 'BF021', severity: 'error' }],
+  // A reactive primitive invoked through a namespace import
   // (`import * as bf from '@barefootjs/client'`, `bf.createSignal(...)`)
   // that the analyzer's checker-less fast path cannot recognize refuses
   // loudly (BF013) instead of silently dropping the declaration — fired
   // in the shared analyzer pass ahead of any adapter's `adapter.generate()`,
-  // so all nine adapters (including Hono) pin this identically.
-  'namespace-import-primitive': [{ code: 'BF013', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2771' }],
+  // so all nine adapters (including Hono) pin this identically. A compile
+  // that supplies a shared `ts.Program` (e.g. via `@barefootjs/vite`)
+  // resolves the primitive normally and never reaches this refusal (formerly
+  // tracked as #2771, closed) — no open issue tracks further work.
+  'namespace-import-primitive': [{ code: 'BF013', severity: 'error' }],
 }

--- a/packages/adapter-mojolicious/src/conformance-pins.ts
+++ b/packages/adapter-mojolicious/src/conformance-pins.ts
@@ -53,18 +53,24 @@ export const conformancePins: ConformancePins = {
   'filter-nested-find-predicate': [{ code: 'BF101', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2320' }],
   'date-method-uncatalogued': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2356' }],
   'rich-prop-client-read': [{ code: 'BF049', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2648' }],
-  // #2667: a ternary/array LITERALLY WRAPPING JSX at a non-children prop
+  // A ternary or array literal LITERALLY WRAPPING JSX at a non-children prop
   // position (e.g. `header={cond ? <a/> : <b/>}`) is refused ahead of
   // `adapter.generate()` in the shared jsx-to-ir.ts phase, so it is pinned
   // identically on every adapter (including Hono) — same reasoning as
-  // `rich-prop-client-read` above.
-  'jsx-element-prop-ternary': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2667' }],
-  'jsx-element-prop-array': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2667' }],
-  // #2771: a reactive primitive invoked through a namespace import
+  // `rich-prop-client-read` above. This is the permanent, intended behavior
+  // (formerly tracked as #2667, closed): the issue's own acceptance criteria
+  // treated a loud refusal as fully resolving the silent-divergence bug, so
+  // no open issue tracks further work here.
+  'jsx-element-prop-ternary': [{ code: 'BF021', severity: 'error' }],
+  'jsx-element-prop-array': [{ code: 'BF021', severity: 'error' }],
+  // A reactive primitive invoked through a namespace import
   // (`import * as bf from '@barefootjs/client'`, `bf.createSignal(...)`)
   // that the analyzer's checker-less fast path cannot recognize refuses
   // loudly (BF013) instead of silently dropping the declaration — fired
   // in the shared analyzer pass ahead of any adapter's `adapter.generate()`,
-  // so all nine adapters (including Hono) pin this identically.
-  'namespace-import-primitive': [{ code: 'BF013', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2771' }],
+  // so all nine adapters (including Hono) pin this identically. A compile
+  // that supplies a shared `ts.Program` (e.g. via `@barefootjs/vite`)
+  // resolves the primitive normally and never reaches this refusal (formerly
+  // tracked as #2771, closed) — no open issue tracks further work.
+  'namespace-import-primitive': [{ code: 'BF013', severity: 'error' }],
 }

--- a/packages/adapter-rust/src/conformance-pins.ts
+++ b/packages/adapter-rust/src/conformance-pins.ts
@@ -61,18 +61,24 @@ export const conformancePins: ConformancePins = {
   // above is refused.
   'date-method-uncatalogued': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2356' }],
   'rich-prop-client-read': [{ code: 'BF049', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2648' }],
-  // #2667: a ternary/array LITERALLY WRAPPING JSX at a non-children prop
+  // A ternary or array literal LITERALLY WRAPPING JSX at a non-children prop
   // position (e.g. `header={cond ? <a/> : <b/>}`) is refused ahead of
   // `adapter.generate()` in the shared jsx-to-ir.ts phase, so it is pinned
   // identically on every adapter (including Hono) — same reasoning as
-  // `rich-prop-client-read` above.
-  'jsx-element-prop-ternary': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2667' }],
-  'jsx-element-prop-array': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2667' }],
-  // #2771: a reactive primitive invoked through a namespace import
+  // `rich-prop-client-read` above. This is the permanent, intended behavior
+  // (formerly tracked as #2667, closed): the issue's own acceptance criteria
+  // treated a loud refusal as fully resolving the silent-divergence bug, so
+  // no open issue tracks further work here.
+  'jsx-element-prop-ternary': [{ code: 'BF021', severity: 'error' }],
+  'jsx-element-prop-array': [{ code: 'BF021', severity: 'error' }],
+  // A reactive primitive invoked through a namespace import
   // (`import * as bf from '@barefootjs/client'`, `bf.createSignal(...)`)
   // that the analyzer's checker-less fast path cannot recognize refuses
   // loudly (BF013) instead of silently dropping the declaration — fired
   // in the shared analyzer pass ahead of any adapter's `adapter.generate()`,
-  // so all nine adapters (including Hono) pin this identically.
-  'namespace-import-primitive': [{ code: 'BF013', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2771' }],
+  // so all nine adapters (including Hono) pin this identically. A compile
+  // that supplies a shared `ts.Program` (e.g. via `@barefootjs/vite`)
+  // resolves the primitive normally and never reaches this refusal (formerly
+  // tracked as #2771, closed) — no open issue tracks further work.
+  'namespace-import-primitive': [{ code: 'BF013', severity: 'error' }],
 }

--- a/packages/adapter-twig/src/conformance-pins.ts
+++ b/packages/adapter-twig/src/conformance-pins.ts
@@ -60,18 +60,24 @@ export const conformancePins: ConformancePins = {
   // above is refused.
   'date-method-uncatalogued': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2356' }],
   'rich-prop-client-read': [{ code: 'BF049', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2648' }],
-  // #2667: a ternary/array LITERALLY WRAPPING JSX at a non-children prop
+  // A ternary or array literal LITERALLY WRAPPING JSX at a non-children prop
   // position (e.g. `header={cond ? <a/> : <b/>}`) is refused ahead of
   // `adapter.generate()` in the shared jsx-to-ir.ts phase, so it is pinned
   // identically on every adapter (including Hono) — same reasoning as
-  // `rich-prop-client-read` above.
-  'jsx-element-prop-ternary': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2667' }],
-  'jsx-element-prop-array': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2667' }],
-  // #2771: a reactive primitive invoked through a namespace import
+  // `rich-prop-client-read` above. This is the permanent, intended behavior
+  // (formerly tracked as #2667, closed): the issue's own acceptance criteria
+  // treated a loud refusal as fully resolving the silent-divergence bug, so
+  // no open issue tracks further work here.
+  'jsx-element-prop-ternary': [{ code: 'BF021', severity: 'error' }],
+  'jsx-element-prop-array': [{ code: 'BF021', severity: 'error' }],
+  // A reactive primitive invoked through a namespace import
   // (`import * as bf from '@barefootjs/client'`, `bf.createSignal(...)`)
   // that the analyzer's checker-less fast path cannot recognize refuses
   // loudly (BF013) instead of silently dropping the declaration — fired
   // in the shared analyzer pass ahead of any adapter's `adapter.generate()`,
-  // so all nine adapters (including Hono) pin this identically.
-  'namespace-import-primitive': [{ code: 'BF013', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2771' }],
+  // so all nine adapters (including Hono) pin this identically. A compile
+  // that supplies a shared `ts.Program` (e.g. via `@barefootjs/vite`)
+  // resolves the primitive normally and never reaches this refusal (formerly
+  // tracked as #2771, closed) — no open issue tracks further work.
+  'namespace-import-primitive': [{ code: 'BF013', severity: 'error' }],
 }

--- a/packages/adapter-xslate/src/conformance-pins.ts
+++ b/packages/adapter-xslate/src/conformance-pins.ts
@@ -60,18 +60,24 @@ export const conformancePins: ConformancePins = {
   // above is refused.
   'date-method-uncatalogued': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2356' }],
   'rich-prop-client-read': [{ code: 'BF049', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2648' }],
-  // #2667: a ternary/array LITERALLY WRAPPING JSX at a non-children prop
+  // A ternary or array literal LITERALLY WRAPPING JSX at a non-children prop
   // position (e.g. `header={cond ? <a/> : <b/>}`) is refused ahead of
   // `adapter.generate()` in the shared jsx-to-ir.ts phase, so it is pinned
   // identically on every adapter (including Hono) — same reasoning as
-  // `rich-prop-client-read` above.
-  'jsx-element-prop-ternary': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2667' }],
-  'jsx-element-prop-array': [{ code: 'BF021', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2667' }],
-  // #2771: a reactive primitive invoked through a namespace import
+  // `rich-prop-client-read` above. This is the permanent, intended behavior
+  // (formerly tracked as #2667, closed): the issue's own acceptance criteria
+  // treated a loud refusal as fully resolving the silent-divergence bug, so
+  // no open issue tracks further work here.
+  'jsx-element-prop-ternary': [{ code: 'BF021', severity: 'error' }],
+  'jsx-element-prop-array': [{ code: 'BF021', severity: 'error' }],
+  // A reactive primitive invoked through a namespace import
   // (`import * as bf from '@barefootjs/client'`, `bf.createSignal(...)`)
   // that the analyzer's checker-less fast path cannot recognize refuses
   // loudly (BF013) instead of silently dropping the declaration — fired
   // in the shared analyzer pass ahead of any adapter's `adapter.generate()`,
-  // so all nine adapters (including Hono) pin this identically.
-  'namespace-import-primitive': [{ code: 'BF013', severity: 'error', issue: 'https://github.com/piconic-ai/barefootjs/issues/2771' }],
+  // so all nine adapters (including Hono) pin this identically. A compile
+  // that supplies a shared `ts.Program` (e.g. via `@barefootjs/vite`)
+  // resolves the primitive normally and never reaches this refusal (formerly
+  // tracked as #2771, closed) — no open issue tracks further work.
+  'namespace-import-primitive': [{ code: 'BF013', severity: 'error' }],
 }

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -2500,81 +2500,54 @@
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2667"
           ]
         },
         "erb": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2667"
           ]
         },
         "go-template": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2667"
           ]
         },
         "hono": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2667"
           ]
         },
         "jinja": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2667"
           ]
         },
         "minijinja": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2667"
           ]
         },
         "mojolicious": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2667"
           ]
         },
         "twig": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2667"
           ]
         },
         "xslate": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2667"
           ]
         }
       },
@@ -2597,81 +2570,54 @@
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2667"
           ]
         },
         "erb": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2667"
           ]
         },
         "go-template": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2667"
           ]
         },
         "hono": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2667"
           ]
         },
         "jinja": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2667"
           ]
         },
         "minijinja": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2667"
           ]
         },
         "mojolicious": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2667"
           ]
         },
         "twig": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2667"
           ]
         },
         "xslate": {
           "kind": "refusal",
           "codes": [
             "BF021"
-          ],
-          "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2667"
           ]
         }
       },
@@ -2844,81 +2790,54 @@
           "kind": "refusal",
           "codes": [
             "BF013"
-          ],
-          "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2771"
           ]
         },
         "erb": {
           "kind": "refusal",
           "codes": [
             "BF013"
-          ],
-          "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2771"
           ]
         },
         "go-template": {
           "kind": "refusal",
           "codes": [
             "BF013"
-          ],
-          "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2771"
           ]
         },
         "hono": {
           "kind": "refusal",
           "codes": [
             "BF013"
-          ],
-          "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2771"
           ]
         },
         "jinja": {
           "kind": "refusal",
           "codes": [
             "BF013"
-          ],
-          "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2771"
           ]
         },
         "minijinja": {
           "kind": "refusal",
           "codes": [
             "BF013"
-          ],
-          "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2771"
           ]
         },
         "mojolicious": {
           "kind": "refusal",
           "codes": [
             "BF013"
-          ],
-          "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2771"
           ]
         },
         "twig": {
           "kind": "refusal",
           "codes": [
             "BF013"
-          ],
-          "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2771"
           ]
         },
         "xslate": {
           "kind": "refusal",
           "codes": [
             "BF013"
-          ],
-          "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2771"
           ]
         }
       },

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -1432,9 +1432,7 @@
             },
             {
               "fixture": "namespace-import-primitive",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2771"
-              ]
+              "issues": []
             }
           ]
         },
@@ -1482,9 +1480,7 @@
             },
             {
               "fixture": "namespace-import-primitive",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2771"
-              ]
+              "issues": []
             },
             {
               "fixture": "preamble-cells",
@@ -1558,9 +1554,7 @@
             },
             {
               "fixture": "namespace-import-primitive",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2771"
-              ]
+              "issues": []
             },
             {
               "fixture": "preamble-cells",
@@ -1640,9 +1634,7 @@
             },
             {
               "fixture": "namespace-import-primitive",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2771"
-              ]
+              "issues": []
             },
             {
               "fixture": "preamble-cells",
@@ -1728,9 +1720,7 @@
             },
             {
               "fixture": "namespace-import-primitive",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2771"
-              ]
+              "issues": []
             },
             {
               "fixture": "preamble-cells",
@@ -1810,9 +1800,7 @@
             },
             {
               "fixture": "namespace-import-primitive",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2771"
-              ]
+              "issues": []
             },
             {
               "fixture": "preamble-cells",
@@ -1886,9 +1874,7 @@
             },
             {
               "fixture": "namespace-import-primitive",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2771"
-              ]
+              "issues": []
             },
             {
               "fixture": "preamble-cells",
@@ -1968,9 +1954,7 @@
             },
             {
               "fixture": "namespace-import-primitive",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2771"
-              ]
+              "issues": []
             },
             {
               "fixture": "preamble-cells",
@@ -2050,9 +2034,7 @@
             },
             {
               "fixture": "namespace-import-primitive",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2771"
-              ]
+              "issues": []
             },
             {
               "fixture": "preamble-cells",
@@ -2248,21 +2230,15 @@
             },
             {
               "fixture": "jsx-element-prop-array",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             },
             {
               "fixture": "jsx-element-prop-ternary",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             },
             {
               "fixture": "namespace-import-primitive",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2771"
-              ]
+              "issues": []
             }
           ]
         },
@@ -2310,15 +2286,11 @@
             },
             {
               "fixture": "jsx-element-prop-array",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             },
             {
               "fixture": "jsx-element-prop-ternary",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             },
             {
               "fixture": "map-array-builder-body",
@@ -2330,9 +2302,7 @@
             },
             {
               "fixture": "namespace-import-primitive",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2771"
-              ]
+              "issues": []
             },
             {
               "fixture": "preamble-cells",
@@ -2406,15 +2376,11 @@
             },
             {
               "fixture": "jsx-element-prop-array",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             },
             {
               "fixture": "jsx-element-prop-ternary",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             },
             {
               "fixture": "map-array-builder-body",
@@ -2426,9 +2392,7 @@
             },
             {
               "fixture": "namespace-import-primitive",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2771"
-              ]
+              "issues": []
             },
             {
               "fixture": "preamble-cells",
@@ -2508,9 +2472,7 @@
             },
             {
               "fixture": "jsx-element-prop-array",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             },
             {
               "fixture": "jsx-element-prop-rest-bag-dynamic",
@@ -2520,9 +2482,7 @@
             },
             {
               "fixture": "jsx-element-prop-ternary",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             },
             {
               "fixture": "map-array-builder-body",
@@ -2534,9 +2494,7 @@
             },
             {
               "fixture": "namespace-import-primitive",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2771"
-              ]
+              "issues": []
             },
             {
               "fixture": "preamble-cells",
@@ -2622,15 +2580,11 @@
             },
             {
               "fixture": "jsx-element-prop-array",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             },
             {
               "fixture": "jsx-element-prop-ternary",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             },
             {
               "fixture": "map-array-builder-body",
@@ -2642,9 +2596,7 @@
             },
             {
               "fixture": "namespace-import-primitive",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2771"
-              ]
+              "issues": []
             },
             {
               "fixture": "preamble-cells",
@@ -2724,15 +2676,11 @@
             },
             {
               "fixture": "jsx-element-prop-array",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             },
             {
               "fixture": "jsx-element-prop-ternary",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             },
             {
               "fixture": "map-array-builder-body",
@@ -2744,9 +2692,7 @@
             },
             {
               "fixture": "namespace-import-primitive",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2771"
-              ]
+              "issues": []
             },
             {
               "fixture": "preamble-cells",
@@ -2820,15 +2766,11 @@
             },
             {
               "fixture": "jsx-element-prop-array",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             },
             {
               "fixture": "jsx-element-prop-ternary",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             },
             {
               "fixture": "map-array-builder-body",
@@ -2840,9 +2782,7 @@
             },
             {
               "fixture": "namespace-import-primitive",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2771"
-              ]
+              "issues": []
             },
             {
               "fixture": "preamble-cells",
@@ -2922,15 +2862,11 @@
             },
             {
               "fixture": "jsx-element-prop-array",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             },
             {
               "fixture": "jsx-element-prop-ternary",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             },
             {
               "fixture": "map-array-builder-body",
@@ -2942,9 +2878,7 @@
             },
             {
               "fixture": "namespace-import-primitive",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2771"
-              ]
+              "issues": []
             },
             {
               "fixture": "preamble-cells",
@@ -3024,15 +2958,11 @@
             },
             {
               "fixture": "jsx-element-prop-array",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             },
             {
               "fixture": "jsx-element-prop-ternary",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             },
             {
               "fixture": "map-array-builder-body",
@@ -3044,9 +2974,7 @@
             },
             {
               "fixture": "namespace-import-primitive",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2771"
-              ]
+              "issues": []
             },
             {
               "fixture": "preamble-cells",
@@ -3156,9 +3084,7 @@
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             }
           ]
         },
@@ -3188,9 +3114,7 @@
             },
             {
               "fixture": "jsx-element-prop-ternary",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             },
             {
               "fixture": "preamble-cells",
@@ -3246,9 +3170,7 @@
             },
             {
               "fixture": "jsx-element-prop-ternary",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             },
             {
               "fixture": "preamble-cells",
@@ -3310,9 +3232,7 @@
             },
             {
               "fixture": "jsx-element-prop-ternary",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             },
             {
               "fixture": "preamble-cells",
@@ -3374,9 +3294,7 @@
             },
             {
               "fixture": "jsx-element-prop-ternary",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             },
             {
               "fixture": "preamble-cells",
@@ -3432,9 +3350,7 @@
             },
             {
               "fixture": "jsx-element-prop-ternary",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             },
             {
               "fixture": "preamble-cells",
@@ -3490,9 +3406,7 @@
             },
             {
               "fixture": "jsx-element-prop-ternary",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             },
             {
               "fixture": "preamble-cells",
@@ -3548,9 +3462,7 @@
             },
             {
               "fixture": "jsx-element-prop-ternary",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             },
             {
               "fixture": "preamble-cells",
@@ -3606,9 +3518,7 @@
             },
             {
               "fixture": "jsx-element-prop-ternary",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             },
             {
               "fixture": "preamble-cells",
@@ -3814,15 +3724,11 @@
             },
             {
               "fixture": "jsx-element-prop-array",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             },
             {
               "fixture": "jsx-element-prop-ternary",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             }
           ]
         },
@@ -3870,15 +3776,11 @@
             },
             {
               "fixture": "jsx-element-prop-array",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             },
             {
               "fixture": "jsx-element-prop-ternary",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             },
             {
               "fixture": "map-array-builder-body",
@@ -3960,15 +3862,11 @@
             },
             {
               "fixture": "jsx-element-prop-array",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             },
             {
               "fixture": "jsx-element-prop-ternary",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             },
             {
               "fixture": "map-array-builder-body",
@@ -4056,9 +3954,7 @@
             },
             {
               "fixture": "jsx-element-prop-array",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             },
             {
               "fixture": "jsx-element-prop-rest-bag-dynamic",
@@ -4068,9 +3964,7 @@
             },
             {
               "fixture": "jsx-element-prop-ternary",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             },
             {
               "fixture": "map-array-builder-body",
@@ -4164,15 +4058,11 @@
             },
             {
               "fixture": "jsx-element-prop-array",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             },
             {
               "fixture": "jsx-element-prop-ternary",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             },
             {
               "fixture": "map-array-builder-body",
@@ -4260,15 +4150,11 @@
             },
             {
               "fixture": "jsx-element-prop-array",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             },
             {
               "fixture": "jsx-element-prop-ternary",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             },
             {
               "fixture": "map-array-builder-body",
@@ -4350,15 +4236,11 @@
             },
             {
               "fixture": "jsx-element-prop-array",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             },
             {
               "fixture": "jsx-element-prop-ternary",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             },
             {
               "fixture": "map-array-builder-body",
@@ -4446,15 +4328,11 @@
             },
             {
               "fixture": "jsx-element-prop-array",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             },
             {
               "fixture": "jsx-element-prop-ternary",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             },
             {
               "fixture": "map-array-builder-body",
@@ -4542,15 +4420,11 @@
             },
             {
               "fixture": "jsx-element-prop-array",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             },
             {
               "fixture": "jsx-element-prop-ternary",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             },
             {
               "fixture": "map-array-builder-body",
@@ -7804,9 +7678,7 @@
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             }
           ]
         },
@@ -7816,9 +7688,7 @@
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             },
             {
               "fixture": "preamble-cells",
@@ -7832,9 +7702,7 @@
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             },
             {
               "fixture": "preamble-cells",
@@ -7854,9 +7722,7 @@
             },
             {
               "fixture": "jsx-element-prop-ternary",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             },
             {
               "fixture": "preamble-cells",
@@ -7876,9 +7742,7 @@
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             },
             {
               "fixture": "preamble-cells",
@@ -7892,9 +7756,7 @@
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             },
             {
               "fixture": "preamble-cells",
@@ -7908,9 +7770,7 @@
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             },
             {
               "fixture": "preamble-cells",
@@ -7924,9 +7784,7 @@
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             },
             {
               "fixture": "preamble-cells",
@@ -7940,9 +7798,7 @@
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2667"
-              ]
+              "issues": []
             },
             {
               "fixture": "preamble-cells",


### PR DESCRIPTION
## Summary

[#2710](https://github.com/piconic-ai/barefootjs/issues/2710) (`compat-issue-freshness`) flagged three closed-issue links referenced by `ui/compat.lock.json` / `ui/support-matrix.lock.json`. Each was investigated by actually running the current behavior on `main`, not just reading history:

- **#2667** (ternary/array-wrapped JSX prop → BF021) and **#2771** (namespace-import primitive → BF013): genuinely resolved. `ir-jsx-props.test.ts` and `namespace-import-primitive.test.ts` confirm the loud refusal is the permanent, intended behavior — not a tracked capability gap. #2771 in particular never fires under real usage at all: a shared `ts.Program` (which `@barefootjs/vite` always supplies) resolves the primitive normally; the refusal only exists for the checker-less conformance-test path. Dropped the `issue:` citation from both entries across all 9 adapters' `conformance-pins.ts` and regenerated the locks (`bun run compat:lock && bun run support-matrix:lock`).
- **#2700** (go-template derived-signal object-literal → BF101): **not** dropped, and the issue was **reopened**. Its own `render-divergences.ts` docstring says the capability gap "stays tracked" at this issue, but PR #2818's `Closes #2700` auto-closed it on merge anyway — likely unintended, since the issue was correctly relabeled `bug` → `enhancement` at the same time. Re-ran the go-template adapter suite against current `main` and confirmed the `BF101` refusal still fires for `signal-object-spread-init` — the faithful lowering this issue tracks is genuinely still unimplemented.

## Test plan

- [x] `bun test packages/jsx/src/__tests__/ir-jsx-props.test.ts` — 22/22 pass
- [x] `bun test packages/jsx/src/__tests__/namespace-import-primitive.test.ts` — 12/12 pass
- [x] `GOTOOLCHAIN=go1.25.6 bun test packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts -t "signal-object-spread-init"` — confirms BF101 refusal still fires
- [x] `bun test packages/compat` — 524/524 pass
- [x] `bun run compat:lock && bun run support-matrix:lock` regenerated after `bun run build`; diff contains only the two closed-issue citations disappearing (no other content changed)

Closes the citations for #2667 and #2771. Does not close #2700 (reopened instead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0156hgTGwCv5jdtch7r3ByLN

---
_Generated by [Claude Code](https://claude.ai/code/session_0156hgTGwCv5jdtch7r3ByLN)_