### PR TITLE
Fix #2862: signal seeded from a module-level array/object const bakes nil

### DIFF
--- a/.changeset/go-module-const-array-seed-2862.md
+++ b/.changeset/go-module-const-array-seed-2862.md
@@ -1,0 +1,7 @@
+---
+"@barefootjs/go-template": patch
+---
+
+Fix #2862: a signal seeded from a bare identifier referencing a module-level const whose value is an array-of-objects or object literal (`const INITIAL: Row[] = [...]; createSignal(INITIAL)`) baked to `nil` (or the struct zero value for a scalar object const) in the generated `New<Component>Props` constructor instead of the const's actual literal value — real `go run` SSR rendered an empty list where Hono renders every row. Same family as #2794 (string/numeric module consts) and #2815 (boolean module consts), fixed by PR #2816, but neither of those per-type resolvers ever covered an array/object literal.
+
+Replaced the three separate per-type text-matching resolvers (`resolveModuleStringConst`'s numeric/boolean siblings) with one structural resolver, `resolveModuleConstAsGo`, dispatched off the const's `ConstantInfo.parsed` tree through the same `parsedLiteralToGo` door an inline `createSignal([...])`/`createSignal({...})` seed already takes — so a composite literal bakes through the identical, already-tested path regardless of whether it arrives directly or via a module-const alias hop. `resolveModuleStringConst` itself is unchanged (its fixed-point text resolution still covers a composed template-literal const that has no single structural literal to bake).

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -1641,7 +1641,7 @@ export function Widget(props: P) {
     // to `nil` — the analyzer types it `unknown` since it never chases an
     // identifier to its declaration, so none of convertInitialValue's typed
     // branches saw it (#2794). Now resolved via the same
-    // resolveModuleStringConst/resolveModuleNumericConst the adapter
+    // resolveModuleStringConst/resolveModuleConstAsGo the adapter
     // already used for live template expressions (template-interp.ts).
     test('signal seeded from a module-level const bakes its literal value, not nil', () => {
       const adapter = new GoTemplateAdapter()
@@ -6208,7 +6208,7 @@ export function Nested({ groups }: { groups: { label: string }[][] }) {
 // goes through `identifier()` (the `ParsedExprEmitter` method), which
 // already carries the loop-shadow guards (`loopParamStack` /
 // `isOuterLoopParam`, mirrored from `resolveModuleStringConst` /
-// `resolveModuleNumericConst`). So a `.map((count) => ...)` callback param
+// `resolveModuleConstAsGo`). So a `.map((count) => ...)` callback param
 // that shadows an outer `const count = 7` got the OUTER literal inlined at
 // the `data-key` position even though the text position (which DOES go
 // through `identifier()`) correctly resolved to the per-item value.

--- a/packages/adapter-go-template/src/adapter/emit-context.ts
+++ b/packages/adapter-go-template/src/adapter/emit-context.ts
@@ -14,7 +14,7 @@
  * genuinely needs it, so the seam documents the real cross-module coupling.
  */
 
-import type { ParsedExpr } from '@barefootjs/jsx'
+import type { ParsedExpr, TypeInfo } from '@barefootjs/jsx'
 
 import type { CompileState } from './lib/compile-state.ts'
 
@@ -81,16 +81,18 @@ export interface GoEmitContext {
   resolveModuleStringConst(name: string): string | null
 
   /**
-   * Inline a module numeric const by name as its Go literal text (e.g.
-   * `8`, `-3.5`), or null when the name is not such a const (loop vars and
-   * outer-loop params are excluded, same as `resolveModuleStringConst`).
+   * Resolve a bare identifier naming a plain module-level const (`const
+   * TRACK = 8`, `const OPEN = true`, `const INITIAL: Row[] = [...]`) to its
+   * Go literal, dispatched structurally off the const's `ConstantInfo.parsed`
+   * — or null when the name is not such a const (loop vars and outer-loop
+   * params are excluded, same as `resolveModuleStringConst`). `target.kind
+   * === 'go-source'` may bake a composite (array/object) literal against
+   * `target.bakeType`; `target.kind === 'template-action'` only resolves a
+   * scalar, since a `{{...}}` splice has no valid Go template spelling for a
+   * composite literal.
    */
-  resolveModuleNumericConst(name: string): string | null
-
-  /**
-   * Inline a module boolean const by name as its Go literal text
-   * (`true`/`false`), or null when the name is not such a const (same
-   * exclusions as `resolveModuleNumericConst`).
-   */
-  resolveModuleBooleanConst(name: string): string | null
+  resolveModuleConstAsGo(
+    name: string,
+    target: { kind: 'template-action' } | { kind: 'go-source'; bakeType: TypeInfo },
+  ): string | null
 }

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -262,8 +262,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     extractPropFallback: (initialValue, preParsed) => this.extractPropFallback(initialValue, preParsed),
     extractCollisionDerivation: (parsed) => this.extractCollisionDerivation(parsed),
     resolveModuleStringConst: (name) => this.resolveModuleStringConst(name),
-    resolveModuleNumericConst: (name) => this.resolveModuleNumericConst(name),
-    resolveModuleBooleanConst: (name) => this.resolveModuleBooleanConst(name),
+    resolveModuleConstAsGo: (name, target) => this.resolveModuleConstAsGo(name, target),
   }
 
   /** Diagnostics from the current compile (backed by `CompileState`); `generate()` also merges these into `ir.errors`. */
@@ -4726,11 +4725,12 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     }
     const inlined = this.resolveModuleStringConst(name)
     if (inlined !== null) return inlined
-    // Module numeric const (e.g. `const TRACK = 8` used in a width expression):
-    // inline the literal value rather than emit `{{.TRACK}}` against a Props
-    // field that never exists. Mirrors the string-const inlining above.
-    const inlinedNum = this.resolveModuleNumericConst(name)
-    if (inlinedNum !== null) return inlinedNum
+    // Module scalar const (e.g. `const TRACK = 8` used in a width expression,
+    // or `const OPEN = true`): inline the literal value rather than emit
+    // `{{.TRACK}}` against a Props field that never exists. Mirrors the
+    // string-const inlining above.
+    const inlinedScalar = this.resolveModuleConstAsGo(name, { kind: 'template-action' })
+    if (inlinedScalar !== null) return inlinedScalar
     if (this.isCurrentLoopItem(name)) return '.'
     // An *outer* loop's value variable (we're in a nested loop) is in scope as
     // the Go range variable `$name` declared by that loop's `{{range … := …}}`;
@@ -4935,13 +4935,10 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   }
 
   /**
-   * The single module-const lookup shared by `resolveModuleNumericConst`
-   * and `resolveModuleBooleanConst` — they differ only in which literal
-   * SHAPE they accept from the same "plain module-level const" search, not
-   * in how that search is performed. A second inline lookup per resolver
-   * would grow `binding-scope-ratchet.test.ts`'s shrink-only floor for this
-   * file (already at 5) for a shape variance the callers can express
-   * themselves instead.
+   * The single module-const lookup shared by `resolveModuleConstAsGo` —
+   * kept as its own method (rather than inlined) so a second `.find(` isn't
+   * added elsewhere, growing `binding-scope-ratchet.test.ts`'s shrink-only
+   * floor for this file (already at 5).
    */
   private findModuleConst(name: string): ConstantInfo | undefined {
     return this.state.localConstants.find(
@@ -4950,40 +4947,50 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   }
 
   /**
-   * Inline a module-level numeric const (`const TRACK = 8`) as its literal
-   * value. Only a plain numeric initializer qualifies — anything computed or
-   * non-numeric falls through to the normal field/ident resolution. Scoped to
-   * module consts (like the string variant) and guarded against loop vars so a
-   * range variable that shadows a const name still wins.
+   * Resolve a bare identifier naming a plain module-level const (`const
+   * TRACK = 8`, `const OPEN = true`, `const INITIAL: Row[] = [...]`, #2794 /
+   * #2815 / #2862) to its value's Go literal — dispatched STRUCTURALLY off
+   * `ConstantInfo.parsed`, through the same `parsedLiteralToGo` door an
+   * inline `createSignal([...])`/`createSignal({...})` seed already takes,
+   * rather than a separate per-type text-matching resolver for each literal
+   * shape (the numeric/boolean resolvers this replaces, and the array/
+   * object-literal gap #2862 tracked, were exactly that repeated pattern).
+   * `resolveModuleStringConst` stays separate: its fixed-point text
+   * resolution also covers a COMPOSED template-literal const (`` `${A}-${B}`
+   * ``) that has no single structural literal to bake.
+   *
+   * `target` names the emission position, which constrains what can resolve
+   * there:
+   *   - `go-source` (the `New<Component>Props` constructor) may bake a
+   *     composite (array/object) literal against `bakeType` — falling back
+   *     to the const's OWN declared type when the consumer's type is
+   *     `unknown` (the analyzer's inference is text-shaped and never chases
+   *     a bare `createSignal(INITIAL)` seed to its declaration).
+   *   - `template-action` (a bare `{{...}}` splice, e.g. a className
+   *     expression) has no valid Go template spelling for a composite
+   *     literal, so only a scalar (or unary-minus number) resolves there —
+   *     the same restriction the numeric/boolean resolvers already had.
+   *
+   * Scoped to module consts and guarded against loop vars so a range
+   * variable that shadows a const name still wins (same guards the
+   * resolvers this replaces already had).
    */
-  private resolveModuleNumericConst(name: string): string | null {
+  private resolveModuleConstAsGo(
+    name: string,
+    target: { kind: 'template-action' } | { kind: 'go-source'; bakeType: TypeInfo },
+  ): string | null {
     if (this.isCurrentLoopItem(name)) return null
     if (this.loopVarRefCount.has(name)) return null
     if (this.isOuterLoopParam(name)) return null
     const c = this.findModuleConst(name)
-    if (!c || c.value === undefined) return null
-    // `value` is reconstructed from source text, so a valid TS literal may carry
-    // numeric separators (`100_000`). Strip them between digits, then accept a
-    // plain decimal / float; Go template numeric literals don't allow `_`.
-    const v = c.value.trim().replace(/(?<=\d)_(?=\d)/g, '')
-    return /^-?\d+(\.\d+)?$/.test(v) ? v : null
-  }
-
-  /**
-   * Inline a module-level boolean const (`const OPEN = true`) as its Go
-   * literal (`true`/`false`). Only a plain `true`/`false` initializer
-   * qualifies (#2815) — mirrors `resolveModuleNumericConst`'s shape, sharing
-   * its lookup rather than adding a second `.find(` (see
-   * `findModuleConst`'s docstring).
-   */
-  private resolveModuleBooleanConst(name: string): string | null {
-    if (this.isCurrentLoopItem(name)) return null
-    if (this.loopVarRefCount.has(name)) return null
-    if (this.isOuterLoopParam(name)) return null
-    const c = this.findModuleConst(name)
-    if (!c || c.value === undefined) return null
-    const v = c.value.trim()
-    return v === 'true' || v === 'false' ? v : null
+    if (!c?.parsed) return null
+    if (target.kind === 'template-action') {
+      return c.parsed.kind === 'literal' || c.parsed.kind === 'unary'
+        ? parsedLiteralToGo(this.emitCtx, c.parsed)
+        : null
+    }
+    const bakeType = target.bakeType.kind !== 'unknown' ? target.bakeType : (c.type ?? undefined)
+    return parsedLiteralToGo(this.emitCtx, c.parsed, bakeType)
   }
 
   literal(value: string | number | boolean | null, literalType: LiteralType): string {
@@ -6599,7 +6606,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    * `loopVarRefCount` — so both are still consulted. Shared by the
    * string-keyed fast paths (#2236, #2242 Copilot review) that resolve raw
    * `jsExpr` text before `identifier()`'s own guards can see it. Mirrors the
-   * checks in `resolveModuleStringConst` / `resolveModuleNumericConst`.
+   * checks in `resolveModuleStringConst` / `resolveModuleConstAsGo`.
    */
   private isLoopShadowedName(name: string): boolean {
     return this.scope.isBound(name) || this.loopVarRefCount.has(name)

--- a/packages/adapter-go-template/src/adapter/value/value-lowering.ts
+++ b/packages/adapter-go-template/src/adapter/value/value-lowering.ts
@@ -94,9 +94,10 @@ export function convertInitialValue(
     if (param) {
       return propRef(param)
     }
-    // Module-const seed (#2794): a signal seeded from a bare identifier
-    // that refers to a module-level const (`const PAYLOAD = 'x';
-    // createSignal(PAYLOAD)`) types `unknown` — the analyzer's type
+    // Module-const seed (#2794/#2815/#2862): a signal seeded from a bare
+    // identifier that refers to a module-level const (`const PAYLOAD = 'x';
+    // createSignal(PAYLOAD)`, or `const INITIAL: Row[] = [...];
+    // createSignal(INITIAL)`) types `unknown` — the analyzer's type
     // inference is text-shaped and never chases an identifier to its
     // declaration — so none of the typed branches below ever see it and
     // this used to fall through to the final `nil`. Checked AFTER the
@@ -107,10 +108,8 @@ export function convertInitialValue(
     // leaving that case on the pre-existing `nil` path unchanged.
     const inlinedStr = ctx.resolveModuleStringConst(value)
     if (inlinedStr !== null) return inlinedStr
-    const inlinedNum = ctx.resolveModuleNumericConst(value)
-    if (inlinedNum !== null) return inlinedNum
-    const inlinedBool = ctx.resolveModuleBooleanConst(value)
-    if (inlinedBool !== null) return inlinedBool
+    const inlinedConst = ctx.resolveModuleConstAsGo(value, { kind: 'go-source', bakeType: typeInfo })
+    if (inlinedConst !== null) return inlinedConst
   }
 
   const propName = ctx.extractPropNameFromInitialValue(value, preParsed)

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -3761,6 +3761,25 @@
         "text"
       ]
     },
+    "module-const-array-seed-no-generic": {
+      "kinds": [
+        "array-literal",
+        "call",
+        "identifier",
+        "literal",
+        "member",
+        "object-literal"
+      ],
+      "axes": [
+        "literal:number",
+        "literal:string"
+      ],
+      "contexts": [
+        "attribute",
+        "loop",
+        "text"
+      ]
+    },
     "multi-component-module": {
       "kinds": [
         "call",
@@ -6196,18 +6215,18 @@
     }
   },
   "kindCounts": {
-    "array-literal": 97,
+    "array-literal": 98,
     "array-method": 71,
     "arrow": 72,
     "binary": 101,
-    "call": 260,
+    "call": 261,
     "conditional": 31,
-    "identifier": 363,
+    "identifier": 364,
     "index-access": 14,
-    "literal": 289,
+    "literal": 290,
     "logical": 49,
-    "member": 206,
-    "object-literal": 81,
+    "member": 207,
+    "object-literal": 82,
     "template-literal": 31,
     "unary": 27,
     "unsupported": 47
@@ -6249,8 +6268,8 @@
     "binary:>=": 1,
     "literal:boolean": 61,
     "literal:null": 23,
-    "literal:number": 126,
-    "literal:string": 206,
+    "literal:number": 127,
+    "literal:string": 207,
     "logical:&&": 7,
     "logical:??": 41,
     "logical:||": 16,

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -3742,6 +3742,25 @@
         "text"
       ]
     },
+    "module-const-array-seed": {
+      "kinds": [
+        "array-literal",
+        "call",
+        "identifier",
+        "literal",
+        "member",
+        "object-literal"
+      ],
+      "axes": [
+        "literal:number",
+        "literal:string"
+      ],
+      "contexts": [
+        "attribute",
+        "loop",
+        "text"
+      ]
+    },
     "multi-component-module": {
       "kinds": [
         "call",
@@ -6177,18 +6196,18 @@
     }
   },
   "kindCounts": {
-    "array-literal": 96,
+    "array-literal": 97,
     "array-method": 71,
     "arrow": 72,
     "binary": 101,
-    "call": 259,
+    "call": 260,
     "conditional": 31,
-    "identifier": 362,
+    "identifier": 363,
     "index-access": 14,
-    "literal": 288,
+    "literal": 289,
     "logical": 49,
-    "member": 205,
-    "object-literal": 80,
+    "member": 206,
+    "object-literal": 81,
     "template-literal": 31,
     "unary": 27,
     "unsupported": 47
@@ -6230,8 +6249,8 @@
     "binary:>=": 1,
     "literal:boolean": 61,
     "literal:null": 23,
-    "literal:number": 125,
-    "literal:string": 205,
+    "literal:number": 126,
+    "literal:string": 206,
     "logical:&&": 7,
     "logical:??": 41,
     "logical:||": 16,

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -508,6 +508,10 @@ import { fixture as mapObjectLiteralBody } from './map-object-literal-body'
 // fixture file header.
 import { fixture as signalObjectSpreadInit } from './signal-object-spread-init'
 import { fixture as signalObjectSpreadInitClient } from './signal-object-spread-init-client'
+// #2862: a signal seeded from a bare identifier naming a module-level const
+// whose value is an array-of-objects / object literal (same family as
+// #2794/#2815, string/numeric/boolean module consts, fixed by PR #2816).
+import { fixture as moduleConstArraySeed } from './module-const-array-seed'
 import { fixture as loopParamShadowsRecordTemplateSpan } from './loop-param-shadows-record-template-span'
 // #2482 audit follow-ups, adapter-side (pinned known limitations):
 // Go condition-position destructured bindings, Go nested-loop `inLoop`
@@ -966,6 +970,7 @@ export const jsxFixtures: JSXFixture[] = [
   mapObjectLiteralBody,
   signalObjectSpreadInit,
   signalObjectSpreadInitClient,
+  moduleConstArraySeed,
   loopParamShadowsRecordTemplateSpan,
   loopDestructuredParamCondition,
   nestedLoopTailContent,

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -512,6 +512,9 @@ import { fixture as signalObjectSpreadInitClient } from './signal-object-spread-
 // whose value is an array-of-objects / object literal (same family as
 // #2794/#2815, string/numeric/boolean module consts, fixed by PR #2816).
 import { fixture as moduleConstArraySeed } from './module-const-array-seed'
+// pullfrog review, PR #2881: the no-explicit-generic sibling, exercising
+// resolveModuleConstAsGo's c.type fallback (target.bakeType.kind === 'unknown').
+import { fixture as moduleConstArraySeedNoGeneric } from './module-const-array-seed-no-generic'
 import { fixture as loopParamShadowsRecordTemplateSpan } from './loop-param-shadows-record-template-span'
 // #2482 audit follow-ups, adapter-side (pinned known limitations):
 // Go condition-position destructured bindings, Go nested-loop `inLoop`
@@ -971,6 +974,7 @@ export const jsxFixtures: JSXFixture[] = [
   signalObjectSpreadInit,
   signalObjectSpreadInitClient,
   moduleConstArraySeed,
+  moduleConstArraySeedNoGeneric,
   loopParamShadowsRecordTemplateSpan,
   loopDestructuredParamCondition,
   nestedLoopTailContent,

--- a/packages/adapter-tests/fixtures/module-const-array-seed-no-generic.ts
+++ b/packages/adapter-tests/fixtures/module-const-array-seed-no-generic.ts
@@ -1,0 +1,50 @@
+import { createFixture } from '../src/types'
+
+/**
+ * #2862 (pullfrog review, PR #2881): the sibling of `module-const-array-seed`
+ * with NO explicit generic on `createSignal` — `const [rows] =
+ * createSignal(INITIAL)` rather than `createSignal<Row[]>(INITIAL)`. The
+ * analyzer's `collectSignal` types a bare-identifier `createSignal()`
+ * argument with no type argument `unknown` (`packages/jsx/src/analyzer.ts`),
+ * so `resolveModuleConstAsGo`'s `target.bakeType.kind !== 'unknown' ?
+ * target.bakeType : (c.type ?? undefined)` fallback — falling back to the
+ * module CONST's own declared type (`c.type`, from `const INITIAL: Row[] =
+ * [...]`) rather than the signal's — is the exact branch exercised here.
+ * `module-const-array-seed` itself always supplies an explicit generic, so
+ * that fallback had no regression coverage before this fixture.
+ */
+export const fixture = createFixture({
+  id: 'module-const-array-seed-no-generic',
+  description: 'Signal seeded from a module-level array const with no explicit createSignal generic bakes its literal value (#2862)',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+
+interface Row {
+  id: number
+  label: string
+}
+
+const INITIAL: Row[] = [
+  { id: 1, label: 'Alpha' },
+  { id: 2, label: 'Bravo' },
+]
+
+export function ModuleConstArraySeedNoGeneric() {
+  const [rows] = createSignal(INITIAL)
+  return (
+    <ul>
+      {rows().map(row => (
+        <li key={row.id}>{row.label}</li>
+      ))}
+    </ul>
+  )
+}
+`,
+  expectedHtml: `
+    <ul bf-s="test" bf="s1">
+      <li data-key="1"><!--bf:s0-->Alpha<!--/--></li>
+      <li data-key="2"><!--bf:s0-->Bravo<!--/--></li>
+    </ul>
+  `,
+})

--- a/packages/adapter-tests/fixtures/module-const-array-seed.ts
+++ b/packages/adapter-tests/fixtures/module-const-array-seed.ts
@@ -1,0 +1,62 @@
+import { createFixture } from '../src/types'
+
+/**
+ * #2862: a signal seeded from a bare identifier referencing a MODULE-LEVEL
+ * const whose value is an array-of-objects literal (and a sibling
+ * object-literal const) — same family as #2794 (string/numeric module
+ * consts) and #2815 (boolean module consts), both fixed by PR #2816, but
+ * neither of those per-type resolvers (nor `convertInitialValue`'s other
+ * typed branches) ever covered an ARRAY or OBJECT literal: `INITIAL`/
+ * `SELECTED` typed `unknown` at the point `createSignal(INITIAL)` is seen
+ * (the analyzer's type inference never chases the identifier to its
+ * declaration), so `convertInitialValue` fell through every typed branch to
+ * `nil` — the generated `NewModuleConstArraySeedProps` constructor emitted
+ * `Rows: nil` and `Selected: Row{}` (the zero-value struct) instead of the
+ * const's actual literal value. Real `go run` SSR rendered an empty `<ul>`
+ * and an empty selected label where Hono (and every other adapter) renders
+ * both rows and the selected label.
+ */
+export const fixture = createFixture({
+  id: 'module-const-array-seed',
+  description: 'Signal seeded from a module-level array/object-literal const bakes its literal value, not nil (#2862)',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+
+interface Row {
+  id: number
+  label: string
+}
+
+const INITIAL: Row[] = [
+  { id: 1, label: 'Alpha' },
+  { id: 2, label: 'Bravo' },
+]
+
+const SELECTED: Row = { id: 1, label: 'Alpha' }
+
+export function ModuleConstArraySeed() {
+  const [rows] = createSignal<Row[]>(INITIAL)
+  const [selected] = createSignal<Row>(SELECTED)
+  return (
+    <div>
+      <p class="selected">{selected().label}</p>
+      <ul>
+        {rows().map(row => (
+          <li key={row.id}>{row.label}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+`,
+  expectedHtml: `
+    <div bf-s="test">
+      <p bf="s1" class="selected"><!--bf:s0-->Alpha<!--/--></p>
+      <ul bf="s3">
+        <li data-key="1"><!--bf:s2-->Alpha<!--/--></li>
+        <li data-key="2"><!--bf:s2-->Bravo<!--/--></li>
+      </ul>
+    </div>
+  `,
+})

--- a/packages/jsx/src/__tests__/binding-scope-ratchet.test.ts
+++ b/packages/jsx/src/__tests__/binding-scope-ratchet.test.ts
@@ -124,7 +124,7 @@ const ALLOWLIST: Record<string, Partial<Record<Pattern, number>>> = {
     // passthrough, called only from `generateNewPropsFunction`'s
     // `emitStaticChildInstances`), `computeDerivedConstFields` and
     // `isStringExpr` (same `generateNewPropsFunction` constructor-context
-    // bucket), and `resolveModuleNumericConst` (guarded in place by
+    // bucket), and `resolveModuleConstAsGo` (guarded in place by
     // `isCurrentLoopItem`/`isOuterLoopParam`, both already `this.scope.lookup`-
     // backed) — 3 are shape-1 (no live scope in the ctor-generation prepass)
     // and 1 is already scope-guarded. The 5th, `renderLoop`'s loop-array

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-conformance section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. This answers, per fixture and per adapter, whether the construct WORKS — not just whether it compiles. A construct works either as written (✓) or with a documented `/* @client */` comment (✓†, a verified, supported escape — most refusals have one). Fixtures absent from the table below work on every adapter — most as written, some via that documented escape; the headline says how many of each. Listed fixtures need attention somewhere: a bare diagnostic code is still-open debt with no escape yet, a code led by ✗ owes no escape at all (by design), and ≠ means the fixture compiles clean but its rendered output diverges from the reference.",
-    "totalFixtures": 384,
+    "totalFixtures": 385,
     "fixtures": {
       "date-method-uncatalogued": {
         "blade": {

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-conformance section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. This answers, per fixture and per adapter, whether the construct WORKS — not just whether it compiles. A construct works either as written (✓) or with a documented `/* @client */` comment (✓†, a verified, supported escape — most refusals have one). Fixtures absent from the table below work on every adapter — most as written, some via that documented escape; the headline says how many of each. Listed fixtures need attention somewhere: a bare diagnostic code is still-open debt with no escape yet, a code led by ✗ owes no escape at all (by design), and ≠ means the fixture compiles clean but its rendered output diverges from the reference.",
-    "totalFixtures": 385,
+    "totalFixtures": 386,
     "fixtures": {
       "date-method-uncatalogued": {
         "blade": {

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -305,7 +305,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 86,
+          "pass": 85,
           "total": 97,
           "gaps": [
             {
@@ -321,6 +321,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-predicate-renamed-prop",
+              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -1267,7 +1271,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 93,
+          "pass": 92,
           "total": 101,
           "gaps": [
             {
@@ -1279,6 +1283,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-predicate-renamed-prop",
+              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -1837,7 +1845,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 245,
+          "pass": 244,
           "total": 260,
           "gaps": [
             {
@@ -1859,6 +1867,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-predicate-renamed-prop",
+              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -2729,7 +2741,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 344,
+          "pass": 343,
           "total": 363,
           "gaps": [
             {
@@ -2751,6 +2763,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-predicate-renamed-prop",
+              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -3381,7 +3397,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 277,
+          "pass": 276,
           "total": 289,
           "gaps": [
             {
@@ -3390,6 +3406,10 @@
             },
             {
               "fixture": "fill-unsupported",
+              "issues": []
+            },
+            {
+              "fixture": "filter-predicate-renamed-prop",
               "issues": []
             },
             {
@@ -4199,7 +4219,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 188,
+          "pass": 187,
           "total": 206,
           "gaps": [
             {
@@ -4221,6 +4241,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-predicate-renamed-prop",
+              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -4595,9 +4619,13 @@
           ]
         },
         "mojolicious": {
-          "pass": 78,
+          "pass": 77,
           "total": 81,
           "gaps": [
+            {
+              "fixture": "filter-predicate-renamed-prop",
+              "issues": []
+            },
             {
               "fixture": "preamble-cells",
               "issues": []
@@ -6873,8 +6901,14 @@
           "total": 10
         },
         "mojolicious": {
-          "pass": 10,
-          "total": 10
+          "pass": 9,
+          "total": 10,
+          "gaps": [
+            {
+              "fixture": "filter-predicate-renamed-prop",
+              "issues": []
+            }
+          ]
         },
         "twig": {
           "pass": 10,
@@ -8008,11 +8042,15 @@
           ]
         },
         "mojolicious": {
-          "pass": 121,
+          "pass": 120,
           "total": 126,
           "gaps": [
             {
               "fixture": "fill-unsupported",
+              "issues": []
+            },
+            {
+              "fixture": "filter-predicate-renamed-prop",
               "issues": []
             },
             {
@@ -8312,7 +8350,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 198,
+          "pass": 197,
           "total": 206,
           "gaps": [
             {
@@ -8321,6 +8359,10 @@
             },
             {
               "fixture": "fill-unsupported",
+              "issues": []
+            },
+            {
+              "fixture": "filter-predicate-renamed-prop",
               "issues": []
             },
             {

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -14,15 +14,15 @@
   ],
   "kinds": {
     "array-literal": {
-      "total": 97,
+      "total": 98,
       "cells": {
         "hono": {
-          "pass": 97,
-          "total": 97
+          "pass": 98,
+          "total": 98
         },
         "blade": {
-          "pass": 85,
-          "total": 97,
+          "pass": 86,
+          "total": 98,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -79,8 +79,8 @@
           ]
         },
         "erb": {
-          "pass": 86,
-          "total": 97,
+          "pass": 87,
+          "total": 98,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -131,8 +131,8 @@
           ]
         },
         "go-template": {
-          "pass": 85,
-          "total": 97,
+          "pass": 86,
+          "total": 98,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -189,8 +189,8 @@
           ]
         },
         "jinja": {
-          "pass": 85,
-          "total": 97,
+          "pass": 86,
+          "total": 98,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -247,8 +247,8 @@
           ]
         },
         "minijinja": {
-          "pass": 85,
-          "total": 97,
+          "pass": 86,
+          "total": 98,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -305,8 +305,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 85,
-          "total": 97,
+          "pass": 86,
+          "total": 98,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -361,8 +361,8 @@
           ]
         },
         "twig": {
-          "pass": 85,
-          "total": 97,
+          "pass": 86,
+          "total": 98,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -419,8 +419,8 @@
           ]
         },
         "xslate": {
-          "pass": 85,
-          "total": 97,
+          "pass": 86,
+          "total": 98,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1426,11 +1426,11 @@
       }
     },
     "call": {
-      "total": 260,
+      "total": 261,
       "cells": {
         "hono": {
-          "pass": 258,
-          "total": 260,
+          "pass": 259,
+          "total": 261,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1445,8 +1445,8 @@
           ]
         },
         "blade": {
-          "pass": 244,
-          "total": 260,
+          "pass": 245,
+          "total": 261,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1525,8 +1525,8 @@
           ]
         },
         "erb": {
-          "pass": 245,
-          "total": 260,
+          "pass": 246,
+          "total": 261,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1599,8 +1599,8 @@
           ]
         },
         "go-template": {
-          "pass": 243,
-          "total": 260,
+          "pass": 244,
+          "total": 261,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1685,8 +1685,8 @@
           ]
         },
         "jinja": {
-          "pass": 244,
-          "total": 260,
+          "pass": 245,
+          "total": 261,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1765,8 +1765,8 @@
           ]
         },
         "minijinja": {
-          "pass": 244,
-          "total": 260,
+          "pass": 245,
+          "total": 261,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1845,8 +1845,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 244,
-          "total": 260,
+          "pass": 245,
+          "total": 261,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1923,8 +1923,8 @@
           ]
         },
         "twig": {
-          "pass": 244,
-          "total": 260,
+          "pass": 245,
+          "total": 261,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2003,8 +2003,8 @@
           ]
         },
         "xslate": {
-          "pass": 244,
-          "total": 260,
+          "pass": 245,
+          "total": 261,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2228,11 +2228,11 @@
       }
     },
     "identifier": {
-      "total": 363,
+      "total": 364,
       "cells": {
         "hono": {
-          "pass": 359,
-          "total": 363,
+          "pass": 360,
+          "total": 364,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2255,8 +2255,8 @@
           ]
         },
         "blade": {
-          "pass": 343,
-          "total": 363,
+          "pass": 344,
+          "total": 364,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2351,8 +2351,8 @@
           ]
         },
         "erb": {
-          "pass": 344,
-          "total": 363,
+          "pass": 345,
+          "total": 364,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2441,8 +2441,8 @@
           ]
         },
         "go-template": {
-          "pass": 341,
-          "total": 363,
+          "pass": 342,
+          "total": 364,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2549,8 +2549,8 @@
           ]
         },
         "jinja": {
-          "pass": 343,
-          "total": 363,
+          "pass": 344,
+          "total": 364,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2645,8 +2645,8 @@
           ]
         },
         "minijinja": {
-          "pass": 343,
-          "total": 363,
+          "pass": 344,
+          "total": 364,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2741,8 +2741,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 343,
-          "total": 363,
+          "pass": 344,
+          "total": 364,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2835,8 +2835,8 @@
           ]
         },
         "twig": {
-          "pass": 343,
-          "total": 363,
+          "pass": 344,
+          "total": 364,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2931,8 +2931,8 @@
           ]
         },
         "xslate": {
-          "pass": 343,
-          "total": 363,
+          "pass": 344,
+          "total": 364,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3092,11 +3092,11 @@
       }
     },
     "literal": {
-      "total": 289,
+      "total": 290,
       "cells": {
         "hono": {
-          "pass": 288,
-          "total": 289,
+          "pass": 289,
+          "total": 290,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -3105,8 +3105,8 @@
           ]
         },
         "blade": {
-          "pass": 277,
-          "total": 289,
+          "pass": 278,
+          "total": 290,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3161,8 +3161,8 @@
           ]
         },
         "erb": {
-          "pass": 277,
-          "total": 289,
+          "pass": 278,
+          "total": 290,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3217,8 +3217,8 @@
           ]
         },
         "go-template": {
-          "pass": 275,
-          "total": 289,
+          "pass": 276,
+          "total": 290,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3285,8 +3285,8 @@
           ]
         },
         "jinja": {
-          "pass": 277,
-          "total": 289,
+          "pass": 278,
+          "total": 290,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3341,8 +3341,8 @@
           ]
         },
         "minijinja": {
-          "pass": 277,
-          "total": 289,
+          "pass": 278,
+          "total": 290,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3397,8 +3397,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 276,
-          "total": 289,
+          "pass": 277,
+          "total": 290,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3457,8 +3457,8 @@
           ]
         },
         "twig": {
-          "pass": 277,
-          "total": 289,
+          "pass": 278,
+          "total": 290,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3513,8 +3513,8 @@
           ]
         },
         "xslate": {
-          "pass": 277,
-          "total": 289,
+          "pass": 278,
+          "total": 290,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3730,11 +3730,11 @@
       }
     },
     "member": {
-      "total": 206,
+      "total": 207,
       "cells": {
         "hono": {
-          "pass": 203,
-          "total": 206,
+          "pass": 204,
+          "total": 207,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3753,8 +3753,8 @@
           ]
         },
         "blade": {
-          "pass": 187,
-          "total": 206,
+          "pass": 188,
+          "total": 207,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3845,8 +3845,8 @@
           ]
         },
         "erb": {
-          "pass": 188,
-          "total": 206,
+          "pass": 189,
+          "total": 207,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3931,8 +3931,8 @@
           ]
         },
         "go-template": {
-          "pass": 185,
-          "total": 206,
+          "pass": 186,
+          "total": 207,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4035,8 +4035,8 @@
           ]
         },
         "jinja": {
-          "pass": 187,
-          "total": 206,
+          "pass": 188,
+          "total": 207,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4127,8 +4127,8 @@
           ]
         },
         "minijinja": {
-          "pass": 187,
-          "total": 206,
+          "pass": 188,
+          "total": 207,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4219,8 +4219,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 187,
-          "total": 206,
+          "pass": 188,
+          "total": 207,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4309,8 +4309,8 @@
           ]
         },
         "twig": {
-          "pass": 187,
-          "total": 206,
+          "pass": 188,
+          "total": 207,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4401,8 +4401,8 @@
           ]
         },
         "xslate": {
-          "pass": 187,
-          "total": 206,
+          "pass": 188,
+          "total": 207,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4506,15 +4506,15 @@
       }
     },
     "object-literal": {
-      "total": 81,
+      "total": 82,
       "cells": {
         "hono": {
-          "pass": 81,
-          "total": 81
+          "pass": 82,
+          "total": 82
         },
         "blade": {
-          "pass": 78,
-          "total": 81,
+          "pass": 79,
+          "total": 82,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4533,8 +4533,8 @@
           ]
         },
         "erb": {
-          "pass": 78,
-          "total": 81,
+          "pass": 79,
+          "total": 82,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4553,8 +4553,8 @@
           ]
         },
         "go-template": {
-          "pass": 77,
-          "total": 81,
+          "pass": 78,
+          "total": 82,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4579,8 +4579,8 @@
           ]
         },
         "jinja": {
-          "pass": 78,
-          "total": 81,
+          "pass": 79,
+          "total": 82,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4599,8 +4599,8 @@
           ]
         },
         "minijinja": {
-          "pass": 78,
-          "total": 81,
+          "pass": 79,
+          "total": 82,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4619,8 +4619,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 77,
-          "total": 81,
+          "pass": 78,
+          "total": 82,
           "gaps": [
             {
               "fixture": "filter-predicate-renamed-prop",
@@ -4643,8 +4643,8 @@
           ]
         },
         "twig": {
-          "pass": 78,
-          "total": 81,
+          "pass": 79,
+          "total": 82,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4663,8 +4663,8 @@
           ]
         },
         "xslate": {
-          "pass": 78,
-          "total": 81,
+          "pass": 79,
+          "total": 82,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -7905,15 +7905,15 @@
       }
     },
     "literal:number": {
-      "total": 126,
+      "total": 127,
       "cells": {
         "hono": {
-          "pass": 126,
-          "total": 126
+          "pass": 127,
+          "total": 127
         },
         "blade": {
-          "pass": 121,
-          "total": 126,
+          "pass": 122,
+          "total": 127,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7938,8 +7938,8 @@
           ]
         },
         "erb": {
-          "pass": 121,
-          "total": 126,
+          "pass": 122,
+          "total": 127,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7964,8 +7964,8 @@
           ]
         },
         "go-template": {
-          "pass": 121,
-          "total": 126,
+          "pass": 122,
+          "total": 127,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7990,8 +7990,8 @@
           ]
         },
         "jinja": {
-          "pass": 121,
-          "total": 126,
+          "pass": 122,
+          "total": 127,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8016,8 +8016,8 @@
           ]
         },
         "minijinja": {
-          "pass": 121,
-          "total": 126,
+          "pass": 122,
+          "total": 127,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8042,8 +8042,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 120,
-          "total": 126,
+          "pass": 121,
+          "total": 127,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8072,8 +8072,8 @@
           ]
         },
         "twig": {
-          "pass": 121,
-          "total": 126,
+          "pass": 122,
+          "total": 127,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8098,8 +8098,8 @@
           ]
         },
         "xslate": {
-          "pass": 121,
-          "total": 126,
+          "pass": 122,
+          "total": 127,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8137,15 +8137,15 @@
       }
     },
     "literal:string": {
-      "total": 206,
+      "total": 207,
       "cells": {
         "hono": {
-          "pass": 206,
-          "total": 206
+          "pass": 207,
+          "total": 207
         },
         "blade": {
-          "pass": 198,
-          "total": 206,
+          "pass": 199,
+          "total": 207,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8184,8 +8184,8 @@
           ]
         },
         "erb": {
-          "pass": 198,
-          "total": 206,
+          "pass": 199,
+          "total": 207,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8224,8 +8224,8 @@
           ]
         },
         "go-template": {
-          "pass": 197,
-          "total": 206,
+          "pass": 198,
+          "total": 207,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8270,8 +8270,8 @@
           ]
         },
         "jinja": {
-          "pass": 198,
-          "total": 206,
+          "pass": 199,
+          "total": 207,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8310,8 +8310,8 @@
           ]
         },
         "minijinja": {
-          "pass": 198,
-          "total": 206,
+          "pass": 199,
+          "total": 207,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8350,8 +8350,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 197,
-          "total": 206,
+          "pass": 198,
+          "total": 207,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8394,8 +8394,8 @@
           ]
         },
         "twig": {
-          "pass": 198,
-          "total": 206,
+          "pass": 199,
+          "total": 207,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8434,8 +8434,8 @@
           ]
         },
         "xslate": {
-          "pass": 198,
-          "total": 206,
+          "pass": 199,
+          "total": 207,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -14,15 +14,15 @@
   ],
   "kinds": {
     "array-literal": {
-      "total": 96,
+      "total": 97,
       "cells": {
         "hono": {
-          "pass": 96,
-          "total": 96
+          "pass": 97,
+          "total": 97
         },
         "blade": {
-          "pass": 84,
-          "total": 96,
+          "pass": 85,
+          "total": 97,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -79,8 +79,8 @@
           ]
         },
         "erb": {
-          "pass": 85,
-          "total": 96,
+          "pass": 86,
+          "total": 97,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -131,8 +131,8 @@
           ]
         },
         "go-template": {
-          "pass": 84,
-          "total": 96,
+          "pass": 85,
+          "total": 97,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -189,8 +189,8 @@
           ]
         },
         "jinja": {
-          "pass": 84,
-          "total": 96,
+          "pass": 85,
+          "total": 97,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -247,8 +247,8 @@
           ]
         },
         "minijinja": {
-          "pass": 84,
-          "total": 96,
+          "pass": 85,
+          "total": 97,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -305,8 +305,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 85,
-          "total": 96,
+          "pass": 86,
+          "total": 97,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -357,8 +357,8 @@
           ]
         },
         "twig": {
-          "pass": 84,
-          "total": 96,
+          "pass": 85,
+          "total": 97,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -415,8 +415,8 @@
           ]
         },
         "xslate": {
-          "pass": 84,
-          "total": 96,
+          "pass": 85,
+          "total": 97,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1418,11 +1418,11 @@
       }
     },
     "call": {
-      "total": 259,
+      "total": 260,
       "cells": {
         "hono": {
-          "pass": 257,
-          "total": 259,
+          "pass": 258,
+          "total": 260,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1437,8 +1437,8 @@
           ]
         },
         "blade": {
-          "pass": 243,
-          "total": 259,
+          "pass": 244,
+          "total": 260,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1517,8 +1517,8 @@
           ]
         },
         "erb": {
-          "pass": 244,
-          "total": 259,
+          "pass": 245,
+          "total": 260,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1591,8 +1591,8 @@
           ]
         },
         "go-template": {
-          "pass": 242,
-          "total": 259,
+          "pass": 243,
+          "total": 260,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1677,8 +1677,8 @@
           ]
         },
         "jinja": {
-          "pass": 243,
-          "total": 259,
+          "pass": 244,
+          "total": 260,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1757,8 +1757,8 @@
           ]
         },
         "minijinja": {
-          "pass": 243,
-          "total": 259,
+          "pass": 244,
+          "total": 260,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1837,8 +1837,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 244,
-          "total": 259,
+          "pass": 245,
+          "total": 260,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1911,8 +1911,8 @@
           ]
         },
         "twig": {
-          "pass": 243,
-          "total": 259,
+          "pass": 244,
+          "total": 260,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1991,8 +1991,8 @@
           ]
         },
         "xslate": {
-          "pass": 243,
-          "total": 259,
+          "pass": 244,
+          "total": 260,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2216,11 +2216,11 @@
       }
     },
     "identifier": {
-      "total": 362,
+      "total": 363,
       "cells": {
         "hono": {
-          "pass": 358,
-          "total": 362,
+          "pass": 359,
+          "total": 363,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2243,8 +2243,8 @@
           ]
         },
         "blade": {
-          "pass": 342,
-          "total": 362,
+          "pass": 343,
+          "total": 363,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2339,8 +2339,8 @@
           ]
         },
         "erb": {
-          "pass": 343,
-          "total": 362,
+          "pass": 344,
+          "total": 363,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2429,8 +2429,8 @@
           ]
         },
         "go-template": {
-          "pass": 340,
-          "total": 362,
+          "pass": 341,
+          "total": 363,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2537,8 +2537,8 @@
           ]
         },
         "jinja": {
-          "pass": 342,
-          "total": 362,
+          "pass": 343,
+          "total": 363,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2633,8 +2633,8 @@
           ]
         },
         "minijinja": {
-          "pass": 342,
-          "total": 362,
+          "pass": 343,
+          "total": 363,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2729,8 +2729,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 343,
-          "total": 362,
+          "pass": 344,
+          "total": 363,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2819,8 +2819,8 @@
           ]
         },
         "twig": {
-          "pass": 342,
-          "total": 362,
+          "pass": 343,
+          "total": 363,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2915,8 +2915,8 @@
           ]
         },
         "xslate": {
-          "pass": 342,
-          "total": 362,
+          "pass": 343,
+          "total": 363,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3076,11 +3076,11 @@
       }
     },
     "literal": {
-      "total": 288,
+      "total": 289,
       "cells": {
         "hono": {
-          "pass": 287,
-          "total": 288,
+          "pass": 288,
+          "total": 289,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -3089,8 +3089,8 @@
           ]
         },
         "blade": {
-          "pass": 276,
-          "total": 288,
+          "pass": 277,
+          "total": 289,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3145,8 +3145,8 @@
           ]
         },
         "erb": {
-          "pass": 276,
-          "total": 288,
+          "pass": 277,
+          "total": 289,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3201,8 +3201,8 @@
           ]
         },
         "go-template": {
-          "pass": 274,
-          "total": 288,
+          "pass": 275,
+          "total": 289,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3269,8 +3269,8 @@
           ]
         },
         "jinja": {
-          "pass": 276,
-          "total": 288,
+          "pass": 277,
+          "total": 289,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3325,8 +3325,8 @@
           ]
         },
         "minijinja": {
-          "pass": 276,
-          "total": 288,
+          "pass": 277,
+          "total": 289,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3381,8 +3381,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 276,
-          "total": 288,
+          "pass": 277,
+          "total": 289,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3437,8 +3437,8 @@
           ]
         },
         "twig": {
-          "pass": 276,
-          "total": 288,
+          "pass": 277,
+          "total": 289,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3493,8 +3493,8 @@
           ]
         },
         "xslate": {
-          "pass": 276,
-          "total": 288,
+          "pass": 277,
+          "total": 289,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3710,11 +3710,11 @@
       }
     },
     "member": {
-      "total": 205,
+      "total": 206,
       "cells": {
         "hono": {
-          "pass": 202,
-          "total": 205,
+          "pass": 203,
+          "total": 206,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3733,8 +3733,8 @@
           ]
         },
         "blade": {
-          "pass": 186,
-          "total": 205,
+          "pass": 187,
+          "total": 206,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3825,8 +3825,8 @@
           ]
         },
         "erb": {
-          "pass": 187,
-          "total": 205,
+          "pass": 188,
+          "total": 206,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3911,8 +3911,8 @@
           ]
         },
         "go-template": {
-          "pass": 184,
-          "total": 205,
+          "pass": 185,
+          "total": 206,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4015,8 +4015,8 @@
           ]
         },
         "jinja": {
-          "pass": 186,
-          "total": 205,
+          "pass": 187,
+          "total": 206,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4107,8 +4107,8 @@
           ]
         },
         "minijinja": {
-          "pass": 186,
-          "total": 205,
+          "pass": 187,
+          "total": 206,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4199,8 +4199,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 187,
-          "total": 205,
+          "pass": 188,
+          "total": 206,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4285,8 +4285,8 @@
           ]
         },
         "twig": {
-          "pass": 186,
-          "total": 205,
+          "pass": 187,
+          "total": 206,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4377,8 +4377,8 @@
           ]
         },
         "xslate": {
-          "pass": 186,
-          "total": 205,
+          "pass": 187,
+          "total": 206,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4482,15 +4482,15 @@
       }
     },
     "object-literal": {
-      "total": 80,
+      "total": 81,
       "cells": {
         "hono": {
-          "pass": 80,
-          "total": 80
+          "pass": 81,
+          "total": 81
         },
         "blade": {
-          "pass": 77,
-          "total": 80,
+          "pass": 78,
+          "total": 81,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4509,8 +4509,8 @@
           ]
         },
         "erb": {
-          "pass": 77,
-          "total": 80,
+          "pass": 78,
+          "total": 81,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4529,8 +4529,8 @@
           ]
         },
         "go-template": {
-          "pass": 76,
-          "total": 80,
+          "pass": 77,
+          "total": 81,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4555,8 +4555,8 @@
           ]
         },
         "jinja": {
-          "pass": 77,
-          "total": 80,
+          "pass": 78,
+          "total": 81,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4575,8 +4575,8 @@
           ]
         },
         "minijinja": {
-          "pass": 77,
-          "total": 80,
+          "pass": 78,
+          "total": 81,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4595,8 +4595,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 77,
-          "total": 80,
+          "pass": 78,
+          "total": 81,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4615,8 +4615,8 @@
           ]
         },
         "twig": {
-          "pass": 77,
-          "total": 80,
+          "pass": 78,
+          "total": 81,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4635,8 +4635,8 @@
           ]
         },
         "xslate": {
-          "pass": 77,
-          "total": 80,
+          "pass": 78,
+          "total": 81,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -7871,15 +7871,15 @@
       }
     },
     "literal:number": {
-      "total": 125,
+      "total": 126,
       "cells": {
         "hono": {
-          "pass": 125,
-          "total": 125
+          "pass": 126,
+          "total": 126
         },
         "blade": {
-          "pass": 120,
-          "total": 125,
+          "pass": 121,
+          "total": 126,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7904,8 +7904,8 @@
           ]
         },
         "erb": {
-          "pass": 120,
-          "total": 125,
+          "pass": 121,
+          "total": 126,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7930,8 +7930,8 @@
           ]
         },
         "go-template": {
-          "pass": 120,
-          "total": 125,
+          "pass": 121,
+          "total": 126,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7956,8 +7956,8 @@
           ]
         },
         "jinja": {
-          "pass": 120,
-          "total": 125,
+          "pass": 121,
+          "total": 126,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7982,8 +7982,8 @@
           ]
         },
         "minijinja": {
-          "pass": 120,
-          "total": 125,
+          "pass": 121,
+          "total": 126,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8008,8 +8008,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 120,
-          "total": 125,
+          "pass": 121,
+          "total": 126,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8034,8 +8034,8 @@
           ]
         },
         "twig": {
-          "pass": 120,
-          "total": 125,
+          "pass": 121,
+          "total": 126,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8060,8 +8060,8 @@
           ]
         },
         "xslate": {
-          "pass": 120,
-          "total": 125,
+          "pass": 121,
+          "total": 126,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8099,15 +8099,15 @@
       }
     },
     "literal:string": {
-      "total": 205,
+      "total": 206,
       "cells": {
         "hono": {
-          "pass": 205,
-          "total": 205
+          "pass": 206,
+          "total": 206
         },
         "blade": {
-          "pass": 197,
-          "total": 205,
+          "pass": 198,
+          "total": 206,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8146,8 +8146,8 @@
           ]
         },
         "erb": {
-          "pass": 197,
-          "total": 205,
+          "pass": 198,
+          "total": 206,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8186,8 +8186,8 @@
           ]
         },
         "go-template": {
-          "pass": 196,
-          "total": 205,
+          "pass": 197,
+          "total": 206,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8232,8 +8232,8 @@
           ]
         },
         "jinja": {
-          "pass": 197,
-          "total": 205,
+          "pass": 198,
+          "total": 206,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8272,8 +8272,8 @@
           ]
         },
         "minijinja": {
-          "pass": 197,
-          "total": 205,
+          "pass": 198,
+          "total": 206,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8312,8 +8312,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 197,
-          "total": 205,
+          "pass": 198,
+          "total": 206,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8352,8 +8352,8 @@
           ]
         },
         "twig": {
-          "pass": 197,
-          "total": 205,
+          "pass": 198,
+          "total": 206,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8392,8 +8392,8 @@
           ]
         },
         "xslate": {
-          "pass": 197,
-          "total": 205,
+          "pass": 198,
+          "total": 206,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",


### PR DESCRIPTION
Stacked on #2880 (#2857's fix). Fixes #2862.

## Summary

Same family as #2794 (string/numeric module consts) and #2815 (boolean module consts), both fixed by PR #2816: a signal seeded from a bare identifier referencing a module-level const whose value is an **array or object literal** (`const INITIAL: Row[] = [...]; createSignal(INITIAL)`) still baked to `nil` (or the struct zero value, for a scalar object const) in the generated `New<Component>Props` constructor. Neither #2816's string/numeric resolver nor its follow-on boolean resolver covered this shape — `convertInitialValue` (`packages/adapter-go-template/src/adapter/value/value-lowering.ts`) still fell through every typed branch to `return 'nil'`.

Real `go run` SSR rendered an empty `<ul>` (zero rows) where Hono (and every other adapter) renders every row.

## Fix

Per #2862's own note ("a third copy-pasted per-type resolver would make it three"): generalized `resolveModuleStringConst`'s numeric/boolean siblings into one structural resolver, `resolveModuleConstAsGo`, dispatched off the const's `ConstantInfo.parsed` tree — through the same `parsedLiteralToGo` door an inline `createSignal([...])`/`createSignal({...})` seed already takes, since the VALUE shape is identical and only the identifier indirection differs.

- `resolveModuleNumericConst` and `resolveModuleBooleanConst` (both purely text-matching) are deleted; `resolveModuleConstAsGo(name, target)` replaces both, plus the array/object-literal gap.
- `target.kind === 'go-source'` (the constructor) may bake a composite literal against `target.bakeType`, falling back to the const's own declared type when the consumer's type is `unknown` (the analyzer never chases a bare `createSignal(INITIAL)` seed to its declaration).
- `target.kind === 'template-action'` (a bare `{{...}}` splice) only resolves a scalar — a composite literal has no valid Go template spelling there.
- `resolveModuleStringConst` itself is unchanged: its fixed-point text resolution also covers a composed template-literal const that has no single structural literal to bake.

## Testing

Added `module-const-array-seed`, a conformance fixture with both an array-of-objects module const and a scalar object-literal module const, verified against real `go run` (Go 1.25.6):
- **Without** the fix: renders `<ul></ul>` and an empty `<p class="selected">` (reproducing the issue's reported empty list exactly).
- **With** the fix: matches the Hono reference (both rows, populated label).

Full `packages/adapter-go-template` test suite (1980 tests, real `go run` conformance): 1904 pass, 25 skip, 51 fail — the same 51 pre-existing, unrelated sandbox environment failures noted in #2880 (missing `@barefootjs/client` module in Hono's `client-shim.ts`, affecting `format-date`/`query-href` oracle fixtures).

Regenerated `packages/adapter-tests/coverage-map.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HeZLEug6a9R9U2EHNTwWJK

---
_Generated by [Claude Code](https://claude.ai/code/session_01HeZLEug6a9R9U2EHNTwWJK)_