### PR TITLE
Fix #2879: filter predicate props.x member reference panics html/template

### DIFF
--- a/.changeset/go-filter-predicate-props-member-2879.md
+++ b/.changeset/go-filter-predicate-props-member-2879.md
@@ -1,0 +1,9 @@
+---
+"@barefootjs/go-template": patch
+---
+
+Fix #2879: a `.filter()`/`.find()`/etc. predicate reading a bare-props-form prop DIRECTLY as a member access (`props.hiddenId`, no local destructure) compiled to a Go template that panicked at render time (`can't evaluate field Props in type ...`) instead of rendering. `renderFilterExprNode`'s `member` arm had no `propsObjectName` branch — unlike its sibling `renderConditionExpr`, which already flattens `props.x` onto the correct root-scope field — so `props.hiddenId` fell through to the generic "nested member access" recursion, which rendered `props` itself as an ordinary root-scope identifier (`$.Props`) and appended `.HiddenId`, reaching for a field the flattened Props struct never has (the real field is `$.HiddenId`).
+
+Fixed by mirroring `renderConditionExpr`'s `propsObjectName` branch in `renderFilterExprNode`'s `member` arm. Also extracted a shared `filterRootFieldRef` helper (the unconditional-`$.`-prefix + alias-resolution pattern already duplicated three times in this method for the `identifier`/signal/`call` cases, #2857) so the new branch reuses it rather than adding a fourth copy.
+
+The same gap exists in every other DSL adapter's filter `member()` emitter (mojolicious, erb, jinja, twig, blade, xslate, rust) — tracked separately as #2886 and pinned per-adapter in each `render-divergences.ts` against the new shared `filter-predicate-props-member` conformance fixture.

--- a/packages/adapter-blade/src/render-divergences.ts
+++ b/packages/adapter-blade/src/render-divergences.ts
@@ -15,4 +15,12 @@ import type { RenderDivergences } from '@barefootjs/jsx'
 // at value position and the runtime evaluator's `object-literal` case
 // now merges it, so the seed classifies `derived` and SSRs identically
 // to Hono.
-export const renderDivergences: RenderDivergences = {}
+export const renderDivergences: RenderDivergences = {
+  // #2886: the filter `member()` emitter has no `props.x` flattening,
+  // unlike its non-filter sibling — a bare-props-form prop read DIRECTLY
+  // (no destructure, `props.hiddenId`) inside a `.filter()` predicate
+  // emits `data_get($props, 'hiddenId')`, and `$props` is undefined. Added
+  // for #2879's Go Template adapter fix, but this fixture is a shared
+  // cross-adapter conformance fixture, not Go-specific.
+  'filter-predicate-props-member': 'https://github.com/piconic-ai/barefootjs/issues/2886',
+}

--- a/packages/adapter-erb/src/render-divergences.ts
+++ b/packages/adapter-erb/src/render-divergences.ts
@@ -15,4 +15,13 @@ import type { RenderDivergences } from '@barefootjs/jsx'
 // at value position and the runtime evaluator's `object-literal` case
 // now merges it, so the seed classifies `derived` and SSRs identically
 // to Hono.
-export const renderDivergences: RenderDivergences = {}
+export const renderDivergences: RenderDivergences = {
+  // #2886: the filter `member()` emitter (expr/emitters.ts:166) has no
+  // `props.x` flattening, unlike its non-filter sibling `member()` a few
+  // hundred lines below (expr/emitters.ts:413-414) — a bare-props-form prop
+  // read DIRECTLY (no destructure, `props.hiddenId`) inside a `.filter()`
+  // predicate emits `v[:props][:hiddenId]`, and `v[:props]` is `nil` →
+  // `NoMethodError`. Added for #2879's Go Template adapter fix, but this
+  // fixture is a shared cross-adapter conformance fixture, not Go-specific.
+  'filter-predicate-props-member': 'https://github.com/piconic-ai/barefootjs/issues/2886',
+}

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -4889,6 +4889,19 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   }
 
   /**
+   * Root-scope field reference from INSIDE a `.filter()`/`.find()` predicate
+   * (#2857, #2879). Same registration + alias resolution as `rootFieldRef`,
+   * but the `$.` prefix is unconditional: a filter predicate's `{{if}}`
+   * always sits inside its loop's own `{{range}}` (`renderLoop` restores
+   * `this.inLoop` before rendering it), so a bare `.Field` would resolve
+   * against the current row's type instead of root.
+   */
+  private filterRootFieldRef(name: string): string {
+    this.rootFieldRef(name)
+    return `$.${capitalizeFieldName(this.resolveRootFieldAlias(name))}`
+  }
+
+  /**
    * When `name` is a local binding of the `searchParams()` env signal, resolve
    * it to the canonical `.SearchParams` field — not `.<Capitalized name>` — so
    * an aliased `import { searchParams as sp }` (`sp()`) reaches the same struct
@@ -6232,8 +6245,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
           // `resolveRootFieldAlias` (#2857) so a getter-alias local
           // (`const items__alias = items`) still emits the field the
           // signal itself seeds instead of a phantom `.Items__alias`.
-          this.rootFieldRef(signal)
-          return `$.${capitalizeFieldName(this.resolveRootFieldAlias(signal))}`
+          return this.filterRootFieldRef(signal)
         }
         // Any other identifier reaching here is ALSO a root-scope
         // reference (a memo, a plain derived const, or — #2857 — a
@@ -6250,8 +6262,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         // root, and `html/template` panics at execute time (`can't
         // evaluate field ... in type ...`) the first time such a
         // reference is exercised.
-        this.rootFieldRef(expr.name)
-        return `$.${capitalizeFieldName(this.resolveRootFieldAlias(expr.name))}`
+        return this.filterRootFieldRef(expr.name)
       }
 
       case 'literal':
@@ -6267,6 +6278,18 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         // t.done -> .Done (or .Todo.Done under a wrapper struct, #2228)
         if (expr.object.kind === 'identifier' && expr.object.name === param) {
           return `${paramPrefix}.${capitalizeFieldName(expr.property)}`
+        }
+        // props.x on a bare-props-form component (#2879): props are
+        // flattened onto the root struct, so this is a root-scope read
+        // (`$.X`), not `.Props.X`. Mirrors `renderConditionExpr`'s own
+        // `propsObjectName` branch; `props.a.b` still reaches root through
+        // the generic recursion below.
+        if (
+          expr.object.kind === 'identifier' &&
+          this.state.propsObjectName &&
+          expr.object.name === this.state.propsObjectName
+        ) {
+          return this.filterRootFieldRef(expr.property)
         }
         // `.length` on a higher-order filter result (e.g.
         // `x.tags.filter(t => t.active).length > 0`). Reuse
@@ -6300,8 +6323,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         // resolution (#2857) — as the `identifier` case above, for the same
         // reason (#2700's BF101 gate; pullfrog review, PR #2818).
         if (expr.callee.kind === 'identifier' && expr.args.length === 0) {
-          this.rootFieldRef(expr.callee.name)
-          return `$.${capitalizeFieldName(this.resolveRootFieldAlias(expr.callee.name))}`
+          return this.filterRootFieldRef(expr.callee.name)
         }
         // A nested callback method call (`other.some(r => …)`) reaching this
         // arm has no Go template form in filter context — the fallthrough

--- a/packages/adapter-jinja/src/render-divergences.ts
+++ b/packages/adapter-jinja/src/render-divergences.ts
@@ -15,4 +15,12 @@ import type { RenderDivergences } from '@barefootjs/jsx'
 // at value position and the runtime evaluator's `object-literal` case
 // now merges it, so the seed classifies `derived` and SSRs identically
 // to Hono.
-export const renderDivergences: RenderDivergences = {}
+export const renderDivergences: RenderDivergences = {
+  // #2886: the filter `member()` emitter has no `props.x` flattening,
+  // unlike its non-filter sibling — a bare-props-form prop read DIRECTLY
+  // (no destructure, `props.hiddenId`) inside a `.filter()` predicate
+  // emits `props['hiddenId']`, and `props` is undefined. Added for #2879's
+  // Go Template adapter fix, but this fixture is a shared cross-adapter
+  // conformance fixture, not Go-specific.
+  'filter-predicate-props-member': 'https://github.com/piconic-ai/barefootjs/issues/2886',
+}

--- a/packages/adapter-mojolicious/src/render-divergences.ts
+++ b/packages/adapter-mojolicious/src/render-divergences.ts
@@ -26,4 +26,13 @@ export const renderDivergences: RenderDivergences = {
   // #2857's Go Template adapter fix that this fixture was added for — this
   // fixture is a shared cross-adapter conformance fixture, not Go-specific.
   'filter-predicate-renamed-prop': 'https://github.com/piconic-ai/barefootjs/issues/2883',
+  // #2886: `MojoFilterEmitter.member()` (expr/emitters.ts) has no `props.x`
+  // flattening, unlike its non-filter sibling `member()` a few hundred
+  // lines below — a bare-props-form prop read DIRECTLY (no destructure,
+  // `props.hiddenId`) inside a `.filter()` predicate emits `$props->{...}`,
+  // a Perl variable never declared under `use strict`. Same family as
+  // #2879's Go Template adapter fix that this fixture was added for, but
+  // this fixture is a shared cross-adapter conformance fixture, not
+  // Go-specific.
+  'filter-predicate-props-member': 'https://github.com/piconic-ai/barefootjs/issues/2886',
 }

--- a/packages/adapter-rust/src/render-divergences.ts
+++ b/packages/adapter-rust/src/render-divergences.ts
@@ -17,4 +17,12 @@ import type { RenderDivergences } from '@barefootjs/jsx'
 // at value position and the runtime evaluator's `object-literal` case
 // now merges it, so the seed classifies `derived` and SSRs identically
 // to Hono.
-export const renderDivergences: RenderDivergences = {}
+export const renderDivergences: RenderDivergences = {
+  // #2886: the filter `member()` emitter has no `props.x` flattening,
+  // unlike its non-filter sibling — a bare-props-form prop read DIRECTLY
+  // (no destructure, `props.hiddenId`) inside a `.filter()` predicate
+  // emits `props.hiddenId`, and `props` is undefined. Added for #2879's Go
+  // Template adapter fix, but this fixture is a shared cross-adapter
+  // conformance fixture, not Go-specific.
+  'filter-predicate-props-member': 'https://github.com/piconic-ai/barefootjs/issues/2886',
+}

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -2392,6 +2392,22 @@
         "text"
       ]
     },
+    "filter-predicate-props-member": {
+      "kinds": [
+        "binary",
+        "call",
+        "identifier",
+        "member"
+      ],
+      "axes": [
+        "binary:!=="
+      ],
+      "contexts": [
+        "attribute",
+        "loop",
+        "text"
+      ]
+    },
     "filter-predicate-renamed-prop": {
       "kinds": [
         "array-literal",
@@ -6252,14 +6268,14 @@
     "array-literal": 99,
     "array-method": 71,
     "arrow": 72,
-    "binary": 102,
-    "call": 263,
+    "binary": 103,
+    "call": 264,
     "conditional": 31,
-    "identifier": 366,
+    "identifier": 367,
     "index-access": 14,
     "literal": 292,
     "logical": 49,
-    "member": 208,
+    "member": 209,
     "object-literal": 83,
     "template-literal": 31,
     "unary": 27,
@@ -6291,7 +6307,7 @@
     "array-method:trimEnd": 1,
     "array-method:trimStart": 1,
     "binary:!=": 2,
-    "binary:!==": 10,
+    "binary:!==": 11,
     "binary:%": 1,
     "binary:*": 12,
     "binary:+": 23,

--- a/packages/adapter-tests/fixtures/filter-predicate-props-member.ts
+++ b/packages/adapter-tests/fixtures/filter-predicate-props-member.ts
@@ -1,0 +1,46 @@
+import { createFixture } from '../src/types'
+
+/**
+ * #2879: a `.filter()` predicate that reads a bare-props-form prop DIRECTLY
+ * as a member access (`props.hiddenId`, no destructure) rather than through
+ * a local alias (the #2857 family).
+ *
+ * `renderFilterExprNode`'s `member` arm had no `propsObjectName` branch
+ * (unlike its sibling `renderConditionExpr`), so `props.hiddenId` fell
+ * through to the generic "nested member access" recursion: the `object`
+ * (`props`) rendered via the `identifier` arm's root-scope fallback with
+ * the literal name `props`, emitting `$.Props.HiddenId` — a field the
+ * flattened Props struct never has (the real field is `$.HiddenId`) — so
+ * `html/template` panicked at execute time.
+ */
+export const fixture = createFixture({
+  id: 'filter-predicate-props-member',
+  description: '.filter() predicate reading props.x directly on a bare-props-form component (#2879)',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+
+type Item = { id: number; label: string }
+
+export function FilterPredicatePropsMember(props: { items: Item[]; hiddenId: number }) {
+  const [items] = createSignal<Item[]>(props.items)
+  return (
+    <ul>
+      {items().filter(it => it.id !== props.hiddenId).map(it => (
+        <li key={it.id}>{it.label}</li>
+      ))}
+    </ul>
+  )
+}
+`,
+  props: {
+    items: [
+      { id: 1, label: 'Alpha' },
+      { id: 2, label: 'Beta' },
+    ],
+    hiddenId: 1,
+  },
+  expectedHtml: `
+    <ul bf-s="test" bf="s1"><li data-key="2"><!--bf:s0-->Beta<!--/--></li></ul>
+  `,
+})

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -139,6 +139,7 @@ import { fixture as filterNestedFindPredicate } from './filter-nested-find-predi
 import { fixture as filterNestedFindPredicateClient } from './filter-nested-find-predicate-client'
 import { fixture as filterPredicateSignalAlias } from './filter-predicate-signal-alias'
 import { fixture as filterPredicateRenamedProp } from './filter-predicate-renamed-prop'
+import { fixture as filterPredicatePropsMember } from './filter-predicate-props-member'
 import { fixture as filterPredicateModulo } from './filter-predicate-modulo'
 import { fixture as fillUnsupported } from './fill-unsupported'
 import { fixture as fillUnsupportedClient } from './fill-unsupported-client'
@@ -694,6 +695,7 @@ export const jsxFixtures: JSXFixture[] = [
   filterNestedFindPredicateClient,
   filterPredicateSignalAlias,
   filterPredicateRenamedProp,
+  filterPredicatePropsMember,
   filterPredicateModulo,
   fillUnsupported,
   fillUnsupportedClient,

--- a/packages/adapter-tests/generated-data-points.json
+++ b/packages/adapter-tests/generated-data-points.json
@@ -1352,6 +1352,63 @@
       }
     }
   ],
+  "filter-predicate-props-member": [
+    {
+      "name": "gen:items:empty",
+      "props": {
+        "items": [],
+        "hiddenId": 1
+      }
+    },
+    {
+      "name": "gen:hiddenId:zero",
+      "props": {
+        "items": [
+          {
+            "id": 1,
+            "label": "Alpha"
+          },
+          {
+            "id": 2,
+            "label": "Beta"
+          }
+        ],
+        "hiddenId": 0
+      }
+    },
+    {
+      "name": "gen:hiddenId:negative",
+      "props": {
+        "items": [
+          {
+            "id": 1,
+            "label": "Alpha"
+          },
+          {
+            "id": 2,
+            "label": "Beta"
+          }
+        ],
+        "hiddenId": -7
+      }
+    },
+    {
+      "name": "gen:hiddenId:large",
+      "props": {
+        "items": [
+          {
+            "id": 1,
+            "label": "Alpha"
+          },
+          {
+            "id": 2,
+            "label": "Beta"
+          }
+        ],
+        "hiddenId": 1234567890
+      }
+    }
+  ],
   "filter-predicate-renamed-prop": [
     {
       "name": "gen:fallbackLabel:empty",

--- a/packages/adapter-twig/src/render-divergences.ts
+++ b/packages/adapter-twig/src/render-divergences.ts
@@ -15,4 +15,13 @@ import type { RenderDivergences } from '@barefootjs/jsx'
 // at value position and the runtime evaluator's `object-literal` case
 // now merges it, so the seed classifies `derived` and SSRs identically
 // to Hono.
-export const renderDivergences: RenderDivergences = {}
+export const renderDivergences: RenderDivergences = {
+  // #2886: the filter `member()` emitter has no `props.x` flattening,
+  // unlike its non-filter sibling — a bare-props-form prop read DIRECTLY
+  // (no destructure, `props.hiddenId`) inside a `.filter()` predicate
+  // emits `bf.neq(it.id, props.hiddenId)`, and `props` is null, so the
+  // comparison never matches and every row is silently kept. Added for
+  // #2879's Go Template adapter fix, but this fixture is a shared
+  // cross-adapter conformance fixture, not Go-specific.
+  'filter-predicate-props-member': 'https://github.com/piconic-ai/barefootjs/issues/2886',
+}

--- a/packages/adapter-xslate/src/render-divergences.ts
+++ b/packages/adapter-xslate/src/render-divergences.ts
@@ -22,4 +22,13 @@ import type { RenderDivergences } from '@barefootjs/jsx'
 // the real name off that capture — the same in-template recompute the other
 // six template-stash backends already had. Keep the file even when the set
 // is empty — the next divergence lands here, not in a re-created file.
-export const renderDivergences: RenderDivergences = {}
+export const renderDivergences: RenderDivergences = {
+  // #2886: the filter `member()` emitter has no `props.x` flattening,
+  // unlike its non-filter sibling — a bare-props-form prop read DIRECTLY
+  // (no destructure, `props.hiddenId`) inside a `.filter()` predicate
+  // emits `$props.hiddenId`, and `$props` is nil, so the comparison never
+  // matches and every row is silently kept. Added for #2879's Go Template
+  // adapter fix, but this fixture is a shared cross-adapter conformance
+  // fixture, not Go-specific.
+  'filter-predicate-props-member': 'https://github.com/piconic-ai/barefootjs/issues/2886',
+}

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-conformance section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. This answers, per fixture and per adapter, whether the construct WORKS — not just whether it compiles. A construct works either as written (✓) or with a documented `/* @client */` comment (✓†, a verified, supported escape — most refusals have one). Fixtures absent from the table below work on every adapter — most as written, some via that documented escape; the headline says how many of each. Listed fixtures need attention somewhere: a bare diagnostic code is still-open debt with no escape yet, a code led by ✗ owes no escape at all (by design), and ≠ means the fixture compiles clean but its rendered output diverges from the reference.",
-    "totalFixtures": 388,
+    "totalFixtures": 389,
     "fixtures": {
       "date-method-uncatalogued": {
         "blade": {

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -2249,6 +2249,36 @@
           }
         }
       },
+      "filter-predicate-props-member": {
+        "blade": {
+          "kind": "render",
+          "reason": "https://github.com/piconic-ai/barefootjs/issues/2886"
+        },
+        "erb": {
+          "kind": "render",
+          "reason": "https://github.com/piconic-ai/barefootjs/issues/2886"
+        },
+        "jinja": {
+          "kind": "render",
+          "reason": "https://github.com/piconic-ai/barefootjs/issues/2886"
+        },
+        "minijinja": {
+          "kind": "render",
+          "reason": "https://github.com/piconic-ai/barefootjs/issues/2886"
+        },
+        "mojolicious": {
+          "kind": "render",
+          "reason": "https://github.com/piconic-ai/barefootjs/issues/2886"
+        },
+        "twig": {
+          "kind": "render",
+          "reason": "https://github.com/piconic-ai/barefootjs/issues/2886"
+        },
+        "xslate": {
+          "kind": "render",
+          "reason": "https://github.com/piconic-ai/barefootjs/issues/2886"
+        }
+      },
       "filter-predicate-renamed-prop": {
         "mojolicious": {
           "kind": "render",
@@ -3588,6 +3618,10 @@
       "filter-nested-find-predicate": {
         "description": "Filter predicate containing a nested .find() callback (#2038)",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/filter-nested-find-predicate.ts"
+      },
+      "filter-predicate-props-member": {
+        "description": ".filter() predicate reading props.x directly on a bare-props-form component (#2879)",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/filter-predicate-props-member.ts"
       },
       "filter-predicate-renamed-prop": {
         "description": ".filter() predicate referencing a renamed prop destructure (#2857)",

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -1037,7 +1037,7 @@
           "total": 103
         },
         "blade": {
-          "pass": 94,
+          "pass": 93,
           "total": 103,
           "gaps": [
             {
@@ -1055,6 +1055,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-predicate-props-member",
+              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -1085,7 +1089,7 @@
           ]
         },
         "erb": {
-          "pass": 95,
+          "pass": 94,
           "total": 103,
           "gaps": [
             {
@@ -1097,6 +1101,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-predicate-props-member",
+              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -1175,7 +1183,7 @@
           ]
         },
         "jinja": {
-          "pass": 94,
+          "pass": 93,
           "total": 103,
           "gaps": [
             {
@@ -1193,6 +1201,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-predicate-props-member",
+              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -1223,7 +1235,7 @@
           ]
         },
         "minijinja": {
-          "pass": 94,
+          "pass": 93,
           "total": 103,
           "gaps": [
             {
@@ -1241,6 +1253,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-predicate-props-member",
+              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -1271,7 +1287,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 94,
+          "pass": 93,
           "total": 103,
           "gaps": [
             {
@@ -1283,6 +1299,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-predicate-props-member",
+              "issues": []
             },
             {
               "fixture": "filter-predicate-renamed-prop",
@@ -1317,7 +1337,7 @@
           ]
         },
         "twig": {
-          "pass": 94,
+          "pass": 93,
           "total": 103,
           "gaps": [
             {
@@ -1335,6 +1355,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-predicate-props-member",
+              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -1365,7 +1389,7 @@
           ]
         },
         "xslate": {
-          "pass": 94,
+          "pass": 93,
           "total": 103,
           "gaps": [
             {
@@ -1383,6 +1407,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-predicate-props-member",
+              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -1445,7 +1473,7 @@
           ]
         },
         "blade": {
-          "pass": 248,
+          "pass": 247,
           "total": 264,
           "gaps": [
             {
@@ -1473,6 +1501,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-predicate-props-member",
+              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -1525,7 +1557,7 @@
           ]
         },
         "erb": {
-          "pass": 249,
+          "pass": 248,
           "total": 264,
           "gaps": [
             {
@@ -1547,6 +1579,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-predicate-props-member",
+              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -1685,7 +1721,7 @@
           ]
         },
         "jinja": {
-          "pass": 248,
+          "pass": 247,
           "total": 264,
           "gaps": [
             {
@@ -1713,6 +1749,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-predicate-props-member",
+              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -1765,7 +1805,7 @@
           ]
         },
         "minijinja": {
-          "pass": 248,
+          "pass": 247,
           "total": 264,
           "gaps": [
             {
@@ -1793,6 +1833,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-predicate-props-member",
+              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -1845,7 +1889,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 248,
+          "pass": 247,
           "total": 264,
           "gaps": [
             {
@@ -1867,6 +1911,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-predicate-props-member",
+              "issues": []
             },
             {
               "fixture": "filter-predicate-renamed-prop",
@@ -1923,7 +1971,7 @@
           ]
         },
         "twig": {
-          "pass": 248,
+          "pass": 247,
           "total": 264,
           "gaps": [
             {
@@ -1951,6 +1999,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-predicate-props-member",
+              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -2003,7 +2055,7 @@
           ]
         },
         "xslate": {
-          "pass": 248,
+          "pass": 247,
           "total": 264,
           "gaps": [
             {
@@ -2031,6 +2083,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-predicate-props-member",
+              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -2255,7 +2311,7 @@
           ]
         },
         "blade": {
-          "pass": 347,
+          "pass": 346,
           "total": 367,
           "gaps": [
             {
@@ -2283,6 +2339,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-predicate-props-member",
+              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -2351,7 +2411,7 @@
           ]
         },
         "erb": {
-          "pass": 348,
+          "pass": 347,
           "total": 367,
           "gaps": [
             {
@@ -2373,6 +2433,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-predicate-props-member",
+              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -2549,7 +2613,7 @@
           ]
         },
         "jinja": {
-          "pass": 347,
+          "pass": 346,
           "total": 367,
           "gaps": [
             {
@@ -2577,6 +2641,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-predicate-props-member",
+              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -2645,7 +2713,7 @@
           ]
         },
         "minijinja": {
-          "pass": 347,
+          "pass": 346,
           "total": 367,
           "gaps": [
             {
@@ -2673,6 +2741,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-predicate-props-member",
+              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -2741,7 +2813,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 347,
+          "pass": 346,
           "total": 367,
           "gaps": [
             {
@@ -2763,6 +2835,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-predicate-props-member",
+              "issues": []
             },
             {
               "fixture": "filter-predicate-renamed-prop",
@@ -2835,7 +2911,7 @@
           ]
         },
         "twig": {
-          "pass": 347,
+          "pass": 346,
           "total": 367,
           "gaps": [
             {
@@ -2863,6 +2939,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-predicate-props-member",
+              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -2931,7 +3011,7 @@
           ]
         },
         "xslate": {
-          "pass": 347,
+          "pass": 346,
           "total": 367,
           "gaps": [
             {
@@ -2959,6 +3039,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-predicate-props-member",
+              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -3753,7 +3837,7 @@
           ]
         },
         "blade": {
-          "pass": 190,
+          "pass": 189,
           "total": 209,
           "gaps": [
             {
@@ -3781,6 +3865,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-predicate-props-member",
+              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -3845,7 +3933,7 @@
           ]
         },
         "erb": {
-          "pass": 191,
+          "pass": 190,
           "total": 209,
           "gaps": [
             {
@@ -3867,6 +3955,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-predicate-props-member",
+              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -4035,7 +4127,7 @@
           ]
         },
         "jinja": {
-          "pass": 190,
+          "pass": 189,
           "total": 209,
           "gaps": [
             {
@@ -4063,6 +4155,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-predicate-props-member",
+              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -4127,7 +4223,7 @@
           ]
         },
         "minijinja": {
-          "pass": 190,
+          "pass": 189,
           "total": 209,
           "gaps": [
             {
@@ -4155,6 +4251,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-predicate-props-member",
+              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -4219,7 +4319,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 190,
+          "pass": 189,
           "total": 209,
           "gaps": [
             {
@@ -4241,6 +4341,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-predicate-props-member",
+              "issues": []
             },
             {
               "fixture": "filter-predicate-renamed-prop",
@@ -4309,7 +4413,7 @@
           ]
         },
         "twig": {
-          "pass": 190,
+          "pass": 189,
           "total": 209,
           "gaps": [
             {
@@ -4337,6 +4441,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-predicate-props-member",
+              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -4401,7 +4509,7 @@
           ]
         },
         "xslate": {
-          "pass": 190,
+          "pass": 189,
           "total": 209,
           "gaps": [
             {
@@ -4429,6 +4537,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
+            },
+            {
+              "fixture": "filter-predicate-props-member",
+              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -6881,29 +6993,57 @@
           "total": 11
         },
         "blade": {
-          "pass": 11,
-          "total": 11
+          "pass": 10,
+          "total": 11,
+          "gaps": [
+            {
+              "fixture": "filter-predicate-props-member",
+              "issues": []
+            }
+          ]
         },
         "erb": {
-          "pass": 11,
-          "total": 11
+          "pass": 10,
+          "total": 11,
+          "gaps": [
+            {
+              "fixture": "filter-predicate-props-member",
+              "issues": []
+            }
+          ]
         },
         "go-template": {
           "pass": 11,
           "total": 11
         },
         "jinja": {
-          "pass": 11,
-          "total": 11
-        },
-        "minijinja": {
-          "pass": 11,
-          "total": 11
-        },
-        "mojolicious": {
           "pass": 10,
           "total": 11,
           "gaps": [
+            {
+              "fixture": "filter-predicate-props-member",
+              "issues": []
+            }
+          ]
+        },
+        "minijinja": {
+          "pass": 10,
+          "total": 11,
+          "gaps": [
+            {
+              "fixture": "filter-predicate-props-member",
+              "issues": []
+            }
+          ]
+        },
+        "mojolicious": {
+          "pass": 9,
+          "total": 11,
+          "gaps": [
+            {
+              "fixture": "filter-predicate-props-member",
+              "issues": []
+            },
             {
               "fixture": "filter-predicate-renamed-prop",
               "issues": []
@@ -6911,12 +7051,24 @@
           ]
         },
         "twig": {
-          "pass": 11,
-          "total": 11
+          "pass": 10,
+          "total": 11,
+          "gaps": [
+            {
+              "fixture": "filter-predicate-props-member",
+              "issues": []
+            }
+          ]
         },
         "xslate": {
-          "pass": 11,
-          "total": 11
+          "pass": 10,
+          "total": 11,
+          "gaps": [
+            {
+              "fixture": "filter-predicate-props-member",
+              "issues": []
+            }
+          ]
         }
       },
       "source": {

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -1030,15 +1030,15 @@
       }
     },
     "binary": {
-      "total": 102,
+      "total": 103,
       "cells": {
         "hono": {
-          "pass": 102,
-          "total": 102
+          "pass": 103,
+          "total": 103
         },
         "blade": {
-          "pass": 93,
-          "total": 102,
+          "pass": 94,
+          "total": 103,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1085,8 +1085,8 @@
           ]
         },
         "erb": {
-          "pass": 94,
-          "total": 102,
+          "pass": 95,
+          "total": 103,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1127,8 +1127,8 @@
           ]
         },
         "go-template": {
-          "pass": 93,
-          "total": 102,
+          "pass": 94,
+          "total": 103,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1175,8 +1175,8 @@
           ]
         },
         "jinja": {
-          "pass": 93,
-          "total": 102,
+          "pass": 94,
+          "total": 103,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1223,8 +1223,8 @@
           ]
         },
         "minijinja": {
-          "pass": 93,
-          "total": 102,
+          "pass": 94,
+          "total": 103,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1271,8 +1271,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 93,
-          "total": 102,
+          "pass": 94,
+          "total": 103,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1317,8 +1317,8 @@
           ]
         },
         "twig": {
-          "pass": 93,
-          "total": 102,
+          "pass": 94,
+          "total": 103,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1365,8 +1365,8 @@
           ]
         },
         "xslate": {
-          "pass": 93,
-          "total": 102,
+          "pass": 94,
+          "total": 103,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1419,18 +1419,18 @@
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/jsx/src/expression-parser.ts#L173"
       },
       "example": {
-        "fixture": "nested-ternary-bare-branch",
-        "description": "Nested ternary chain under a non-reactive (module-const) outer condition (#2470)",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/nested-ternary-bare-branch.ts",
-        "code": "MODE === 'a'"
+        "fixture": "filter-predicate-props-member",
+        "description": ".filter() predicate reading props.x directly on a bare-props-form component (#2879)",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/filter-predicate-props-member.ts",
+        "code": "it.id !== props.hiddenId"
       }
     },
     "call": {
-      "total": 263,
+      "total": 264,
       "cells": {
         "hono": {
-          "pass": 261,
-          "total": 263,
+          "pass": 262,
+          "total": 264,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1445,8 +1445,8 @@
           ]
         },
         "blade": {
-          "pass": 247,
-          "total": 263,
+          "pass": 248,
+          "total": 264,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1525,8 +1525,8 @@
           ]
         },
         "erb": {
-          "pass": 248,
-          "total": 263,
+          "pass": 249,
+          "total": 264,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1599,8 +1599,8 @@
           ]
         },
         "go-template": {
-          "pass": 246,
-          "total": 263,
+          "pass": 247,
+          "total": 264,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1685,8 +1685,8 @@
           ]
         },
         "jinja": {
-          "pass": 247,
-          "total": 263,
+          "pass": 248,
+          "total": 264,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1765,8 +1765,8 @@
           ]
         },
         "minijinja": {
-          "pass": 247,
-          "total": 263,
+          "pass": 248,
+          "total": 264,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1845,8 +1845,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 247,
-          "total": 263,
+          "pass": 248,
+          "total": 264,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1923,8 +1923,8 @@
           ]
         },
         "twig": {
-          "pass": 247,
-          "total": 263,
+          "pass": 248,
+          "total": 264,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2003,8 +2003,8 @@
           ]
         },
         "xslate": {
-          "pass": 247,
-          "total": 263,
+          "pass": 248,
+          "total": 264,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2228,11 +2228,11 @@
       }
     },
     "identifier": {
-      "total": 366,
+      "total": 367,
       "cells": {
         "hono": {
-          "pass": 362,
-          "total": 366,
+          "pass": 363,
+          "total": 367,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2255,8 +2255,8 @@
           ]
         },
         "blade": {
-          "pass": 346,
-          "total": 366,
+          "pass": 347,
+          "total": 367,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2351,8 +2351,8 @@
           ]
         },
         "erb": {
-          "pass": 347,
-          "total": 366,
+          "pass": 348,
+          "total": 367,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2441,8 +2441,8 @@
           ]
         },
         "go-template": {
-          "pass": 344,
-          "total": 366,
+          "pass": 345,
+          "total": 367,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2549,8 +2549,8 @@
           ]
         },
         "jinja": {
-          "pass": 346,
-          "total": 366,
+          "pass": 347,
+          "total": 367,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2645,8 +2645,8 @@
           ]
         },
         "minijinja": {
-          "pass": 346,
-          "total": 366,
+          "pass": 347,
+          "total": 367,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2741,8 +2741,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 346,
-          "total": 366,
+          "pass": 347,
+          "total": 367,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2835,8 +2835,8 @@
           ]
         },
         "twig": {
-          "pass": 346,
-          "total": 366,
+          "pass": 347,
+          "total": 367,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2931,8 +2931,8 @@
           ]
         },
         "xslate": {
-          "pass": 346,
-          "total": 366,
+          "pass": 347,
+          "total": 367,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3730,11 +3730,11 @@
       }
     },
     "member": {
-      "total": 208,
+      "total": 209,
       "cells": {
         "hono": {
-          "pass": 205,
-          "total": 208,
+          "pass": 206,
+          "total": 209,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3753,8 +3753,8 @@
           ]
         },
         "blade": {
-          "pass": 189,
-          "total": 208,
+          "pass": 190,
+          "total": 209,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3845,8 +3845,8 @@
           ]
         },
         "erb": {
-          "pass": 190,
-          "total": 208,
+          "pass": 191,
+          "total": 209,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3931,8 +3931,8 @@
           ]
         },
         "go-template": {
-          "pass": 187,
-          "total": 208,
+          "pass": 188,
+          "total": 209,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4035,8 +4035,8 @@
           ]
         },
         "jinja": {
-          "pass": 189,
-          "total": 208,
+          "pass": 190,
+          "total": 209,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4127,8 +4127,8 @@
           ]
         },
         "minijinja": {
-          "pass": 189,
-          "total": 208,
+          "pass": 190,
+          "total": 209,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4219,8 +4219,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 189,
-          "total": 208,
+          "pass": 190,
+          "total": 209,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4309,8 +4309,8 @@
           ]
         },
         "twig": {
-          "pass": 189,
-          "total": 208,
+          "pass": 190,
+          "total": 209,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4401,8 +4401,8 @@
           ]
         },
         "xslate": {
-          "pass": 189,
-          "total": 208,
+          "pass": 190,
+          "total": 209,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -6874,35 +6874,35 @@
       }
     },
     "binary:!==": {
-      "total": 10,
+      "total": 11,
       "cells": {
         "hono": {
-          "pass": 10,
-          "total": 10
+          "pass": 11,
+          "total": 11
         },
         "blade": {
-          "pass": 10,
-          "total": 10
+          "pass": 11,
+          "total": 11
         },
         "erb": {
-          "pass": 10,
-          "total": 10
+          "pass": 11,
+          "total": 11
         },
         "go-template": {
-          "pass": 10,
-          "total": 10
+          "pass": 11,
+          "total": 11
         },
         "jinja": {
-          "pass": 10,
-          "total": 10
+          "pass": 11,
+          "total": 11
         },
         "minijinja": {
-          "pass": 10,
-          "total": 10
+          "pass": 11,
+          "total": 11
         },
         "mojolicious": {
-          "pass": 9,
-          "total": 10,
+          "pass": 10,
+          "total": 11,
           "gaps": [
             {
               "fixture": "filter-predicate-renamed-prop",
@@ -6911,12 +6911,12 @@
           ]
         },
         "twig": {
-          "pass": 10,
-          "total": 10
+          "pass": 11,
+          "total": 11
         },
         "xslate": {
-          "pass": 10,
-          "total": 10
+          "pass": 11,
+          "total": 11
         }
       },
       "source": {
@@ -6925,10 +6925,10 @@
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/src/coverage-map.ts#L155"
       },
       "example": {
-        "fixture": "comparison-ternary-text",
-        "description": "Comparison operators (>=, ===, !==) as ternary conditions",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/comparison-ternary-text.ts",
-        "code": "n() !== 0"
+        "fixture": "filter-predicate-props-member",
+        "description": ".filter() predicate reading props.x directly on a bare-props-form component (#2879)",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/filter-predicate-props-member.ts",
+        "code": "it.id !== props.hiddenId"
       }
     },
     "binary:%": {


### PR DESCRIPTION
Fixes #2879.

## Summary

`renderFilterExprNode`'s `member` arm (the `.filter()`/`.find()`/etc. predicate emitter, Go Template adapter) had no `propsObjectName` branch — unlike its sibling `renderConditionExpr`, which already flattens `props.x` onto the correct root-scope field (`propsObjectName` is set for bare-props-form components, `function C(props: {...})`, no destructuring).

A prop read DIRECTLY as a member access inside a filter predicate (`props.hiddenId`, no local destructure — distinct from the #2857 alias family, which covered a *destructured local* referencing the prop) fell through to the generic "nested member access" recursion: `props` itself rendered via the `identifier` arm's root-scope fallback with the literal name `props`, emitting `$.Props.HiddenId` — a field the flattened Props struct never has (the real field is `$.HiddenId`). `html/template` panics at execute time:

```
template error: ...: executing "..." at <$.Props.HiddenId>: can't evaluate field Props in type main.FilterPredicatePropsMemberProps
```

This is a silent-at-compile-time, loud-at-render-time divergence: `bf build` succeeds, and the failure only surfaces when the template actually executes.

## Fix

Added the `propsObjectName` branch to `renderFilterExprNode`'s `member` arm, mirroring `renderConditionExpr`'s existing branch. Also extracted a shared `filterRootFieldRef` helper for the unconditional-`$.`-prefix + alias-resolution pattern that was already duplicated three times in this method (the `identifier`/signal/`call` cases, #2857) — the new branch reuses it instead of adding a fourth copy of the same two lines.

## Testing

Added `filter-predicate-props-member`, a conformance fixture with a `.filter()` predicate reading `props.hiddenId` directly, verified against real `go run` (Go 1.25.6):
- **Without** the fix: panics with the exact reported error, `can't evaluate field Props in type ...`.
- **With** the fix: matches the Hono reference (only the non-hidden row survives).

Regenerated `packages/adapter-tests/coverage-map.json`, `packages/adapter-tests/generated-data-points.json`, `ui/compat.lock.json`, `ui/support-matrix.lock.json`.

## Cross-adapter follow-up

The same shape of gap exists in every other DSL adapter's filter `member()` emitter (mojolicious, erb, jinja, twig, blade, xslate, rust) — each has the `props.x` flattening in its non-filter `member()` sibling but not its filter one. Filed as #2886 (mirroring how #2883 was found while fixing #2857) and pinned per-adapter in each `render-divergences.ts` against the new shared fixture, so this PR's fixture doesn't turn those adapters' CI red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HeZLEug6a9R9U2EHNTwWJK

---
_Generated by [Claude Code](https://claude.ai/code/session_01HeZLEug6a9R9U2EHNTwWJK)_