### PR TITLE
Fix #2857: renderFilterExprNode bypasses rootFieldRef's alias resolution

### DIFF
--- a/.changeset/go-filter-predicate-alias-2857.md
+++ b/.changeset/go-filter-predicate-alias-2857.md
@@ -1,0 +1,9 @@
+---
+"@barefootjs/go-template": patch
+---
+
+Fix #2857: a `.filter()` predicate that referenced a root-scope value through an alias — a signal-getter alias (`const items__alias = items`, #2813's family) or a bare-props-form body-destructured renamed prop (`const { children: kids } = props`, #2788's family) — emitted a Go struct field derived from the raw local/alias name (e.g. `.Kids`) instead of the field the aliased entity actually seeds (`.Children`). That field was never populated by `New<Component>Props`, so `html/template` panicked at render time with `can't evaluate field ... in type ...`.
+
+`renderFilterExprNode`'s `identifier` and `call` arms called `rootFieldRef` only for its BF101 registration side effect, then re-derived the emitted field name from the raw identifier instead of using `rootFieldRef`'s alias-resolved name. Both arms (and `rootFieldRef` itself) now share one alias-resolution helper (`resolveRootFieldAlias`).
+
+Fixing this also surfaced a second, adjacent bug in the same `identifier` arm: a bare (non-alias, non-signal) root-scope reference inside a filter predicate — a memo, a plain derived const, or a renamed prop destructure — emitted a bare `.Field` instead of the `$.Field` every `.filter().map()` loop's `{{range}}{{if}}` gate requires to escape the current loop item and reach the root struct. That's now fixed too, since it blocked this same fix's own regression fixture from passing on real `go run`.

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -4866,17 +4866,26 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    * rebinds. Outside any loop the root *is* the dot, so we emit `.Field`.
    */
   private rootFieldRef(name: string): string {
-    // #2813 / #2788: `name` may be a bare local-const alias of a
-    // signal/memo getter (`const items__alias = items`) or a bare-props-
-    // form body destructure's renamed prop (`const { children: kids } =
-    // props`) — resolve it to the ALIASED entity's own name FIRST, so the
-    // emitted field matches what that entity itself seeds (`.Items`,
-    // `.Children`) instead of registering a second, never-populated field
-    // under the local alias (`.Items__alias`, `.Kids`).
-    const resolved = this.state.getterAliases.get(name) ?? this.state.propDestructureAliases.get(name) ?? name
+    const resolved = this.resolveRootFieldAlias(name)
     this.state.templateReadRootFields.add(resolved)
     const prefix = this.inLoop ? '$.' : '.'
     return `${prefix}${capitalizeFieldName(resolved)}`
+  }
+
+  /**
+   * #2813 / #2788: `name` may be a bare local-const alias of a signal/memo
+   * getter (`const items__alias = items`) or a bare-props-form body
+   * destructure's renamed prop (`const { children: kids } = props`) —
+   * resolve it to the ALIASED entity's own name, so a caller that needs to
+   * build its own prefixed field reference (e.g. `renderFilterExprNode`,
+   * which must hardcode `$.` regardless of `rootFieldRef`'s
+   * `this.inLoop`-conditional prefix — #2857) still lands on the field that
+   * entity itself seeds (`.Items`, `.Children`) instead of a never-populated
+   * field under the local alias (`.Items__alias`, `.Kids`). `rootFieldRef`
+   * itself is built on top of this so there is exactly one resolution.
+   */
+  private resolveRootFieldAlias(name: string): string {
+    return this.state.getterAliases.get(name) ?? this.state.propDestructureAliases.get(name) ?? name
   }
 
   /**
@@ -6212,12 +6221,30 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
           // prefix because a filter predicate must always escape back to
           // root regardless of loop nesting; call it only for its
           // registration side effect and keep the prefix here (pullfrog
-          // review, PR #2818).
+          // review, PR #2818). The field name itself DOES go through
+          // `resolveRootFieldAlias` (#2857) so a getter-alias local
+          // (`const items__alias = items`) still emits the field the
+          // signal itself seeds instead of a phantom `.Items__alias`.
           this.rootFieldRef(signal)
-          return `$.${capitalizeFieldName(signal)}`
+          return `$.${capitalizeFieldName(this.resolveRootFieldAlias(signal))}`
         }
+        // Any other identifier reaching here is ALSO a root-scope
+        // reference (a memo, a plain derived const, or — #2857 — a
+        // bare-props-form destructured/renamed prop) rather than the
+        // loop's own param, so it needs the same unconditional `$.`
+        // escape as the signal branch above, for the same reason: a
+        // `.filter().map()` JSX loop's `{{if}}` gate (built from
+        // `loop.filterPredicate` a few hundred lines below, via
+        // `renderPredicateCondition` → this method) always sits inside
+        // that loop's own `{{range}}`, never at the template's un-rebound
+        // root, so `rootFieldRef`'s own `this.inLoop`-conditional prefix
+        // would be wrong here even without the alias bug — a bare
+        // `.Field` resolves against the CURRENT LOOP ITEM's type, not
+        // root, and `html/template` panics at execute time (`can't
+        // evaluate field ... in type ...`) the first time such a
+        // reference is exercised.
         this.rootFieldRef(expr.name)
-        return `.${capitalizeFieldName(expr.name)}`
+        return `$.${capitalizeFieldName(this.resolveRootFieldAlias(expr.name))}`
       }
 
       case 'literal':
@@ -6262,11 +6289,12 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
           return `${paramPrefix}.${capitalizeFieldName(expr.callee.property)}`
         }
         // Signal calls: `filter()` -> `$.Filter`. Same registration-only
-        // `rootFieldRef` call as the `identifier` case above, for the same
+        // `rootFieldRef` call — and the same `resolveRootFieldAlias` field
+        // resolution (#2857) — as the `identifier` case above, for the same
         // reason (#2700's BF101 gate; pullfrog review, PR #2818).
         if (expr.callee.kind === 'identifier' && expr.args.length === 0) {
           this.rootFieldRef(expr.callee.name)
-          return `$.${capitalizeFieldName(expr.callee.name)}`
+          return `$.${capitalizeFieldName(this.resolveRootFieldAlias(expr.callee.name))}`
         }
         // A nested callback method call (`other.some(r => …)`) reaching this
         // arm has no Go template form in filter context — the fallthrough

--- a/packages/adapter-mojolicious/src/render-divergences.ts
+++ b/packages/adapter-mojolicious/src/render-divergences.ts
@@ -15,4 +15,15 @@ import type { RenderDivergences } from '@barefootjs/jsx'
 // at value position and the runtime evaluator's `object-literal` case
 // now merges it, so the seed classifies `derived` and SSRs identically
 // to Hono.
-export const renderDivergences: RenderDivergences = {}
+export const renderDivergences: RenderDivergences = {
+  // #2883: `MojoFilterEmitter.identifier()` (expr/emitters.ts) resolves a
+  // `.filter()` predicate identifier against only the loop param and
+  // `localVarMap` — a bare-props-form renamed prop destructure (`const {
+  // fallbackLabel: skipLabel } = props`, the #2788 alias family) falls
+  // through to a bare `$skipLabel`, a Perl variable never declared in the
+  // generated `.html.ep`. Every row is filtered out (the fixture's
+  // reference expects only the non-matching row to survive). Unrelated to
+  // #2857's Go Template adapter fix that this fixture was added for — this
+  // fixture is a shared cross-adapter conformance fixture, not Go-specific.
+  'filter-predicate-renamed-prop': 'https://github.com/piconic-ai/barefootjs/issues/2883',
+}

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -2358,6 +2358,49 @@
         "text"
       ]
     },
+    "filter-predicate-renamed-prop": {
+      "kinds": [
+        "array-literal",
+        "binary",
+        "call",
+        "identifier",
+        "literal",
+        "member",
+        "object-literal"
+      ],
+      "axes": [
+        "binary:!==",
+        "literal:number",
+        "literal:string"
+      ],
+      "contexts": [
+        "attribute",
+        "loop",
+        "text"
+      ]
+    },
+    "filter-predicate-signal-alias": {
+      "kinds": [
+        "array-literal",
+        "binary",
+        "call",
+        "identifier",
+        "literal",
+        "member",
+        "object-literal"
+      ],
+      "axes": [
+        "binary:===",
+        "literal:boolean",
+        "literal:number",
+        "literal:string"
+      ],
+      "contexts": [
+        "attribute",
+        "loop",
+        "text"
+      ]
+    },
     "filter-simple": {
       "kinds": [
         "array-literal",
@@ -6134,18 +6177,18 @@
     }
   },
   "kindCounts": {
-    "array-literal": 94,
+    "array-literal": 96,
     "array-method": 71,
     "arrow": 72,
-    "binary": 99,
-    "call": 257,
+    "binary": 101,
+    "call": 259,
     "conditional": 31,
-    "identifier": 360,
+    "identifier": 362,
     "index-access": 14,
-    "literal": 286,
+    "literal": 288,
     "logical": 49,
-    "member": 203,
-    "object-literal": 78,
+    "member": 205,
+    "object-literal": 80,
     "template-literal": 31,
     "unary": 27,
     "unsupported": 47
@@ -6176,19 +6219,19 @@
     "array-method:trimEnd": 1,
     "array-method:trimStart": 1,
     "binary:!=": 2,
-    "binary:!==": 9,
+    "binary:!==": 10,
     "binary:*": 12,
     "binary:+": 23,
     "binary:-": 12,
     "binary:/": 1,
     "binary:<": 1,
-    "binary:===": 52,
+    "binary:===": 53,
     "binary:>": 11,
     "binary:>=": 1,
-    "literal:boolean": 60,
+    "literal:boolean": 61,
     "literal:null": 23,
-    "literal:number": 123,
-    "literal:string": 203,
+    "literal:number": 125,
+    "literal:string": 205,
     "logical:&&": 7,
     "logical:??": 41,
     "logical:||": 16,

--- a/packages/adapter-tests/fixtures/filter-predicate-renamed-prop.ts
+++ b/packages/adapter-tests/fixtures/filter-predicate-renamed-prop.ts
@@ -1,0 +1,47 @@
+import { createFixture } from '../src/types'
+
+/**
+ * #2857: a `.filter()` predicate that references a bare-props-form
+ * body-destructured, RENAMED prop directly (`const { fallbackLabel:
+ * skipLabel } = props`, the #2788 alias family) as a plain identifier.
+ *
+ * `renderFilterExprNode`'s `identifier` arm called `rootFieldRef` on the
+ * raw local name only for its BF101 registration side effect, then
+ * re-derived the emitted Go struct field from that same raw local name
+ * (`.SkipLabel`) instead of the field the prop itself is seeded under
+ * (`.FallbackLabel`). The phantom `.SkipLabel` field was never populated,
+ * so it defaulted to Go's `""` zero value — a predicate comparing against
+ * it (`t.label !== skipLabel`) then always matched, keeping every row
+ * instead of filtering the one row equal to the real prop value.
+ */
+export const fixture = createFixture({
+  id: 'filter-predicate-renamed-prop',
+  description: '.filter() predicate referencing a renamed prop destructure (#2857)',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+
+type Todo = { id: number; label: string }
+
+export function FilterPredicateRenamedProp(props: { fallbackLabel: string }) {
+  const { fallbackLabel: skipLabel } = props
+  const [todos] = createSignal<Todo[]>([
+    { id: 1, label: 'Alpha' },
+    { id: 2, label: 'Beta' },
+  ])
+  return (
+    <ul>
+      {todos().filter(t => t.label !== skipLabel).map(t => (
+        <li key={t.id}>{t.label}</li>
+      ))}
+    </ul>
+  )
+}
+`,
+  props: {
+    fallbackLabel: 'Alpha',
+  },
+  expectedHtml: `
+    <ul bf-s="test" bf="s1"><li data-key="2"><!--bf:s0-->Beta<!--/--></li></ul>
+  `,
+})

--- a/packages/adapter-tests/fixtures/filter-predicate-signal-alias.ts
+++ b/packages/adapter-tests/fixtures/filter-predicate-signal-alias.ts
@@ -1,0 +1,45 @@
+import { createFixture } from '../src/types'
+
+/**
+ * #2857: a `.filter()` predicate that CALLS a signal-getter alias
+ * (`const showDone__alias = showDone`) as a zero-arg identifier call.
+ *
+ * `renderFilterExprNode`'s `call` arm called `rootFieldRef` on the raw
+ * alias name only for its BF101 registration side effect, then re-derived
+ * the emitted Go struct field from that same raw alias name (`.ShowDoneAlias`)
+ * instead of the field the ALIASED signal itself seeds (`.ShowDone`). The
+ * phantom `.ShowDoneAlias` field was never populated by `New*Props`, so it
+ * defaulted to Go's `false` zero value regardless of the signal's real
+ * (`true`) initial value — seeding `showDone` to `true` (not `false`) makes
+ * that phantom-field divergence observable: the correct render keeps only
+ * the `done: true` row, the buggy one keeps only the `done: false` row.
+ */
+export const fixture = createFixture({
+  id: 'filter-predicate-signal-alias',
+  description: '.filter() predicate calling a signal-getter alias (#2857)',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+
+type Todo = { id: number; label: string; done: boolean }
+
+export function FilterPredicateSignalAlias() {
+  const [todos] = createSignal<Todo[]>([
+    { id: 1, label: 'Alpha', done: false },
+    { id: 2, label: 'Beta', done: true },
+  ])
+  const [showDone] = createSignal(true)
+  const showDone__alias = showDone
+  return (
+    <ul>
+      {todos().filter(t => t.done === showDone__alias()).map(t => (
+        <li key={t.id}>{t.label}</li>
+      ))}
+    </ul>
+  )
+}
+`,
+  expectedHtml: `
+    <ul bf-s="test" bf="s1"><li data-key="2"><!--bf:s0-->Beta<!--/--></li></ul>
+  `,
+})

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -136,6 +136,8 @@ import { fixture as filterTypeofPredicate } from './filter-typeof-predicate'
 import { fixture as filterTypeofPredicateClient } from './filter-typeof-predicate-client'
 import { fixture as filterNestedFindPredicate } from './filter-nested-find-predicate'
 import { fixture as filterNestedFindPredicateClient } from './filter-nested-find-predicate-client'
