### PR TITLE
Fix #2886: DSL adapters' filter predicate props.x member emits wrong ref

### DIFF
--- a/.changeset/dsl-filter-predicate-props-member-2886.md
+++ b/.changeset/dsl-filter-predicate-props-member-2886.md
@@ -1,0 +1,13 @@
+---
+"@barefootjs/mojolicious": patch
+"@barefootjs/erb": patch
+"@barefootjs/jinja": patch
+"@barefootjs/twig": patch
+"@barefootjs/blade": patch
+"@barefootjs/xslate": patch
+"@barefootjs/rust": patch
+---
+
+Fix #2886: a `.filter()`/`.find()`/etc. predicate reading a bare-props-form prop DIRECTLY as a member access (`props.hiddenId`, no local destructure) rendered divergent from the Hono reference on every DSL adapter — the same shape of bug fixed for the Go Template adapter in #2879. Each adapter's filter `member()` emitter lacked the `props.x` flattening its own non-filter `member()` sibling already had, so `props` itself fell through to the generic member-access path as an ordinary identifier: Mojolicious/Xslate emitted an undeclared/nil variable (a hard runtime error under Perl `use strict`, or a silent nil-comparison keeping every row), ERB raised `NoMethodError` on `nil[...]`, and Jinja/Twig/Blade/minijinja silently kept every row instead of filtering (a null/undefined comparison never matches).
+
+Fixed by extracting a `flattenPropsMember` helper in each adapter's `expr/emitters.ts` (mirroring the flattening logic already in that adapter's non-filter `member()` emitter) and calling it from both the filter and non-filter `member()` emitters, closing the one-decision-two-implementations gap. Unpinned the shared `filter-predicate-props-member` conformance fixture (added in #2887) in all seven `render-divergences.ts` files, verified against each adapter's real interpreter (Perl/Mojolicious, Perl/Text::Xslate, Ruby/ERB, Python/Jinja2, PHP/Twig, PHP/Blade, and the Rust minijinja binary) — confirmed each adapter reproduces its own reported failure without the fix and passes with it.

--- a/packages/adapter-blade/src/adapter/expr/emitters.ts
+++ b/packages/adapter-blade/src/adapter/expr/emitters.ts
@@ -144,6 +144,21 @@ export function truthyTest(node: ParsedExpr, rendered: string): string {
 }
 
 /**
+ * `props.x` on a bare-props-form component flattens to the bare context var
+ * the SSR caller binds each prop to (props arrive as individual top-level
+ * context entries, not a nested `props` hash). Single door for BOTH
+ * `member()` emitters below (#2886) — `BladeFilterEmitter` lacked this
+ * decision entirely (#2879's cross-adapter follow-up), silently reaching
+ * `data_get($props, 'x')`, and `$props` is undefined. Returns null for any
+ * other receiver so callers fall through to their generic member lowering —
+ * `props.a.b` flattens only the inner hop.
+ */
+function flattenPropsMember(object: ParsedExpr, property: string): string | null {
+  if (object.kind === 'identifier' && object.name === 'props') return bladeVar(property)
+  return null
+}
+
+/**
  * Lowering for the predicate body of a filter / every / some / find, plus the
  * same shape used by the loop-hoist `.filter().map()` inline condition.
  * Higher-order predicates are emitted using PHP's own scalar comparison
@@ -200,6 +215,8 @@ export class BladeFilterEmitter implements ParsedExprEmitter {
   }
 
   member(object: ParsedExpr, property: string, _computed: boolean, _optional: boolean, emit: (e: ParsedExpr) => string): string {
+    const flat = flattenPropsMember(object, property)
+    if (flat !== null) return flat
     // `.length` — route through `$bf->length` (handles both array element
     // count and string char count, JS-compatibly).
     if (property === 'length') {
@@ -405,12 +422,8 @@ export class BladeTopLevelEmitter implements ParsedExprEmitter {
   }
 
   member(object: ParsedExpr, property: string, _computed: boolean, _optional: boolean, emit: (e: ParsedExpr) => string): string {
-    // `props.x` flattens to the bare context var the SSR caller binds each
-    // prop to (props arrive as individual top-level context entries, not a
-    // nested `props` hash).
-    if (object.kind === 'identifier' && object.name === 'props') {
-      return bladeVar(property)
-    }
+    const flat = flattenPropsMember(object, property)
+    if (flat !== null) return flat
     // Static property access on a module object-literal const
     // (`variantClasses.ghost`, #1897) resolves at compile time — the
     // generic `data_get` lowering below would reference a context var that

--- a/packages/adapter-blade/src/render-divergences.ts
+++ b/packages/adapter-blade/src/render-divergences.ts
@@ -15,12 +15,4 @@ import type { RenderDivergences } from '@barefootjs/jsx'
 // at value position and the runtime evaluator's `object-literal` case
 // now merges it, so the seed classifies `derived` and SSRs identically
 // to Hono.
-export const renderDivergences: RenderDivergences = {
-  // #2886: the filter `member()` emitter has no `props.x` flattening,
-  // unlike its non-filter sibling — a bare-props-form prop read DIRECTLY
-  // (no destructure, `props.hiddenId`) inside a `.filter()` predicate
-  // emits `data_get($props, 'hiddenId')`, and `$props` is undefined. Added
-  // for #2879's Go Template adapter fix, but this fixture is a shared
-  // cross-adapter conformance fixture, not Go-specific.
-  'filter-predicate-props-member': 'https://github.com/piconic-ai/barefootjs/issues/2886',
-}
+export const renderDivergences: RenderDivergences = {}

--- a/packages/adapter-erb/src/adapter/expr/emitters.ts
+++ b/packages/adapter-erb/src/adapter/expr/emitters.ts
@@ -92,6 +92,21 @@ function unusedIsStringName(_n: string): boolean {
   return false
 }
 
+/**
+ * `props.x` on a bare-props-form component flattens to the `v[:x]` the ERB
+ * SSR caller seeds each prop under (props arrive as vars-Hash entries, not
+ * a nested `props` Hash). Single door for BOTH `member()` emitters below
+ * (#2886) — `ErbFilterEmitter` lacked this decision entirely (#2879's
+ * cross-adapter follow-up), silently reaching `v[:props][:x]`, which is
+ * `nil[...]` at runtime (`NoMethodError`). Returns null for any other
+ * receiver so callers fall through to their generic member lowering —
+ * `props.a.b` flattens only the inner hop.
+ */
+function flattenPropsMember(object: ParsedExpr, property: string): string | null {
+  if (object.kind === 'identifier' && object.name === 'props') return `v[${rubySymbolLiteral(property)}]`
+  return null
+}
+
 export class ErbFilterEmitter implements ParsedExprEmitter {
   // Plain field declarations + assignment, NOT TS constructor-parameter-
   // property shorthand: Vite's `bundleConfigFile` externalizes any bare
@@ -164,6 +179,8 @@ export class ErbFilterEmitter implements ParsedExprEmitter {
   }
 
   member(object: ParsedExpr, property: string, _computed: boolean, optional: boolean, emit: (e: ParsedExpr) => string): string {
+    const flat = flattenPropsMember(object, property)
+    if (flat !== null) return flat
     // `.length` needs no special higher-order form here — see the file
     // docstring's simplification (2): `.select { ... }.length` just works
     // in Ruby, unlike Perl's anonymous-arrayref `scalar(@{...})` detour.
@@ -411,11 +428,8 @@ export class ErbTopLevelEmitter implements ParsedExprEmitter {
   }
 
   member(object: ParsedExpr, property: string, _computed: boolean, optional: boolean, emit: (e: ParsedExpr) => string): string {
-    // `props.x` flattens to the `v[:x]` the ERB SSR caller seeds each prop
-    // under (props arrive as vars-Hash entries, not a nested `props` Hash).
-    if (object.kind === 'identifier' && object.name === 'props') {
-      return `v[${rubySymbolLiteral(property)}]`
-    }
+    const flat = flattenPropsMember(object, property)
+    if (flat !== null) return flat
     // Static property access on a module object-literal const
     // (`variantClasses.ghost`) resolves at compile time — the generic Hash
     // lowering below would read a vars-Hash key that doesn't exist

--- a/packages/adapter-erb/src/render-divergences.ts
+++ b/packages/adapter-erb/src/render-divergences.ts
@@ -15,13 +15,4 @@ import type { RenderDivergences } from '@barefootjs/jsx'
 // at value position and the runtime evaluator's `object-literal` case
 // now merges it, so the seed classifies `derived` and SSRs identically
 // to Hono.
-export const renderDivergences: RenderDivergences = {
-  // #2886: the filter `member()` emitter (expr/emitters.ts:166) has no
-  // `props.x` flattening, unlike its non-filter sibling `member()` a few
-  // hundred lines below (expr/emitters.ts:413-414) — a bare-props-form prop
-  // read DIRECTLY (no destructure, `props.hiddenId`) inside a `.filter()`
-  // predicate emits `v[:props][:hiddenId]`, and `v[:props]` is `nil` →
-  // `NoMethodError`. Added for #2879's Go Template adapter fix, but this
-  // fixture is a shared cross-adapter conformance fixture, not Go-specific.
-  'filter-predicate-props-member': 'https://github.com/piconic-ai/barefootjs/issues/2886',
-}
+export const renderDivergences: RenderDivergences = {}

--- a/packages/adapter-jinja/src/adapter/expr/emitters.ts
+++ b/packages/adapter-jinja/src/adapter/expr/emitters.ts
@@ -109,6 +109,21 @@ export function truthyTest(node: ParsedExpr, rendered: string): string {
 }
 
 /**
+ * `props.x` on a bare-props-form component flattens to the bare context var
+ * the SSR caller binds each prop to (props arrive as individual top-level
+ * context entries, not a nested `props` dict). Single door for BOTH
+ * `member()` emitters below (#2886) — `JinjaFilterEmitter` lacked this
+ * decision entirely (#2879's cross-adapter follow-up), silently reaching
+ * `props['x']`, and `props` is undefined in the predicate's context.
+ * Returns null for any other receiver so callers fall through to their
+ * generic member lowering — `props.a.b` flattens only the inner hop.
+ */
+function flattenPropsMember(object: ParsedExpr, property: string): string | null {
+  if (object.kind === 'identifier' && object.name === 'props') return jinjaIdent(property)
+  return null
+}
+
+/**
  * Lowering for the predicate body of a filter / every / some / find, plus the
  * same shape used by the loop-hoist `.filter().map()` inline condition.
  * Higher-order predicates are emitted using Jinja's own scalar comparison
@@ -165,6 +180,8 @@ export class JinjaFilterEmitter implements ParsedExprEmitter {
   }
 
   member(object: ParsedExpr, property: string, _computed: boolean, _optional: boolean, emit: (e: ParsedExpr) => string): string {
+    const flat = flattenPropsMember(object, property)
+    if (flat !== null) return flat
     // `.length` — route through `bf.length` (handles both array element
     // count and string char count, JS-compatibly). Jinja's builtin
     // `|length` filter also faults trying to match JS semantics for every
@@ -390,12 +407,8 @@ export class JinjaTopLevelEmitter implements ParsedExprEmitter {
   }
 
   member(object: ParsedExpr, property: string, _computed: boolean, _optional: boolean, emit: (e: ParsedExpr) => string): string {
-    // `props.x` flattens to the bare context var the SSR caller binds each
-    // prop to (props arrive as individual top-level context entries, not a
-    // nested `props` dict).
-    if (object.kind === 'identifier' && object.name === 'props') {
-      return jinjaIdent(property)
-    }
+    const flat = flattenPropsMember(object, property)
+    if (flat !== null) return flat
     // Static property access on a module object-literal const
     // (`variantClasses.ghost`, #1897) resolves at compile time — the
     // generic dot lowering below would reference a context var that

--- a/packages/adapter-jinja/src/render-divergences.ts
+++ b/packages/adapter-jinja/src/render-divergences.ts
@@ -15,12 +15,4 @@ import type { RenderDivergences } from '@barefootjs/jsx'
 // at value position and the runtime evaluator's `object-literal` case
 // now merges it, so the seed classifies `derived` and SSRs identically
 // to Hono.
-export const renderDivergences: RenderDivergences = {
-  // #2886: the filter `member()` emitter has no `props.x` flattening,
-  // unlike its non-filter sibling — a bare-props-form prop read DIRECTLY
-  // (no destructure, `props.hiddenId`) inside a `.filter()` predicate
-  // emits `props['hiddenId']`, and `props` is undefined. Added for #2879's
-  // Go Template adapter fix, but this fixture is a shared cross-adapter
-  // conformance fixture, not Go-specific.
-  'filter-predicate-props-member': 'https://github.com/piconic-ai/barefootjs/issues/2886',
-}
+export const renderDivergences: RenderDivergences = {}

--- a/packages/adapter-mojolicious/src/adapter/expr/emitters.ts
+++ b/packages/adapter-mojolicious/src/adapter/expr/emitters.ts
@@ -81,6 +81,22 @@ const PREDICATE_METHODS: ReadonlySet<string> = new Set([
   'filter', 'find', 'findIndex', 'findLast', 'findLastIndex', 'every', 'some',
 ])
 
+/**
+ * `props.x` on a bare-props-form component flattens to the bare `$x` the
+ * Mojo SSR caller binds each prop to (props arrive as individual `my $x`
+ * vars, not a `$props` hashref). Single door for BOTH `member()` emitters
+ * below (#2886) — `MojoFilterEmitter` lacked this decision entirely
+ * (#2879's cross-adapter follow-up), silently reaching `$props->{x}`, a
+ * Perl variable never declared under `use strict`. Returns null for any
+ * other receiver so callers fall through to their generic member
+ * lowering — `props.a.b` flattens only the inner hop, then the caller's
+ * own recursion appends `.b`.
+ */
+function flattenPropsMember(object: ParsedExpr, property: string): string | null {
+  if (object.kind === 'identifier' && object.name === 'props') return `$${property}`
+  return null
+}
+
 export class MojoFilterEmitter implements ParsedExprEmitter {
   // Plain field declarations + assignment, NOT TS constructor-parameter-
   // property shorthand: Vite's `bundleConfigFile` externalizes any bare
@@ -129,6 +145,8 @@ export class MojoFilterEmitter implements ParsedExprEmitter {
   }
 
   member(object: ParsedExpr, property: string, _computed: boolean, _optional: boolean, emit: (e: ParsedExpr) => string): string {
+    const flat = flattenPropsMember(object, property)
+    if (flat !== null) return flat
     // `.length` on a higher-order result (e.g.
     // `x.tags.filter(t => t.active).length > 0` inside the outer
     // filter predicate, #1443). The higher-order emit produces an
@@ -381,12 +399,8 @@ export class MojoTopLevelEmitter implements ParsedExprEmitter {
   }
 
   member(object: ParsedExpr, property: string, _computed: boolean, _optional: boolean, emit: (e: ParsedExpr) => string): string {
-    // `props.x` flattens to the bare `$x` the Mojo SSR caller binds each
-    // prop to (props arrive as individual `my $x = ...` vars, not a
-    // `$props` hashref).
-    if (object.kind === 'identifier' && object.name === 'props') {
-      return `$${property}`
-    }
+    const flat = flattenPropsMember(object, property)
+    if (flat !== null) return flat
     // Static property access on a module object-literal const
     // (`variantClasses.ghost`, #1897) resolves at compile time — the
     // generic hash lowering below would dereference a Perl var that

--- a/packages/adapter-mojolicious/src/render-divergences.ts
+++ b/packages/adapter-mojolicious/src/render-divergences.ts
@@ -26,13 +26,4 @@ export const renderDivergences: RenderDivergences = {
   // #2857's Go Template adapter fix that this fixture was added for — this
   // fixture is a shared cross-adapter conformance fixture, not Go-specific.
   'filter-predicate-renamed-prop': 'https://github.com/piconic-ai/barefootjs/issues/2883',
-  // #2886: `MojoFilterEmitter.member()` (expr/emitters.ts) has no `props.x`
-  // flattening, unlike its non-filter sibling `member()` a few hundred
-  // lines below — a bare-props-form prop read DIRECTLY (no destructure,
-  // `props.hiddenId`) inside a `.filter()` predicate emits `$props->{...}`,
-  // a Perl variable never declared under `use strict`. Same family as
-  // #2879's Go Template adapter fix that this fixture was added for, but
-  // this fixture is a shared cross-adapter conformance fixture, not
-  // Go-specific.
-  'filter-predicate-props-member': 'https://github.com/piconic-ai/barefootjs/issues/2886',
 }

--- a/packages/adapter-rust/src/adapter/expr/emitters.ts
+++ b/packages/adapter-rust/src/adapter/expr/emitters.ts
@@ -108,6 +108,22 @@ export function truthyTest(node: ParsedExpr, rendered: string): string {
 }
 
 /**
+ * `props.x` on a bare-props-form component flattens to the bare context var
+ * the SSR caller binds each prop to (props arrive as individual top-level
+ * context entries, not a nested `props` dict). Single door for BOTH
+ * `member()` emitters below (#2886) — `JinjaFilterEmitter` (this adapter's
+ * minijinja filter emitter) lacked this decision entirely (#2879's
+ * cross-adapter follow-up), silently reaching `props.x`, and `props` is
+ * undefined in the predicate's context. Returns null for any other
+ * receiver so callers fall through to their generic member lowering —
+ * `props.a.b` flattens only the inner hop.
+ */
+function flattenPropsMember(object: ParsedExpr, property: string): string | null {
+  if (object.kind === 'identifier' && object.name === 'props') return minijinjaIdent(property)
+  return null
+}
+
+/**
  * Lowering for the predicate body of a filter / every / some / find, plus the
  * same shape used by the loop-hoist `.filter().map()` inline condition.
  * Higher-order predicates are emitted using Jinja's own scalar comparison
@@ -164,6 +180,8 @@ export class JinjaFilterEmitter implements ParsedExprEmitter {
   }
 
   member(object: ParsedExpr, property: string, _computed: boolean, _optional: boolean, emit: (e: ParsedExpr) => string): string {
+    const flat = flattenPropsMember(object, property)
+    if (flat !== null) return flat
     // `.length` — route through `bf.length` (handles both array element
     // count and string char count, JS-compatibly). Jinja's builtin
     // `|length` filter also faults trying to match JS semantics for every
@@ -371,12 +389,8 @@ export class JinjaTopLevelEmitter implements ParsedExprEmitter {
   }
 
   member(object: ParsedExpr, property: string, _computed: boolean, _optional: boolean, emit: (e: ParsedExpr) => string): string {
-    // `props.x` flattens to the bare context var the SSR caller binds each
-    // prop to (props arrive as individual top-level context entries, not a
-    // nested `props` dict).
-    if (object.kind === 'identifier' && object.name === 'props') {
-      return minijinjaIdent(property)
-    }
+    const flat = flattenPropsMember(object, property)
+    if (flat !== null) return flat
     // Static property access on a module object-literal const
     // (`variantClasses.ghost`, #1897) resolves at compile time — the
     // generic dot lowering below would reference a context var that

--- a/packages/adapter-rust/src/render-divergences.ts
+++ b/packages/adapter-rust/src/render-divergences.ts
@@ -17,12 +17,4 @@ import type { RenderDivergences } from '@barefootjs/jsx'
 // at value position and the runtime evaluator's `object-literal` case
 // now merges it, so the seed classifies `derived` and SSRs identically
 // to Hono.
-export const renderDivergences: RenderDivergences = {
-  // #2886: the filter `member()` emitter has no `props.x` flattening,
-  // unlike its non-filter sibling — a bare-props-form prop read DIRECTLY
-  // (no destructure, `props.hiddenId`) inside a `.filter()` predicate
-  // emits `props.hiddenId`, and `props` is undefined. Added for #2879's Go
-  // Template adapter fix, but this fixture is a shared cross-adapter
-  // conformance fixture, not Go-specific.
-  'filter-predicate-props-member': 'https://github.com/piconic-ai/barefootjs/issues/2886',
-}
+export const renderDivergences: RenderDivergences = {}

--- a/packages/adapter-twig/src/adapter/expr/emitters.ts
+++ b/packages/adapter-twig/src/adapter/expr/emitters.ts
@@ -121,6 +121,22 @@ export function truthyTest(node: ParsedExpr, rendered: string): string {
 }
 
 /**
+ * `props.x` on a bare-props-form component flattens to the bare context var
+ * the SSR caller binds each prop to (props arrive as individual top-level
+ * context entries, not a nested `props` hash). Single door for BOTH
+ * `member()` emitters below (#2886) — `TwigFilterEmitter` lacked this
+ * decision entirely (#2879's cross-adapter follow-up), silently reaching
+ * `props.x`, where `props` is null in the predicate's context (silent —
+ * every row is kept instead of filtered). Returns null for any other
+ * receiver so callers fall through to their generic member lowering —
+ * `props.a.b` flattens only the inner hop.
+ */
+function flattenPropsMember(object: ParsedExpr, property: string): string | null {
+  if (object.kind === 'identifier' && object.name === 'props') return twigIdent(property)
+  return null
+}
+
+/**
  * Lowering for the predicate body of a filter / every / some / find, plus the
  * same shape used by the loop-hoist `.filter().map()` inline condition.
  * Higher-order predicates are emitted using Twig's own scalar comparison
@@ -177,6 +193,8 @@ export class TwigFilterEmitter implements ParsedExprEmitter {
   }
 
   member(object: ParsedExpr, property: string, _computed: boolean, _optional: boolean, emit: (e: ParsedExpr) => string): string {
+    const flat = flattenPropsMember(object, property)
+    if (flat !== null) return flat
     // `.length` — route through `bf.length` (handles both array element
     // count and string char count, JS-compatibly). Twig's builtin
     // `|length` filter also faults trying to match JS semantics for every
@@ -396,12 +414,8 @@ export class TwigTopLevelEmitter implements ParsedExprEmitter {
   }
 
   member(object: ParsedExpr, property: string, _computed: boolean, _optional: boolean, emit: (e: ParsedExpr) => string): string {
-    // `props.x` flattens to the bare context var the SSR caller binds each
-    // prop to (props arrive as individual top-level context entries, not a
-    // nested `props` hash).
-    if (object.kind === 'identifier' && object.name === 'props') {
-      return twigIdent(property)
-    }
+    const flat = flattenPropsMember(object, property)
+    if (flat !== null) return flat
     // Static property access on a module object-literal const
     // (`variantClasses.ghost`, #1897) resolves at compile time — the
     // generic dot lowering below would reference a context var that

--- a/packages/adapter-twig/src/render-divergences.ts
+++ b/packages/adapter-twig/src/render-divergences.ts
@@ -15,13 +15,4 @@ import type { RenderDivergences } from '@barefootjs/jsx'
 // at value position and the runtime evaluator's `object-literal` case
 // now merges it, so the seed classifies `derived` and SSRs identically
 // to Hono.
-export const renderDivergences: RenderDivergences = {
-  // #2886: the filter `member()` emitter has no `props.x` flattening,
-  // unlike its non-filter sibling — a bare-props-form prop read DIRECTLY
-  // (no destructure, `props.hiddenId`) inside a `.filter()` predicate
-  // emits `bf.neq(it.id, props.hiddenId)`, and `props` is null, so the
-  // comparison never matches and every row is silently kept. Added for
-  // #2879's Go Template adapter fix, but this fixture is a shared
-  // cross-adapter conformance fixture, not Go-specific.
-  'filter-predicate-props-member': 'https://github.com/piconic-ai/barefootjs/issues/2886',
-}
+export const renderDivergences: RenderDivergences = {}

--- a/packages/adapter-xslate/src/adapter/expr/emitters.ts
+++ b/packages/adapter-xslate/src/adapter/expr/emitters.ts
@@ -65,6 +65,21 @@ const PREDICATE_METHODS = new Set<HigherOrderMethod>([
 ])
 
 /**
+ * `props.x` on a bare-props-form component flattens to the bare `$x` the
+ * SSR caller binds each prop to (props arrive as individual top-level vars,
+ * not a `$props` hashref). Single door for BOTH `member()` emitters below
+ * (#2886) — `XslateFilterEmitter` lacked this decision entirely (#2879's
+ * cross-adapter follow-up), silently reaching `$props.x`, and `$props` is
+ * nil at runtime (silent — every row is kept instead of filtered). Returns
+ * null for any other receiver so callers fall through to their generic
+ * member lowering — `props.a.b` flattens only the inner hop.
+ */
+function flattenPropsMember(object: ParsedExpr, property: string): string | null {
+  if (object.kind === 'identifier' && object.name === 'props') return `$${property}`
+  return null
+}
+
+/**
  * Lowering for the predicate body of a filter / every / some / find, plus the
  * same shape used by `renderBlockBodyCondition` for complex block-body
  * filters. Higher-order predicates are emitted using Kolon's own scalar
@@ -119,6 +134,8 @@ export class XslateFilterEmitter implements ParsedExprEmitter {
   }
 
   member(object: ParsedExpr, property: string, _computed: boolean, _optional: boolean, emit: (e: ParsedExpr) => string): string {
+    const flat = flattenPropsMember(object, property)
+    if (flat !== null) return flat
     // `.length` — route through `$bf.length` (handles both array element
     // count and string char count, JS-compatibly). Kolon's builtin `.size()`
     // is array-only and faults on a string.
@@ -323,11 +340,8 @@ export class XslateTopLevelEmitter implements ParsedExprEmitter {
   }
 
   member(object: ParsedExpr, property: string, _computed: boolean, _optional: boolean, emit: (e: ParsedExpr) => string): string {
-    // `props.x` flattens to the bare `$x` the SSR caller binds each prop to
-    // (props arrive as individual top-level vars, not a `$props` hashref).
-    if (object.kind === 'identifier' && object.name === 'props') {
-      return `$${property}`
-    }
+    const flat = flattenPropsMember(object, property)
+    if (flat !== null) return flat
     // Static property access on a module object-literal const
     // (`variantClasses.ghost`, #1897) resolves at compile time — the
     // generic dot lowering below would reference a Kolon var that

--- a/packages/adapter-xslate/src/render-divergences.ts
+++ b/packages/adapter-xslate/src/render-divergences.ts
@@ -22,13 +22,4 @@ import type { RenderDivergences } from '@barefootjs/jsx'
 // the real name off that capture — the same in-template recompute the other
 // six template-stash backends already had. Keep the file even when the set
 // is empty — the next divergence lands here, not in a re-created file.
-export const renderDivergences: RenderDivergences = {
-  // #2886: the filter `member()` emitter has no `props.x` flattening,
-  // unlike its non-filter sibling — a bare-props-form prop read DIRECTLY
-  // (no destructure, `props.hiddenId`) inside a `.filter()` predicate
-  // emits `$props.hiddenId`, and `$props` is nil, so the comparison never
-  // matches and every row is silently kept. Added for #2879's Go Template
-  // adapter fix, but this fixture is a shared cross-adapter conformance
-  // fixture, not Go-specific.
-  'filter-predicate-props-member': 'https://github.com/piconic-ai/barefootjs/issues/2886',
-}
+export const renderDivergences: RenderDivergences = {}

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -2249,36 +2249,6 @@
           }
         }
       },
-      "filter-predicate-props-member": {
-        "blade": {
-          "kind": "render",
-          "reason": "https://github.com/piconic-ai/barefootjs/issues/2886"
-        },
-        "erb": {
-          "kind": "render",
-          "reason": "https://github.com/piconic-ai/barefootjs/issues/2886"
-        },
-        "jinja": {
-          "kind": "render",
-          "reason": "https://github.com/piconic-ai/barefootjs/issues/2886"
-        },
-        "minijinja": {
-          "kind": "render",
-          "reason": "https://github.com/piconic-ai/barefootjs/issues/2886"
-        },
-        "mojolicious": {
-          "kind": "render",
-          "reason": "https://github.com/piconic-ai/barefootjs/issues/2886"
-        },
-        "twig": {
-          "kind": "render",
-          "reason": "https://github.com/piconic-ai/barefootjs/issues/2886"
-        },
-        "xslate": {
-          "kind": "render",
-          "reason": "https://github.com/piconic-ai/barefootjs/issues/2886"
-        }
-      },
       "filter-predicate-renamed-prop": {
         "mojolicious": {
           "kind": "render",
@@ -3618,10 +3588,6 @@
       "filter-nested-find-predicate": {
         "description": "Filter predicate containing a nested .find() callback (#2038)",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/filter-nested-find-predicate.ts"
-      },
-      "filter-predicate-props-member": {
-        "description": ".filter() predicate reading props.x directly on a bare-props-form component (#2879)",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/filter-predicate-props-member.ts"
       },
       "filter-predicate-renamed-prop": {
         "description": ".filter() predicate referencing a renamed prop destructure (#2857)",

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -1037,7 +1037,7 @@
           "total": 103
         },
         "blade": {
-          "pass": 93,
+          "pass": 94,
           "total": 103,
           "gaps": [
             {
@@ -1055,10 +1055,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
-            },
-            {
-              "fixture": "filter-predicate-props-member",
-              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -1089,7 +1085,7 @@
           ]
         },
         "erb": {
-          "pass": 94,
+          "pass": 95,
           "total": 103,
           "gaps": [
             {
@@ -1101,10 +1097,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
-            },
-            {
-              "fixture": "filter-predicate-props-member",
-              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -1183,7 +1175,7 @@
           ]
         },
         "jinja": {
-          "pass": 93,
+          "pass": 94,
           "total": 103,
           "gaps": [
             {
@@ -1201,10 +1193,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
-            },
-            {
-              "fixture": "filter-predicate-props-member",
-              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -1235,7 +1223,7 @@
           ]
         },
         "minijinja": {
-          "pass": 93,
+          "pass": 94,
           "total": 103,
           "gaps": [
             {
@@ -1253,10 +1241,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
-            },
-            {
-              "fixture": "filter-predicate-props-member",
-              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -1287,7 +1271,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 93,
+          "pass": 94,
           "total": 103,
           "gaps": [
             {
@@ -1299,10 +1283,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
-            },
-            {
-              "fixture": "filter-predicate-props-member",
-              "issues": []
             },
             {
               "fixture": "filter-predicate-renamed-prop",
@@ -1337,7 +1317,7 @@
           ]
         },
         "twig": {
-          "pass": 93,
+          "pass": 94,
           "total": 103,
           "gaps": [
             {
@@ -1355,10 +1335,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
-            },
-            {
-              "fixture": "filter-predicate-props-member",
-              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -1389,7 +1365,7 @@
           ]
         },
         "xslate": {
-          "pass": 93,
+          "pass": 94,
           "total": 103,
           "gaps": [
             {
@@ -1407,10 +1383,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
-            },
-            {
-              "fixture": "filter-predicate-props-member",
-              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -1473,7 +1445,7 @@
           ]
         },
         "blade": {
-          "pass": 247,
+          "pass": 248,
           "total": 264,
           "gaps": [
             {
@@ -1501,10 +1473,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
-            },
-            {
-              "fixture": "filter-predicate-props-member",
-              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -1557,7 +1525,7 @@
           ]
         },
         "erb": {
-          "pass": 248,
+          "pass": 249,
           "total": 264,
           "gaps": [
             {
@@ -1579,10 +1547,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
-            },
-            {
-              "fixture": "filter-predicate-props-member",
-              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -1721,7 +1685,7 @@
           ]
         },
         "jinja": {
-          "pass": 247,
+          "pass": 248,
           "total": 264,
           "gaps": [
             {
@@ -1749,10 +1713,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
-            },
-            {
-              "fixture": "filter-predicate-props-member",
-              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -1805,7 +1765,7 @@
           ]
         },
         "minijinja": {
-          "pass": 247,
+          "pass": 248,
           "total": 264,
           "gaps": [
             {
@@ -1833,10 +1793,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
-            },
-            {
-              "fixture": "filter-predicate-props-member",
-              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -1889,7 +1845,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 247,
+          "pass": 248,
           "total": 264,
           "gaps": [
             {
@@ -1911,10 +1867,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
-            },
-            {
-              "fixture": "filter-predicate-props-member",
-              "issues": []
             },
             {
               "fixture": "filter-predicate-renamed-prop",
@@ -1971,7 +1923,7 @@
           ]
         },
         "twig": {
-          "pass": 247,
+          "pass": 248,
           "total": 264,
           "gaps": [
             {
@@ -1999,10 +1951,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
-            },
-            {
-              "fixture": "filter-predicate-props-member",
-              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -2055,7 +2003,7 @@
           ]
         },
         "xslate": {
-          "pass": 247,
+          "pass": 248,
           "total": 264,
           "gaps": [
             {
@@ -2083,10 +2031,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
-            },
-            {
-              "fixture": "filter-predicate-props-member",
-              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -2311,7 +2255,7 @@
           ]
         },
         "blade": {
-          "pass": 346,
+          "pass": 347,
           "total": 367,
           "gaps": [
             {
@@ -2339,10 +2283,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
-            },
-            {
-              "fixture": "filter-predicate-props-member",
-              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -2411,7 +2351,7 @@
           ]
         },
         "erb": {
-          "pass": 347,
+          "pass": 348,
           "total": 367,
           "gaps": [
             {
@@ -2433,10 +2373,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
-            },
-            {
-              "fixture": "filter-predicate-props-member",
-              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -2613,7 +2549,7 @@
           ]
         },
         "jinja": {
-          "pass": 346,
+          "pass": 347,
           "total": 367,
           "gaps": [
             {
@@ -2641,10 +2577,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
-            },
-            {
-              "fixture": "filter-predicate-props-member",
-              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -2713,7 +2645,7 @@
           ]
         },
         "minijinja": {
-          "pass": 346,
+          "pass": 347,
           "total": 367,
           "gaps": [
             {
@@ -2741,10 +2673,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
-            },
-            {
-              "fixture": "filter-predicate-props-member",
-              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -2813,7 +2741,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 346,
+          "pass": 347,
           "total": 367,
           "gaps": [
             {
@@ -2835,10 +2763,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
-            },
-            {
-              "fixture": "filter-predicate-props-member",
-              "issues": []
             },
             {
               "fixture": "filter-predicate-renamed-prop",
@@ -2911,7 +2835,7 @@
           ]
         },
         "twig": {
-          "pass": 346,
+          "pass": 347,
           "total": 367,
           "gaps": [
             {
@@ -2939,10 +2863,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
-            },
-            {
-              "fixture": "filter-predicate-props-member",
-              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -3011,7 +2931,7 @@
           ]
         },
         "xslate": {
-          "pass": 346,
+          "pass": 347,
           "total": 367,
           "gaps": [
             {
@@ -3039,10 +2959,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
-            },
-            {
-              "fixture": "filter-predicate-props-member",
-              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -3837,7 +3753,7 @@
           ]
         },
         "blade": {
-          "pass": 189,
+          "pass": 190,
           "total": 209,
           "gaps": [
             {
@@ -3865,10 +3781,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
-            },
-            {
-              "fixture": "filter-predicate-props-member",
-              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -3933,7 +3845,7 @@
           ]
         },
         "erb": {
-          "pass": 190,
+          "pass": 191,
           "total": 209,
           "gaps": [
             {
@@ -3955,10 +3867,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
-            },
-            {
-              "fixture": "filter-predicate-props-member",
-              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -4127,7 +4035,7 @@
           ]
         },
         "jinja": {
-          "pass": 189,
+          "pass": 190,
           "total": 209,
           "gaps": [
             {
@@ -4155,10 +4063,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
-            },
-            {
-              "fixture": "filter-predicate-props-member",
-              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -4223,7 +4127,7 @@
           ]
         },
         "minijinja": {
-          "pass": 189,
+          "pass": 190,
           "total": 209,
           "gaps": [
             {
@@ -4251,10 +4155,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
-            },
-            {
-              "fixture": "filter-predicate-props-member",
-              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -4319,7 +4219,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 189,
+          "pass": 190,
           "total": 209,
           "gaps": [
             {
@@ -4341,10 +4241,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
-            },
-            {
-              "fixture": "filter-predicate-props-member",
-              "issues": []
             },
             {
               "fixture": "filter-predicate-renamed-prop",
@@ -4413,7 +4309,7 @@
           ]
         },
         "twig": {
-          "pass": 189,
+          "pass": 190,
           "total": 209,
           "gaps": [
             {
@@ -4441,10 +4337,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
-            },
-            {
-              "fixture": "filter-predicate-props-member",
-              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -4509,7 +4401,7 @@
           ]
         },
         "xslate": {
-          "pass": 189,
+          "pass": 190,
           "total": 209,
           "gaps": [
             {
@@ -4537,10 +4429,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
-            },
-            {
-              "fixture": "filter-predicate-props-member",
-              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -6993,57 +6881,29 @@
           "total": 11
         },
         "blade": {
-          "pass": 10,
-          "total": 11,
-          "gaps": [
-            {
-              "fixture": "filter-predicate-props-member",
-              "issues": []
-            }
-          ]
+          "pass": 11,
+          "total": 11
         },
         "erb": {
-          "pass": 10,
-          "total": 11,
-          "gaps": [
-            {
-              "fixture": "filter-predicate-props-member",
-              "issues": []
-            }
-          ]
+          "pass": 11,
+          "total": 11
         },
         "go-template": {
           "pass": 11,
           "total": 11
         },
         "jinja": {
-          "pass": 10,
-          "total": 11,
-          "gaps": [
-            {
-              "fixture": "filter-predicate-props-member",
-              "issues": []
-            }
-          ]
+          "pass": 11,
+          "total": 11
         },
         "minijinja": {
+          "pass": 11,
+          "total": 11
+        },
+        "mojolicious": {
           "pass": 10,
           "total": 11,
           "gaps": [
-            {
-              "fixture": "filter-predicate-props-member",
-              "issues": []
-            }
-          ]
-        },
-        "mojolicious": {
-          "pass": 9,
-          "total": 11,
-          "gaps": [
-            {
-              "fixture": "filter-predicate-props-member",
-              "issues": []
-            },
             {
               "fixture": "filter-predicate-renamed-prop",
               "issues": []
@@ -7051,24 +6911,12 @@
           ]
         },
         "twig": {
-          "pass": 10,
-          "total": 11,
-          "gaps": [
-            {
-              "fixture": "filter-predicate-props-member",
-              "issues": []
-            }
-          ]
+          "pass": 11,
+          "total": 11
         },
         "xslate": {
-          "pass": 10,
-          "total": 11,
-          "gaps": [
-            {
-              "fixture": "filter-predicate-props-member",
-              "issues": []
-            }
-          ]
+          "pass": 11,
+          "total": 11
         }
       },
       "source": {


### PR DESCRIPTION
Fixes #2886.

## Summary

Each DSL adapter's filter `member()` emitter (mojolicious, erb, jinja, twig, blade, xslate, rust/minijinja) lacked the `props.x` flattening its own non-filter `member()` sibling already had — the same shape of bug fixed for the Go Template adapter in #2879.

A bare-props-form prop read directly as a member access (`props.hiddenId`, no local destructure) inside a `.filter()`/`.find()` predicate fell through to the generic member-access path, reaching for `props` as an ordinary identifier:

| adapter | emitted predicate reference | observed effect |
|---|---|---|
| mojolicious | `$props->{hiddenId}` | `$props` undeclared under `use strict` (hard error) |
| xslate | `$props.hiddenId` | `$props` nil → comparison never matches, every row kept (silent) |
| erb | `v[:props][:hiddenId]` | `v[:props]` is `nil` → `NoMethodError` (hard error) |
| jinja | `props['hiddenId']` | `props` undefined → every row kept (silent) |
| twig | `bf.neq(it.id, props.hiddenId)` | `props` null → every row kept (silent) |
| blade | `data_get($props, 'hiddenId')` | `$props` undefined → every row kept (silent) |
| rust (minijinja) | `props.hiddenId` | `props` undefined → every row kept (silent) |

## Fix

Extracted a `flattenPropsMember(object, property)` helper in each adapter's `expr/emitters.ts`, mirroring the flattening logic already present in that adapter's non-filter `member()` emitter, and called it from the start of both `member()` implementations. This closes the "one decision, two implementations, no test comparing them" gap for all seven adapters, matching how #2879 fixed the Go Template adapter's own `renderFilterExprNode`.

## Testing

Unpinned the shared `filter-predicate-props-member` conformance fixture (added in #2887 for #2879) in all seven `render-divergences.ts` files. Verified each adapter individually against its real interpreter, using the same revert-and-confirm methodology for each: temporarily reverted the emitter fix, rebuilt, confirmed the fixture reproduces the exact reported failure, then restored the fix and confirmed it passes.

- **Mojolicious** (real Perl + Mojolicious): confirmed `Global symbol "$props" requires explicit package name` without the fix.
- **ERB** (real Ruby): confirmed `NoMethodError: undefined method '[]' for nil` without the fix.
- **Jinja** (real Python jinja2): confirmed the silent "keeps every row" divergence without the fix.
- **Twig** (real PHP Twig): same silent divergence confirmed.
- **Blade** (real PHP Blade): same silent divergence confirmed.
- **Xslate** (real Perl Text::Xslate): same silent divergence confirmed.
- **Rust/minijinja** (real `bf-render` binary): same silent divergence confirmed.

Regenerated `ui/compat.lock.json` and `ui/support-matrix.lock.json` after a full rebuild. `packages/adapter-tests/coverage-map.json` and `generated-data-points.json` were unaffected (the fixture already existed; only its per-adapter pin/skip changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HeZLEug6a9R9U2EHNTwWJK

---
_Generated by [Claude Code](https://claude.ai/code/session_01HeZLEug6a9R9U2EHNTwWJK)_