### PR TITLE
Collapse ui/support-matrix.lock.json in GitHub PR diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,11 @@
 # when the compiler changes, the snapshot diff is the review signal
 # (expected output change vs regression), so it must stay expandable.
 packages/adapter-tests/fixtures/__snapshots__/** linguist-generated=true
+
+# `ui/support-matrix.lock.json` (support-matrix-cli.ts): the per-adapter
+# capability matrix, mechanically regenerated from the full fixture corpus.
+# Nearly every fixture addition/removal reshuffles pass/total counts across
+# every adapter cell, so the diff is thousands of lines of noise rather than
+# a review signal — collapse it by default in PR diffs (still expandable,
+# and kept out of language stats).
+ui/support-matrix.lock.json linguist-generated=true


### PR DESCRIPTION
## Summary

`ui/support-matrix.lock.json` is a mechanically regenerated report (`bun run support-matrix:lock`) — the per-adapter capability matrix computed from the full fixture corpus. It's currently 9,700+ lines, and nearly every fixture addition/removal reshuffles pass/total counts across every adapter cell, so its PR diffs are thousands of lines of noise rather than a useful review signal.

## Change

Mark it `linguist-generated=true` in `.gitattributes`, matching the existing convention for the fixture-hydrate snapshot corpus (`packages/adapter-tests/fixtures/__snapshots__/**`). This collapses the file by default in GitHub's PR diff view — still expandable on demand ("Load diff") — and excludes it from GitHub's language statistics. No functional/build change.

## Testing

N/A — `.gitattributes`-only change, no code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HeZLEug6a9R9U2EHNTwWJK

---
_Generated by [Claude Code](https://claude.ai/code/session_01HeZLEug6a9R9U2EHNTwWJK)_