### PR TITLE
Fix #2856: branch-local substitution corrupts object-literal shorthand

### DIFF
--- a/.changeset/branch-local-shorthand-2856.md
+++ b/.changeset/branch-local-shorthand-2856.md
@@ -1,0 +1,7 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Fix #2856: `replaceBranchLocalRefs` (the #1425 branch-local-in-attr/reactive-expression substitution machinery in `jsx-to-ir.ts`) used a regex-based text scanner (`replaceInExprContexts`) with no notion of AST position. Substituting a branch-local referenced via object-literal shorthand (`{ local }`, simultaneously the key and the value) wrapped the substitution in parens and silently dropped the key, emitting invalid JS like `{ (_p.tag) }` — a syntax error that could break the whole client bundle's parse at hydrate time, with no compile-time diagnostic.
+
+`replaceBranchLocalRefs` now tries a new AST-based, scope-aware `rewriteScopedValueRefs` (`prop-rewrite.ts`, generalized from the existing `applyScopedPropRefRewrite` used for destructured-prop rewriting) first, falling back to the legacy regex scanner only when the text doesn't parse as an expression or statement list. This also fixes an unrelated pre-existing gap for the same reason: a branch-local referenced inside a template-literal interpolation hole (`` `label:${local}` ``) used to be skipped entirely (the regex scanner treats a whole template literal as one opaque token) — it now resolves correctly there too.

--- a/packages/jsx/src/__tests__/branch-local-in-attr-position.test.ts
+++ b/packages/jsx/src/__tests__/branch-local-in-attr-position.test.ts
@@ -305,19 +305,28 @@ describe('branch-local at element-attribute position (#1414)', () => {
     expect(hydrate).toContain('foo bar')
   })
 