+import { fixture as filterPredicateSignalAlias } from './filter-predicate-signal-alias'
+import { fixture as filterPredicateRenamedProp } from './filter-predicate-renamed-prop'
 import { fixture as fillUnsupported } from './fill-unsupported'
 import { fixture as fillUnsupportedClient } from './fill-unsupported-client'
 import { fixture as findTypeofPredicate } from './find-typeof-predicate'
@@ -680,6 +682,8 @@ export const jsxFixtures: JSXFixture[] = [
   filterTypeofPredicateClient,
   filterNestedFindPredicate,
   filterNestedFindPredicateClient,
+  filterPredicateSignalAlias,
+  filterPredicateRenamedProp,
   fillUnsupported,
   fillUnsupportedClient,
   findTypeofPredicate,

--- a/packages/adapter-tests/generated-data-points.json
+++ b/packages/adapter-tests/generated-data-points.json
@@ -1352,6 +1352,26 @@
       }
     }
   ],
+  "filter-predicate-renamed-prop": [
+    {
+      "name": "gen:fallbackLabel:empty",
+      "props": {
+        "fallbackLabel": ""
+      }
+    },
+    {
+      "name": "gen:fallbackLabel:markup",
+      "props": {
+        "fallbackLabel": "<b>&\"'</b>"
+      }
+    },
+    {
+      "name": "gen:fallbackLabel:multibyte",
+      "props": {
+        "fallbackLabel": "日本語"
+      }
+    }
+  ],
   "flatmap-expression-body": [
     {
       "name": "gen:items:empty",

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-conformance section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. This answers, per fixture and per adapter, whether the construct WORKS — not just whether it compiles. A construct works either as written (✓) or with a documented `/* @client */` comment (✓†, a verified, supported escape — most refusals have one). Fixtures absent from the table below work on every adapter — most as written, some via that documented escape; the headline says how many of each. Listed fixtures need attention somewhere: a bare diagnostic code is still-open debt with no escape yet, a code led by ✗ owes no escape at all (by design), and ≠ means the fixture compiles clean but its rendered output diverges from the reference.",
-    "totalFixtures": 382,
+    "totalFixtures": 384,
     "fixtures": {
       "date-method-uncatalogued": {
         "blade": {
@@ -2247,6 +2247,12 @@
             "state": "escapable",
             "twin": "filter-nested-find-predicate-client"
           }
+        }
+      },
+      "filter-predicate-renamed-prop": {
+        "mojolicious": {
+          "kind": "render",
+          "reason": "https://github.com/piconic-ai/barefootjs/issues/2883"
         }
       },
       "filter-typeof-predicate": {
@@ -3582,6 +3588,10 @@
       "filter-nested-find-predicate": {
         "description": "Filter predicate containing a nested .find() callback (#2038)",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/filter-nested-find-predicate.ts"
+      },
+      "filter-predicate-renamed-prop": {
+        "description": ".filter() predicate referencing a renamed prop destructure (#2857)",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/filter-predicate-renamed-prop.ts"
       },
       "filter-typeof-predicate": {
         "description": "Off-subset filter predicate (typeof) — JS-runtime faithful, DSL diagnostic",

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -305,7 +305,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 85,
+          "pass": 84,
           "total": 96,
           "gaps": [
             {
@@ -321,6 +321,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-predicate-renamed-prop",
+              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -1267,7 +1271,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 93,
+          "pass": 92,
           "total": 101,
           "gaps": [
             {
@@ -1279,6 +1283,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-predicate-renamed-prop",
+              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -1837,7 +1845,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 244,
+          "pass": 243,
           "total": 259,
           "gaps": [
             {
@@ -1859,6 +1867,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-predicate-renamed-prop",
+              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -2729,7 +2741,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 343,
+          "pass": 342,
           "total": 362,
           "gaps": [
             {
@@ -2751,6 +2763,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-predicate-renamed-prop",
+              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -3381,7 +3397,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 276,
+          "pass": 275,
           "total": 288,
           "gaps": [
             {
@@ -3390,6 +3406,10 @@
             },
             {
               "fixture": "fill-unsupported",
+              "issues": []
+            },
+            {
+              "fixture": "filter-predicate-renamed-prop",
               "issues": []
             },
             {
@@ -4199,7 +4219,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 187,
+          "pass": 186,
           "total": 205,
           "gaps": [
             {
@@ -4221,6 +4241,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-predicate-renamed-prop",
+              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -4595,9 +4619,13 @@
           ]
         },
         "mojolicious": {
-          "pass": 77,
+          "pass": 76,
           "total": 80,
           "gaps": [
+            {
+              "fixture": "filter-predicate-renamed-prop",
+              "issues": []
+            },
             {
               "fixture": "preamble-cells",
               "issues": []
@@ -6873,8 +6901,14 @@
           "total": 10
         },
         "mojolicious": {
-          "pass": 10,
-          "total": 10
+          "pass": 9,
+          "total": 10,
+          "gaps": [
+            {
+              "fixture": "filter-predicate-renamed-prop",
+              "issues": []
+            }
+          ]
         },
         "twig": {
           "pass": 10,
@@ -8008,11 +8042,15 @@
           ]
         },
         "mojolicious": {
-          "pass": 120,
+          "pass": 119,
           "total": 125,
           "gaps": [
             {
               "fixture": "fill-unsupported",
+              "issues": []
+            },
+            {
+              "fixture": "filter-predicate-renamed-prop",
               "issues": []
             },
             {
@@ -8312,7 +8350,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 197,
+          "pass": 196,
           "total": 205,
           "gaps": [
             {
@@ -8321,6 +8359,10 @@
             },
             {
               "fixture": "fill-unsupported",
+              "issues": []
+            },
+            {
+              "fixture": "filter-predicate-renamed-prop",
               "issues": []
             },
             {

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -14,15 +14,15 @@
   ],
   "kinds": {
     "array-literal": {
-      "total": 94,
+      "total": 96,
       "cells": {
         "hono": {
-          "pass": 94,
-          "total": 94
+          "pass": 96,
+          "total": 96
         },
         "blade": {
-          "pass": 82,
-          "total": 94,
+          "pass": 84,
+          "total": 96,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -79,8 +79,8 @@
           ]
         },
         "erb": {
-          "pass": 83,
-          "total": 94,
+          "pass": 85,
+          "total": 96,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -131,8 +131,8 @@
           ]
         },
         "go-template": {
-          "pass": 82,
-          "total": 94,
+          "pass": 84,
+          "total": 96,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -189,8 +189,8 @@
           ]
         },
         "jinja": {
-          "pass": 82,
-          "total": 94,
+          "pass": 84,
+          "total": 96,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -247,8 +247,8 @@
           ]
         },
         "minijinja": {
-          "pass": 82,
-          "total": 94,
+          "pass": 84,
+          "total": 96,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -305,8 +305,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 83,
-          "total": 94,
+          "pass": 85,
+          "total": 96,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -357,8 +357,8 @@
           ]
         },
         "twig": {
-          "pass": 82,
-          "total": 94,
+          "pass": 84,
+          "total": 96,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -415,8 +415,8 @@
           ]
         },
         "xslate": {
-          "pass": 82,
-          "total": 94,
+          "pass": 84,
+          "total": 96,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1026,15 +1026,15 @@
       }
     },
     "binary": {
-      "total": 99,
+      "total": 101,
       "cells": {
         "hono": {
-          "pass": 99,
-          "total": 99
+          "pass": 101,
+          "total": 101
         },
         "blade": {
-          "pass": 90,
-          "total": 99,
+          "pass": 92,
+          "total": 101,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1081,8 +1081,8 @@
           ]
         },
         "erb": {
-          "pass": 91,
-          "total": 99,
+          "pass": 93,
+          "total": 101,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1123,8 +1123,8 @@
           ]
         },
         "go-template": {
-          "pass": 90,
-          "total": 99,
+          "pass": 92,
+          "total": 101,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1171,8 +1171,8 @@
           ]
         },
         "jinja": {
-          "pass": 90,
-          "total": 99,
+          "pass": 92,
+          "total": 101,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1219,8 +1219,8 @@
           ]
         },
         "minijinja": {
-          "pass": 90,
-          "total": 99,
+          "pass": 92,
+          "total": 101,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1267,8 +1267,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 91,
-          "total": 99,
+          "pass": 93,
+          "total": 101,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1309,8 +1309,8 @@
           ]
         },
         "twig": {
-          "pass": 90,
-          "total": 99,
+          "pass": 92,
+          "total": 101,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1357,8 +1357,8 @@
           ]
         },
         "xslate": {
-          "pass": 90,
-          "total": 99,
+          "pass": 92,
+          "total": 101,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1418,11 +1418,11 @@
       }
     },
     "call": {
-      "total": 257,
+      "total": 259,
       "cells": {
         "hono": {
-          "pass": 255,
-          "total": 257,
+          "pass": 257,
+          "total": 259,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1437,8 +1437,8 @@
           ]
         },
         "blade": {
-          "pass": 241,
-          "total": 257,
+          "pass": 243,
+          "total": 259,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1517,8 +1517,8 @@
           ]
         },
         "erb": {
-          "pass": 242,
-          "total": 257,
+          "pass": 244,
+          "total": 259,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1591,8 +1591,8 @@
           ]
         },
         "go-template": {
-          "pass": 240,
-          "total": 257,
+          "pass": 242,
+          "total": 259,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1677,8 +1677,8 @@
           ]
         },
         "jinja": {
-          "pass": 241,
-          "total": 257,
+          "pass": 243,
+          "total": 259,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1757,8 +1757,8 @@
           ]
         },
         "minijinja": {
-          "pass": 241,
-          "total": 257,
+          "pass": 243,
+          "total": 259,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1837,8 +1837,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 242,
-          "total": 257,
+          "pass": 244,
+          "total": 259,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1911,8 +1911,8 @@
           ]
         },
         "twig": {
-          "pass": 241,
-          "total": 257,
+          "pass": 243,
+          "total": 259,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1991,8 +1991,8 @@
           ]
         },
         "xslate": {
-          "pass": 241,
-          "total": 257,
+          "pass": 243,
+          "total": 259,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2216,11 +2216,11 @@
       }
     },
     "identifier": {
-      "total": 360,
+      "total": 362,
       "cells": {
         "hono": {
-          "pass": 356,
-          "total": 360,
+          "pass": 358,
+          "total": 362,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2243,8 +2243,8 @@
           ]
         },
         "blade": {
-          "pass": 340,
-          "total": 360,
+          "pass": 342,
+          "total": 362,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2339,8 +2339,8 @@
           ]
         },
         "erb": {
-          "pass": 341,
-          "total": 360,
+          "pass": 343,
+          "total": 362,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2429,8 +2429,8 @@
           ]
         },
         "go-template": {
-          "pass": 338,
-          "total": 360,
+          "pass": 340,
+          "total": 362,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2537,8 +2537,8 @@
           ]
         },
         "jinja": {
-          "pass": 340,
-          "total": 360,
+          "pass": 342,
+          "total": 362,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2633,8 +2633,8 @@
           ]
         },
         "minijinja": {
-          "pass": 340,
-          "total": 360,
+          "pass": 342,
+          "total": 362,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2729,8 +2729,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 341,
-          "total": 360,
+          "pass": 343,
+          "total": 362,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2819,8 +2819,8 @@
           ]
         },
         "twig": {
-          "pass": 340,
-          "total": 360,
+          "pass": 342,
+          "total": 362,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2915,8 +2915,8 @@
           ]
         },
         "xslate": {
-          "pass": 340,
-          "total": 360,
+          "pass": 342,
+          "total": 362,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3076,11 +3076,11 @@
       }
     },
     "literal": {
-      "total": 286,
+      "total": 288,
       "cells": {
         "hono": {
-          "pass": 285,
-          "total": 286,
+          "pass": 287,
+          "total": 288,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -3089,8 +3089,8 @@
           ]
         },
         "blade": {
-          "pass": 274,
-          "total": 286,
+          "pass": 276,
+          "total": 288,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3145,8 +3145,8 @@
           ]
         },
         "erb": {
-          "pass": 274,
-          "total": 286,
+          "pass": 276,
+          "total": 288,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3201,8 +3201,8 @@
           ]
         },
         "go-template": {
-          "pass": 272,
-          "total": 286,
+          "pass": 274,
+          "total": 288,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3269,8 +3269,8 @@
           ]
         },
         "jinja": {
-          "pass": 274,
-          "total": 286,
+          "pass": 276,
+          "total": 288,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3325,8 +3325,8 @@
           ]
         },
         "minijinja": {
-          "pass": 274,
-          "total": 286,
+          "pass": 276,
+          "total": 288,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3381,8 +3381,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 274,
-          "total": 286,
+          "pass": 276,
+          "total": 288,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3437,8 +3437,8 @@
           ]
         },
         "twig": {
-          "pass": 274,
-          "total": 286,
+          "pass": 276,
+          "total": 288,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3493,8 +3493,8 @@
           ]
         },
         "xslate": {
-          "pass": 274,
-          "total": 286,
+          "pass": 276,
+          "total": 288,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3710,11 +3710,11 @@
       }
     },
     "member": {
-      "total": 203,
+      "total": 205,
       "cells": {
         "hono": {
-          "pass": 200,
-          "total": 203,
+          "pass": 202,
+          "total": 205,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3733,8 +3733,8 @@
           ]
         },
         "blade": {
-          "pass": 184,
-          "total": 203,
+          "pass": 186,
+          "total": 205,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3825,8 +3825,8 @@
           ]
         },
         "erb": {
-          "pass": 185,
-          "total": 203,
+          "pass": 187,
+          "total": 205,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3911,8 +3911,8 @@
           ]
         },
         "go-template": {
-          "pass": 182,
-          "total": 203,
+          "pass": 184,
+          "total": 205,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4015,8 +4015,8 @@
           ]
         },
         "jinja": {
-          "pass": 184,
-          "total": 203,
+          "pass": 186,
+          "total": 205,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4107,8 +4107,8 @@
           ]
         },
         "minijinja": {
-          "pass": 184,
-          "total": 203,
+          "pass": 186,
+          "total": 205,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4199,8 +4199,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 185,
-          "total": 203,
+          "pass": 187,
+          "total": 205,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4285,8 +4285,8 @@
           ]
         },
         "twig": {
-          "pass": 184,
-          "total": 203,
+          "pass": 186,
+          "total": 205,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4377,8 +4377,8 @@
           ]
         },
         "xslate": {
-          "pass": 184,
-          "total": 203,
+          "pass": 186,
+          "total": 205,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4482,15 +4482,15 @@
       }
     },
     "object-literal": {
-      "total": 78,
+      "total": 80,
       "cells": {
         "hono": {
-          "pass": 78,
-          "total": 78
+          "pass": 80,
+          "total": 80
         },
         "blade": {
-          "pass": 75,
-          "total": 78,
+          "pass": 77,
+          "total": 80,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4509,8 +4509,8 @@
           ]
         },
         "erb": {
-          "pass": 75,
-          "total": 78,
+          "pass": 77,
+          "total": 80,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4529,8 +4529,8 @@
           ]
         },
         "go-template": {
-          "pass": 74,
-          "total": 78,
+          "pass": 76,
+          "total": 80,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4555,8 +4555,8 @@
           ]
         },
         "jinja": {
-          "pass": 75,
-          "total": 78,
+          "pass": 77,
+          "total": 80,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4575,8 +4575,8 @@
           ]
         },
         "minijinja": {
-          "pass": 75,
-          "total": 78,
+          "pass": 77,
+          "total": 80,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4595,8 +4595,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 75,
-          "total": 78,
+          "pass": 77,
+          "total": 80,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4615,8 +4615,8 @@
           ]
         },
         "twig": {
-          "pass": 75,
-          "total": 78,
+          "pass": 77,
+          "total": 80,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4635,8 +4635,8 @@
           ]
         },
         "xslate": {
-          "pass": 75,
-          "total": 78,
+          "pass": 77,
+          "total": 80,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -6846,43 +6846,43 @@
       }
     },
     "binary:!==": {
-      "total": 9,
+      "total": 10,
       "cells": {
         "hono": {
-          "pass": 9,
-          "total": 9
+          "pass": 10,
+          "total": 10
         },
         "blade": {
-          "pass": 9,
-          "total": 9
+          "pass": 10,
+          "total": 10
         },
         "erb": {
-          "pass": 9,
-          "total": 9
+          "pass": 10,
+          "total": 10
         },
         "go-template": {
-          "pass": 9,
-          "total": 9
+          "pass": 10,
+          "total": 10
         },
         "jinja": {
-          "pass": 9,
-          "total": 9
+          "pass": 10,
+          "total": 10
         },
         "minijinja": {
-          "pass": 9,
-          "total": 9
+          "pass": 10,
+          "total": 10
         },
         "mojolicious": {
-          "pass": 9,
-          "total": 9
+          "pass": 10,
+          "total": 10
         },
         "twig": {
-          "pass": 9,
-          "total": 9
+          "pass": 10,
+          "total": 10
         },
         "xslate": {
-          "pass": 9,
-          "total": 9
+          "pass": 10,
+          "total": 10
         }
       },
       "source": {
@@ -7222,15 +7222,15 @@
       }
     },
     "binary:===": {
-      "total": 52,
+      "total": 53,
       "cells": {
         "hono": {
-          "pass": 52,
-          "total": 52
+          "pass": 53,
+          "total": 53
         },
         "blade": {
-          "pass": 44,
-          "total": 52,
+          "pass": 45,
+          "total": 53,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7271,8 +7271,8 @@
           ]
         },
         "erb": {
-          "pass": 45,
-          "total": 52,
+          "pass": 46,
+          "total": 53,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7307,8 +7307,8 @@
           ]
         },
         "go-template": {
-          "pass": 44,
-          "total": 52,
+          "pass": 45,
+          "total": 53,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7349,8 +7349,8 @@
           ]
         },
         "jinja": {
-          "pass": 44,
-          "total": 52,
+          "pass": 45,
+          "total": 53,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7391,8 +7391,8 @@
           ]
         },
         "minijinja": {
-          "pass": 44,
-          "total": 52,
+          "pass": 45,
+          "total": 53,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7433,8 +7433,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 45,
-          "total": 52,
+          "pass": 46,
+          "total": 53,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7469,8 +7469,8 @@
           ]
         },
         "twig": {
-          "pass": 44,
-          "total": 52,
+          "pass": 45,
+          "total": 53,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7511,8 +7511,8 @@
           ]
         },
         "xslate": {
-          "pass": 44,
-          "total": 52,
+          "pass": 45,
+          "total": 53,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7670,11 +7670,11 @@
       }
     },
     "literal:boolean": {
-      "total": 60,
+      "total": 61,
       "cells": {
         "hono": {
-          "pass": 59,
-          "total": 60,
+          "pass": 60,
+          "total": 61,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -7683,8 +7683,8 @@
           ]
         },
         "blade": {
-          "pass": 58,
-          "total": 60,
+          "pass": 59,
+          "total": 61,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -7697,8 +7697,8 @@
           ]
         },
         "erb": {
-          "pass": 58,
-          "total": 60,
+          "pass": 59,
+          "total": 61,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -7711,8 +7711,8 @@
           ]
         },
         "go-template": {
-          "pass": 56,
-          "total": 60,
+          "pass": 57,
+          "total": 61,
           "gaps": [
             {
               "fixture": "jsx-element-prop-rest-bag-dynamic",
@@ -7737,8 +7737,8 @@
           ]
         },
         "jinja": {
-          "pass": 58,
-          "total": 60,
+          "pass": 59,
+          "total": 61,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -7751,8 +7751,8 @@
           ]
         },
         "minijinja": {
-          "pass": 58,
-          "total": 60,
+          "pass": 59,
+          "total": 61,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -7765,8 +7765,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 58,
-          "total": 60,
+          "pass": 59,
+          "total": 61,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -7779,8 +7779,8 @@
           ]
         },
         "twig": {
-          "pass": 58,
-          "total": 60,
+          "pass": 59,
+          "total": 61,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -7793,8 +7793,8 @@
           ]
         },
         "xslate": {
-          "pass": 58,
-          "total": 60,
+          "pass": 59,
+          "total": 61,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -7871,15 +7871,15 @@
       }
     },
     "literal:number": {
-      "total": 123,
+      "total": 125,
       "cells": {
         "hono": {
-          "pass": 123,
-          "total": 123
+          "pass": 125,
+          "total": 125
         },
         "blade": {
-          "pass": 118,
-          "total": 123,
+          "pass": 120,
+          "total": 125,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7904,8 +7904,8 @@
           ]
         },
         "erb": {
-          "pass": 118,
-          "total": 123,
+          "pass": 120,
+          "total": 125,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7930,8 +7930,8 @@
           ]
         },
         "go-template": {
-          "pass": 118,
-          "total": 123,
+          "pass": 120,
+          "total": 125,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7956,8 +7956,8 @@
           ]
         },
         "jinja": {
-          "pass": 118,
-          "total": 123,
+          "pass": 120,
+          "total": 125,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7982,8 +7982,8 @@
           ]
         },
         "minijinja": {
-          "pass": 118,
-          "total": 123,
+          "pass": 120,
+          "total": 125,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8008,8 +8008,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 118,
-          "total": 123,
+          "pass": 120,
+          "total": 125,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8034,8 +8034,8 @@
           ]
         },
         "twig": {
-          "pass": 118,
-          "total": 123,
+          "pass": 120,
+          "total": 125,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8060,8 +8060,8 @@
           ]
         },
         "xslate": {
-          "pass": 118,
-          "total": 123,
+          "pass": 120,
+          "total": 125,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8099,15 +8099,15 @@
       }
     },
     "literal:string": {
-      "total": 203,
+      "total": 205,
       "cells": {
         "hono": {
-          "pass": 203,
-          "total": 203
+          "pass": 205,
+          "total": 205
         },
         "blade": {
-          "pass": 195,
-          "total": 203,
+          "pass": 197,
+          "total": 205,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8146,8 +8146,8 @@
           ]
         },
         "erb": {
-          "pass": 195,
-          "total": 203,
+          "pass": 197,
+          "total": 205,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8186,8 +8186,8 @@
           ]
         },
         "go-template": {
-          "pass": 194,
-          "total": 203,
+          "pass": 196,
+          "total": 205,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8232,8 +8232,8 @@
           ]
         },
         "jinja": {
-          "pass": 195,
-          "total": 203,
+          "pass": 197,
+          "total": 205,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8272,8 +8272,8 @@
           ]
         },
         "minijinja": {
-          "pass": 195,
-          "total": 203,
+          "pass": 197,
+          "total": 205,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8312,8 +8312,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 195,
-          "total": 203,
+          "pass": 197,
+          "total": 205,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8352,8 +8352,8 @@
           ]
         },
         "twig": {
-          "pass": 195,
-          "total": 203,
+          "pass": 197,
+          "total": 205,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8392,8 +8392,8 @@
           ]
         },
         "xslate": {
-          "pass": 195,
-          "total": 203,
+          "pass": 197,
+          "total": 205,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",


### PR DESCRIPTION
Fixes #2857.

## Summary

`rootFieldRef` is the single door every root-scope field reference (signal / prop / derived-const, including the alias families from #2813 and #2788) is meant to resolve through before being capitalized into a Go struct field name. `renderFilterExprNode`'s `identifier` arm and the `call` arm's zero-arg signal case called `rootFieldRef` only for its registration side effect, then re-derived the emitted field name from the raw, unresolved identifier instead of using `rootFieldRef`'s resolved value.

So a `.filter()` predicate that referenced a renamed local directly — either a signal-getter alias (`const items__alias = items`) or a body-destructured-renamed prop (`const { children: kids } = props`) — emitted a field name derived from the alias/local name (e.g. `.Kids`) instead of the field its origin actually seeds (`.Children`). That phantom field was never seeded by `New<Component>Props`, so `html/template` panicked at render time (`can't evaluate field ... in type ...`).

## Fix

- Extracted `rootFieldRef`'s alias-resolution logic (`getterAliases` / `propDestructureAliases` lookup) into a shared `resolveRootFieldAlias` helper, with `rootFieldRef` built on top of it.
- `renderFilterExprNode`'s `identifier` and `call` arms now route the emitted field name through `resolveRootFieldAlias` instead of re-deriving it from the raw identifier.
- Fixing this surfaced a second, adjacent bug in the same `identifier` arm: a bare (non-alias, non-signal) root-scope reference inside a filter predicate — a memo, a plain derived const, or a renamed prop destructure — emitted a bare `.Field` instead of the `$.Field` a `.filter().map()` loop's `{{range}}{{if}}` gate requires to escape the current loop item and reach the root struct. Fixed in the same arm, since it's the exact same underlying category (a root reference not correctly escaping to root scope) and it blocked this PR's own regression fixture from passing on real `go run`.

## Testing

Added two conformance fixtures exercising both alias families inside a `.filter()` predicate (`filter-predicate-signal-alias`, `filter-predicate-renamed-prop`), verified against real `go run` (Go 1.25.6):
- Both **panic** with `can't evaluate field ... in type ...` on the pre-fix code.
- Both **pass**, matching the Hono reference output, with the fix.

Full `packages/adapter-go-template` test suite (1977 tests, real `go run` conformance) run against the fix: 1901 pass, 25 skip, 51 fail — all 51 failures are a pre-existing, unrelated sandbox environment issue (`Cannot find module '@barefootjs/client'` in Hono's `client-shim.ts`, affecting `format-date`/`query-href` oracle fixtures), confirmed identical on the unpatched baseline.

Regenerated `packages/adapter-tests/coverage-map.json` for the two new fixtures (coverage-ledger floor test).

## Scope note

While investigating this, found a separate, unrelated gap: `renderFilterExprNode`'s `member` arm has no `propsObjectName` branch (unlike `renderConditionExpr`), so `.filter(it => it.id !== props.hidden)` on a bare-props-form component also panics — for a different reason (no alias involved at all). Filed as #2879 rather than folded into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HeZLEug6a9R9U2EHNTwWJK

---
_Generated by [Claude Code](https://claude.ai/code/session_01HeZLEug6a9R9U2EHNTwWJK)_