-  test('branch-local substitution skips string literals and `$`-prefixed identifiers', () => {
+  test('branch-local substitution skips string-literal text and correctly resolves a `$`-prefixed identifier', () => {
     // The substitution machinery used to scan with `text.replace(/\b
     // (name1|name2)\b/g, ...)`, which would (a) rewrite occurrences
     // of the name inside string literals into invalid JS and
     // (b) mis-match `\b` between `$` and a word char, splitting an
     // identifier like `$kind` and rewriting just its `kind` tail.
-    // The fix routes both substitution passes through
-    // `replaceInExprContexts` (skips opaque tokens — strings, regex,
-    // template bodies, comments) and replaces `\b` with `[\w$]`
-    // lookarounds so the boundary check treats `$` as part of an
-    // identifier. This test pins both invariants by declaring a
-    // branch-local whose name collides with a token inside a string
-    // literal *and* with the tail of a `$`-prefixed identifier.
+    // The regex-scanner fallback (`replaceInExprContexts`, still used
+    // when text doesn't parse as an expression/statement list) fixes
+    // both by skipping opaque tokens — strings, regex, template
+    // bodies, comments — and replacing `\b` with `[\w$]` lookarounds.
+    // But it treats an entire template literal as one opaque token,
+    // so it can't reach a branch-local reference INSIDE a `${...}`
+    // hole either — `$kind` used to survive as a literal, undeclared
+    // identifier in the emitted output (a latent ReferenceError, the
+    // same failure class as #2856). The AST-based
+    // `rewriteScopedValueRefs` (#2856) parses the template literal
+    // properly and resolves the hole like any other expression
+    // position, while still leaving the cooked text (`label:kind=`)
+    // alone since it's not an identifier. This test pins a branch-local
+    // whose name collides with a token inside a string literal *and*
+    // with the tail of a `$`-prefixed identifier used inside a
+    // template-literal hole.
     const source = `
       'use client'
       import { createSignal } from '@barefootjs/client'
@@ -345,9 +354,12 @@ describe('branch-local at element-attribute position (#1414)', () => {
     // verbatim — pre-fix, the `kind` inside the template-literal head
     // would have been rewritten into `('plain')`, mangling the string.
     expect(clientJs).toContain('label:kind=')
-    // The `$kind` identifier must stay intact — pre-fix, `\\bkind\\b`
-    // would have split `$kind` into `$` + `kind` and rewritten just
-    // the `kind` tail.
-    expect(clientJs).toContain('$kind')
+    // The `$kind` identifier (distinct from the branch-local `kind`)
+    // must resolve to its own branch-local value, not leak through
+    // unresolved (which would be a ReferenceError at hydrate — no
+    // `$kind` binding exists in the emitted module scope) and not have
+    // its `kind` tail mistakenly matched by the `kind` substitution.
+    expect(clientJs).not.toMatch(/[^(]\$kind\b/)
+    expect(clientJs).toContain("label:kind=${('dollar')}")
   })
 })

--- a/packages/jsx/src/__tests__/issue-2856-branch-local-shorthand.test.ts
+++ b/packages/jsx/src/__tests__/issue-2856-branch-local-shorthand.test.ts
@@ -53,6 +53,20 @@ describe('rewriteScopedValueRefs (#2856)', () => {
     expect(out).toBe('(_p.tag) + [1, 2, 3].map((local) => local).join(",")')
   })
 
+  test('does not touch a destructuring declaration\'s source key (pullfrog review, #2889)', () => {
+    // `{ local: renamed } = obj` -- `local` here is the SOURCE key of a
+    // renamed destructuring binding, not a value reference. Distinct from
+    // the shorthand case above: a renamed destructuring pattern has BOTH
+    // `propertyName` (the source key) and `name` (the local binding), and
+    // only the latter was excluded pre-fix.
+    const out = rewriteScopedValueRefs(
+      '(el) => { const { local: renamed } = obj; use(renamed) }',
+      new Set(['local']),
+      () => '(_p.tag)',
+    )
+    expect(out).toBe('(el) => { const { local: renamed } = obj; use(renamed) }')
+  })
+
   test('resolves inside a template-literal interpolation hole, leaving the cooked text alone', () => {
     const out = rewriteScopedValueRefs('`label:local=${local}`', new Set(['local']), () => '(_p.tag)')
     expect(out).toBe('`label:local=${(_p.tag)}`')

--- a/packages/jsx/src/__tests__/issue-2856-branch-local-shorthand.test.ts
+++ b/packages/jsx/src/__tests__/issue-2856-branch-local-shorthand.test.ts
@@ -1,0 +1,72 @@
+/**
+ * #2856: `replaceBranchLocalRefs` (jsx-to-ir.ts) used to substitute a
+ * branch-local's occurrences via a plain regex token scanner
+ * (`replaceInExprContexts`), which has no notion of AST position. An
+ * object-literal shorthand property (`{ local }`, simultaneously the
+ * key and the value) got its substitution wrapped in parens with the
+ * key silently dropped — `{ (_p.tag) }` — invalid JS that broke the
+ * whole client bundle's parse at runtime with no compile-time
+ * diagnostic.
+ *
+ * The fix routes both call sites through `rewriteScopedValueRefs`
+ * (`prop-rewrite.ts`), the same AST-based, scope-aware walk that
+ * already handled this exact key/value duality for destructured props
+ * (#2828/#2853). These tests pin the general mechanism directly
+ * (`rewriteScopedValueRefs`) — shorthand expansion, and the three
+ * sibling positions a naive scanner conflates with a value reference:
+ * a member-access name, an explicit object-literal key, and a name
+ * shadowed by an inner binding. An end-to-end compiler regression for
+ * the issue's own repro lives in
+ * `rewrite-destructured-props.test.ts` ("branch-local transitive
+ * prop-dep via shorthand reference").
+ */
+import { describe, test, expect } from 'bun:test'
+import { rewriteScopedValueRefs } from '../prop-rewrite.ts'
+
+describe('rewriteScopedValueRefs (#2856)', () => {
+  test('expands an object-literal shorthand property to `name: value`', () => {
+    const out = rewriteScopedValueRefs('{ local }', new Set(['local']), () => '(_p.tag)')
+    expect(out).toBe('{ local: (_p.tag) }')
+  })
+
+  test('does not touch a member-access name that merely shares the branch-local name', () => {
+    const out = rewriteScopedValueRefs('obj.local', new Set(['local']), () => '(_p.tag)')
+    expect(out).toBe('obj.local')
+  })
+
+  test('does not touch an explicit object-literal key', () => {
+    const out = rewriteScopedValueRefs('{ local: 1 }', new Set(['local']), () => '(_p.tag)')
+    expect(out).toBe('{ local: 1 }')
+  })
+
+  test('does not substitute a name shadowed by an inner arrow parameter', () => {
+    const out = rewriteScopedValueRefs('[1, 2, 3].map((local) => local)', new Set(['local']), () => '(_p.tag)')
+    expect(out).toBe('[1, 2, 3].map((local) => local)')
+  })
+
+  test('substitutes a real value reference alongside an unrelated shadowed one', () => {
+    const out = rewriteScopedValueRefs(
+      'local + [1, 2, 3].map((local) => local).join(",")',
+      new Set(['local']),
+      () => '(_p.tag)',
+    )
+    expect(out).toBe('(_p.tag) + [1, 2, 3].map((local) => local).join(",")')
+  })
+
+  test('resolves inside a template-literal interpolation hole, leaving the cooked text alone', () => {
+    const out = rewriteScopedValueRefs('`label:local=${local}`', new Set(['local']), () => '(_p.tag)')
+    expect(out).toBe('`label:local=${(_p.tag)}`')
+  })
+
+  test('returns null for text that does not parse as an expression when allowStatements is not set', () => {
+    const out = rewriteScopedValueRefs('const x = local', new Set(['local']), () => '(_p.tag)')
+    expect(out).toBeNull()
+  })
+
+  test('with allowStatements, resolves a value reference in statement-shaped text', () => {
+    const out = rewriteScopedValueRefs('const x = local', new Set(['local']), () => '(_p.tag)', {
+      allowStatements: true,
+    })
+    expect(out).toBe('const x = (_p.tag)')
+  })
+})

--- a/packages/jsx/src/__tests__/rewrite-destructured-props.test.ts
+++ b/packages/jsx/src/__tests__/rewrite-destructured-props.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect } from 'bun:test'
+import ts from 'typescript'
 import { compileJSX } from '../index'
 import { HonoAdapter } from '../../../adapter-hono/src/adapter/index'
 
@@ -153,11 +154,15 @@ export function Comp({ tag }: { tag: string }) {
     // Pre-fix: the hydrate template's module-scope lambda kept a bare
     // `tag` reference (no binding at that scope -- ReferenceError at pure
     // CSR mount). Post-fix: it resolves through `_p.tag` like every other
-    // prop reference. (The surrounding `{ (_p.tag) }` shape -- the branch-
-    // local substitution dropping the shorthand's own key -- is a
-    // separate, pre-existing defect tracked independently; this test pins
-    // only the prop-dependency question #2828's follow-up fixed.)
+    // prop reference, and the shorthand key survives the substitution
+    // (#2856 -- the branch-local substitution used to drop it, emitting
+    // the invalid `{ (_p.tag) }`).
     expect(js).not.toContain('{ (tag) }')
-    expect(js).toContain('{ (_p.tag) }')
+    expect(js).not.toContain('{ (_p.tag) }')
+    expect(js).toContain('{ local: (_p.tag) }')
+    // The emitted client JS must actually parse.
+    const sf = ts.createSourceFile('__test.ts', js, ts.ScriptTarget.Latest, true)
+    const diagnostics = (sf as unknown as { parseDiagnostics?: unknown[] }).parseDiagnostics
+    expect(diagnostics ?? []).toHaveLength(0)
   })
 })

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -49,6 +49,7 @@ import { containsReactiveExpression, collectReactiveBrandLeaves } from './reacti
 import {
   rewriteBarePropRefs as rewriteBarePropRefsCore,
   collectAstPropRefs,
+  rewriteScopedValueRefs,
 } from './prop-rewrite.ts'
 import { boundPropLocalNames, buildPropAliasMap, resolveAliasOrigin, resolveRestSpreadOriginCore } from './props-binding.ts'
 import { resolveFreeRefs, isNameBound as isNameBoundInEnv, type BindingEnvironment } from './free-refs.ts'
@@ -8456,10 +8457,19 @@ function inferExpressionType(
 
 /**
  * Substitute branch-local identifier references in `text` with the
- * value returned by `resolve(name)`. Skips occurrences inside string
- * / regex / template-body / comment tokens via the shared
- * `replaceInExprContexts` scanner, so a string like `'mergedClass'`
- * never gets rewritten into invalid JS. Identifier boundaries use
+ * value returned by `resolve(name)`. Tries the AST-based, scope-aware
+ * `rewriteScopedValueRefs` (`prop-rewrite.ts`) first — it correctly
+ * expands an object-literal shorthand property (`{ local }`) to
+ * `{ local: <resolved> }` instead of corrupting it to `{ (<resolved>) }`
+ * (#2856), and understands inner-scope shadowing. `allowStatements`
+ * covers raw-captured text that isn't guaranteed to be a bare
+ * expression (e.g. a `.map()`-callback preamble statement).
+ *
+ * Falls back to the legacy `replaceInExprContexts` scanner — which
+ * skips occurrences inside string / regex / template-body / comment
+ * tokens, so a string like `'mergedClass'` never gets rewritten into
+ * invalid JS, but has no notion of AST position — only when `text`
+ * doesn't parse under either attempt. Identifier boundaries use
  * `[\w$]` lookarounds rather than `\b`, since JS regex's word-char
  * class excludes `$` — a bare `\b` would mis-match the `foo` inside
  * `$foo`. Branch-local names are syntactically `[A-Za-z_$][A-Za-z0-9_$]*`
@@ -8478,6 +8488,8 @@ function replaceBranchLocalRefs(
   resolve: (name: string) => string,
 ): string {
   if (branchNames.length === 0) return text
+  const astResult = rewriteScopedValueRefs(text, new Set(branchNames), resolve, { allowStatements: true })
+  if (astResult !== null) return astResult
   const pattern = new RegExp(`(?<![\\w$])(${branchNames.join('|')})(?![\\w$])`, 'g')
   return replaceInExprContexts(text, pattern, (_match, name) => resolve(name))
 }

--- a/packages/jsx/src/prop-rewrite.ts
+++ b/packages/jsx/src/prop-rewrite.ts
@@ -130,49 +130,54 @@ export function collectAstPropRefs(
 
 /**
  * Scope-aware rewrite: parse `text` as an expression, walk it with the
- * binding stack, and splice `${PROPS_PARAM}.` onto exactly the
- * identifier references that are (a) in `propRefs` and (b) not
- * shadowed by a binding inside the text. Shorthand properties expand
- * (`{ org }` → `{ org: _p.org }`) so the result stays syntactically
- * valid.
+ * binding stack, and splice `replacementFor(name)` onto exactly the
+ * identifier references that are (a) in `names` and (b) not shadowed by
+ * a binding inside the text. Shorthand properties expand
+ * (`{ org }` → `{ org: <replacement> }`) so the result stays
+ * syntactically valid — this is the one place in the compiler that
+ * correctly distinguishes a value reference from an object-literal key
+ * / property-access name / shorthand property / binding name, so every
+ * caller doing this class of substitution (prop refs, #1425 branch-local
+ * refs, …) should route through this rather than growing its own
+ * regex-based text splice (#2856 — a second, regex-based substitution
+ * mechanism doesn't know shorthand is simultaneously a key and a value,
+ * and drops the key).
  *
- * `replacementFor` overrides the substitution text for a value
- * reference (default `${PROPS_PARAM}.<callerKey>`) — e.g. the reactive
- * client-JS emit path (`emit-reactive.ts`'s `rewriteDestructuredPropsInExpr`)
- * wraps it in a `(_p.x ?? <default>)` fallback for a prop with a
- * destructure default. Kept as a caller override rather than a
- * duplicate AST walk in that module, per the "one decision, one
- * implementation" rule (CLAUDE.md) — this walk is already the one place
- * that correctly distinguishes a value reference from an object-literal
- * key / property-access name / shorthand property / binding name.
+ * With `allowStatements`, a `text` that fails to parse as a bare
+ * expression is retried as a standalone statement list (no wrapping
+ * parens) — for callers whose raw-captured text isn't guaranteed to be
+ * expression-shaped (e.g. a `.map()`-callback preamble statement).
  *
- * Returns null when `text` does not parse cleanly as an expression —
- * the caller falls back to the legacy regex rewrite.
+ * Returns null when `text` doesn't parse cleanly under either attempt —
+ * the caller falls back to its own legacy mechanism.
  */
-function applyScopedPropRefRewrite(
+export function rewriteScopedValueRefs(
   text: string,
-  propRefs: Set<string>,
-  propAliases?: ReadonlyMap<string, string>,
-  replacementFor?: (localName: string, callerKey: string) => string,
+  names: ReadonlySet<string>,
+  replacementFor: (name: string) => string,
+  opts?: { allowStatements?: boolean },
 ): string | null {
   // Wrap in parens so object literals and arrows parse as expressions.
   const prefix = '('
-  const sf = ts.createSourceFile('__bf_prop_rewrite.ts', `${prefix}${text}\n)`, ts.ScriptTarget.Latest, true)
-  const parseDiagnostics = (sf as unknown as { parseDiagnostics?: unknown[] }).parseDiagnostics
-  if (parseDiagnostics && parseDiagnostics.length > 0) return null
+  let sf = ts.createSourceFile('__bf_scoped_rewrite.ts', `${prefix}${text}\n)`, ts.ScriptTarget.Latest, true)
+  let parseDiagnostics = (sf as unknown as { parseDiagnostics?: unknown[] }).parseDiagnostics
+  let usedPrefix = prefix
+  if (parseDiagnostics && parseDiagnostics.length > 0) {
+    if (!opts?.allowStatements) return null
+    sf = ts.createSourceFile('__bf_scoped_rewrite.ts', text, ts.ScriptTarget.Latest, true)
+    parseDiagnostics = (sf as unknown as { parseDiagnostics?: unknown[] }).parseDiagnostics
+    if (parseDiagnostics && parseDiagnostics.length > 0) return null
+    usedPrefix = ''
+  }
 
   const edits: Array<{ start: number; end: number; replacement: string }> = []
   walkWithScope(sf, (n, parent, shadowed) => {
-    if (shadowed || !propRefs.has(n.text)) return
+    if (shadowed || !names.has(n.text)) return
     if (isNonValuePosition(n, parent)) return
-    const start = n.getStart(sf) - prefix.length
-    const end = n.getEnd() - prefix.length
+    const start = n.getStart(sf) - usedPrefix.length
+    const end = n.getEnd() - usedPrefix.length
     if (start < 0 || end > text.length) return
-    // `_p` is always keyed by the caller-facing name (`sourceName ?? name`
-    // — #2524 CSR half); the local binding (`n.text`) only survives on the
-    // left of a shorthand expansion.
-    const callerKey = propAliases?.get(n.text) ?? n.text
-    const value = replacementFor ? replacementFor(n.text, callerKey) : `${PROPS_PARAM}.${callerKey}`
+    const value = replacementFor(n.text)
     if (parent && ts.isShorthandPropertyAssignment(parent) && parent.name === n) {
       edits.push({ start, end, replacement: `${n.text}: ${value}` })
       return
@@ -186,6 +191,33 @@ function applyScopedPropRefRewrite(
     result = result.slice(0, edit.start) + edit.replacement + result.slice(edit.end)
   }
   return result
+}
+
+/**
+ * `applyScopedPropRefRewrite` specializes `rewriteScopedValueRefs` for
+ * the destructured-prop case: the substitution defaults to
+ * `${PROPS_PARAM}.<callerKey>`, where the caller-facing key comes from
+ * `propAliases` (`_p` is always keyed by the caller-facing name —
+ * `sourceName ?? name`, #2524 CSR half — the local binding only
+ * survives on the left of a shorthand expansion).
+ *
+ * `replacementFor` overrides the substitution text for a value
+ * reference — e.g. the reactive client-JS emit path
+ * (`emit-reactive.ts`'s `rewriteDestructuredPropsInExpr`) wraps it in a
+ * `(_p.x ?? <default>)` fallback for a prop with a destructure default.
+ * Kept as a caller override rather than a duplicate AST walk in that
+ * module, per the "one decision, one implementation" rule (CLAUDE.md).
+ */
+function applyScopedPropRefRewrite(
+  text: string,
+  propRefs: Set<string>,
+  propAliases?: ReadonlyMap<string, string>,
+  replacementFor?: (localName: string, callerKey: string) => string,
+): string | null {
+  return rewriteScopedValueRefs(text, propRefs, (name) => {
+    const callerKey = propAliases?.get(name) ?? name
+    return replacementFor ? replacementFor(name, callerKey) : `${PROPS_PARAM}.${callerKey}`
+  })
 }
 
 /**

--- a/packages/jsx/src/prop-rewrite.ts
+++ b/packages/jsx/src/prop-rewrite.ts
@@ -89,8 +89,16 @@ function walkWithScope(
 /**
  * True when `n` sits in a non-value position where a prop rewrite must
  * never apply: an object-literal key, a member-access name, a binding
- * position (parameter / variable / binding-element name), or a type
- * reference.
+ * position (parameter / variable / binding-element name), a destructuring
+ * declaration's SOURCE key (`propertyName`, e.g. the `local` in
+ * `const { local: renamed } = obj`), or a type reference.
+ *
+ * The `propertyName` check matters even though `BindingElement.name` is
+ * already excluded above it: a renamed destructuring pattern has BOTH —
+ * `propertyName` is the source key (`local`) and `name` is the local
+ * binding (`renamed`) — and pullfrog review on #2889 caught that only the
+ * latter was excluded, so a substituted name colliding with the SOURCE key
+ * still corrupted to invalid JS (`const { (_p.tag): renamed } = obj`).
  */
 function isNonValuePosition(n: ts.Identifier, parent: ts.Node | undefined): boolean {
   if (!parent) return false
@@ -98,6 +106,7 @@ function isNonValuePosition(n: ts.Identifier, parent: ts.Node | undefined): bool
   if (ts.isPropertyAccessExpression(parent) && parent.name === n) return true
   if (ts.isQualifiedName(parent) && parent.right === n) return true
   if ((ts.isParameter(parent) || ts.isVariableDeclaration(parent) || ts.isBindingElement(parent)) && parent.name === n) return true
+  if (ts.isBindingElement(parent) && parent.propertyName === n) return true
   if (ts.isTypeReferenceNode(parent)) return true
   return false
 }


### PR DESCRIPTION
## Summary

`replaceBranchLocalRefs` (the #1425 branch-local-in-attr/reactive-expression substitution machinery in `jsx-to-ir.ts`) used a regex-based text scanner (`replaceInExprContexts`) with no notion of AST position. Substituting a branch-local referenced via object-literal shorthand (`{ local }`, simultaneously the key and the value) wrapped the substitution in parens and silently dropped the key, emitting invalid JS like `{ (_p.tag) }` — a syntax error that could break the whole client bundle's parse at hydrate time, with no compile-time diagnostic.

- `replaceBranchLocalRefs` now tries a new AST-based, scope-aware `rewriteScopedValueRefs` (`prop-rewrite.ts`, generalized from the existing `applyScopedPropRefRewrite` used for destructured-prop rewriting) first, falling back to the legacy regex scanner only when the text doesn't parse as an expression or statement list.
- As a side effect, this also fixes an unrelated pre-existing gap: a branch-local referenced inside a template-literal interpolation hole (`` `label:${local}` ``) used to be skipped entirely (the regex scanner treats a whole template literal as one opaque token) — it now resolves correctly there too. `branch-local-in-attr-position.test.ts`'s existing pin for that shape is updated to assert the corrected (previously-broken) behavior.

Fixes https://github.com/piconic-ai/barefootjs/issues/2856.

## Test plan

- [x] `bun test packages/jsx/src/__tests__/issue-2856-branch-local-shorthand.test.ts` — new unit tests directly on `rewriteScopedValueRefs` (shorthand expansion, member-access/object-key/shadowed-name non-interference, template-literal hole resolution).
- [x] `bun test packages/jsx/src/__tests__/rewrite-destructured-props.test.ts` — updated to assert the issue's own repro now emits valid, parseable JS.
- [x] `bun test packages/jsx/src/__tests__/branch-local-in-attr-position.test.ts` — updated for the template-literal-hole behavior change; all other cases pass unchanged.
- [x] `bun test packages/jsx` — full suite, 3367 pass / 5 fail, all 5 failures confirmed pre-existing and unrelated (the known `primitive-resolver-*` full-suite-only flake, reproduces identically on unmodified `main`).
- [x] `bunx tsgo --noEmit -p packages/jsx/tsconfig.json` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166GL67BeXNZb4duYnnn6kt

---
_Generated by [Claude Code](https://claude.ai/code/session_0166GL67BeXNZb4duYnnn6kt)_