### PR TITLE
Fix #2883: Mojolicious filter predicate against a renamed prop uses numeric comparison

### DIFF
--- a/.changeset/mojo-filter-renamed-prop-2883.md
+++ b/.changeset/mojo-filter-renamed-prop-2883.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/mojolicious": patch
+---
+
+Fix #2883: a `.filter()`/`.find()` predicate comparing against a bare-props-form BODY-destructured, RENAMED prop (`const { fallbackLabel: skipLabel } = props`, the #2788 alias family) lowered to Perl's numeric `!=`/`==` instead of string `ne`/`eq`, because `collectStringValueNames`'s string-typed-name witness had no notion of this alias family — only `MojoTopLevelEmitter`'s stash-derived `$skipLabel` variable (correctly resolved, contrary to this issue's original diagnosis of `MojoFilterEmitter.identifier()`) ever reached the comparison. `'Alpha' != 'Alpha'` and `'Beta' != 'Alpha'` both numify to `0 != 0`, so every row was silently filtered out regardless of the real string value. `collectStringValueNames` now also resolves this alias family via the shared `resolveBodyDestructuredPropAliases` helper (already used by the #2788 top-level splice path), so both emitters read the same, now-correct witness.

--- a/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
+++ b/packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts
@@ -733,6 +733,40 @@ export function L() {
     expect(result.template).not.toContain('$sel eq $t->{n}')
   })
 
+  test('compares a filter predicate against a renamed body-destructured prop with Perl `ne`, not numeric `!=` (#2883)', () => {
+    // `MojoFilterEmitter.identifier()` correctly resolves `skipLabel` to
+    // `$skipLabel` (Mojo seeds/derives that stash key for the #2788 alias
+    // family, same as the top-level splice path) — the actual bug was
+    // `collectStringValueNames`'s witness for `eq`/`ne` vs `==`/`!=` not
+    // knowing about body-destructured RENAMED props, so this comparison
+    // fell through to numeric `!=`. `'Alpha' != 'Alpha'` and
+    // `'Beta' != 'Alpha'` both numify to `0 != 0` — every row was
+    // filtered out regardless of the real string value.
+    const result = compileAndGenerate(`
+"use client"
+import { createSignal } from "@barefootjs/client"
+
+type Todo = { id: number; label: string }
+
+export function FilterPredicateRenamedProp(props: { fallbackLabel: string }) {
+  const { fallbackLabel: skipLabel } = props
+  const [todos] = createSignal<Todo[]>([
+    { id: 1, label: 'Alpha' },
+    { id: 2, label: 'Beta' },
+  ])
+  return (
+    <ul>
+      {todos().filter(t => t.label !== skipLabel).map(t => (
+        <li key={t.id}>{t.label}</li>
+      ))}
+    </ul>
+  )
+}
+`)
+    expect(result.template).toContain('$t->{label} ne $skipLabel')
+    expect(result.template).not.toContain('$t->{label} != $skipLabel')
+  })
+
   test('generates script registration for client components', () => {
     const result = compileAndGenerate(`
 "use client"

--- a/packages/adapter-mojolicious/src/adapter/props/prop-classes.ts
+++ b/packages/adapter-mojolicious/src/adapter/props/prop-classes.ts
@@ -7,7 +7,7 @@
  * adapter's `props/prop-types.ts`. No adapter instance state.
  */
 
-import { collectLoopBoundNames, type ComponentIR } from '@barefootjs/jsx'
+import { collectLoopBoundNames, resolveBodyDestructuredPropAliases, type ComponentIR } from '@barefootjs/jsx'
 import { isStringTypeInfo, isBareStringLiteral } from '../value/parsed-literal.ts'
 
 /**
@@ -88,6 +88,22 @@ export function collectNullableOptionalProps(ir: ComponentIR): Set<string> {
  * elsewhere in the component) but safe: the suppressed case just falls
  * back to today's numeric `+` — the same, already-accepted residual as an
  * unresolvable operand — never silently-wrong output.
+ *
+ * A bare-props-form component's BODY-destructured, RENAMED prop
+ * (`const { fallbackLabel: skipLabel } = props`, the #2788 alias family)
+ * has no `propsParams` entry of its own — `propsParams` only carries the
+ * TYPE-level, caller-facing names, and the local alias never appears
+ * there. Without the alias resolved here too, a string-typed prop
+ * referenced only under its local rename inside a filter predicate
+ * (`t => t.label !== skipLabel`) is invisible to this witness, so its
+ * equality lowers to numeric `!=` instead of `ne` — every row is
+ * dropped, since `'Alpha' != 'Alpha'` and `'Beta' != 'Alpha'` both
+ * numify to `0 != 0` (#2883). `resolveBodyDestructuredPropAliases`
+ * already recognizes this exact destructuring shape (built for #2788's
+ * top-level splice path); reusing it here keeps this one witness the
+ * single source of truth `MojoFilterEmitter`/`MojoTopLevelEmitter` both
+ * read via `_isStringValueName`, rather than growing a second, adapter-
+ * emitter-local alias lookup.
  */
 export function collectStringValueNames(ir: ComponentIR): Set<string> {
   const names = new Set<string>()
@@ -98,6 +114,12 @@ export function collectStringValueNames(ir: ComponentIR): Set<string> {
   }
   for (const p of ir.metadata.propsParams) {
     if (isStringTypeInfo(p.type)) names.add(p.name)
+  }
+  for (const [local, callerKey] of resolveBodyDestructuredPropAliases(
+    ir.metadata.localConstants ?? [],
+    ir.metadata.propsObjectName,
+  )) {
+    if (names.has(callerKey)) names.add(local)
   }
   for (const c of ir.metadata.localConstants) {
     if (isStringTypeInfo(c.type ?? undefined) || isBareStringLiteral(c.value)) names.add(c.name)

--- a/packages/adapter-mojolicious/src/render-divergences.ts
+++ b/packages/adapter-mojolicious/src/render-divergences.ts
@@ -15,15 +15,4 @@ import type { RenderDivergences } from '@barefootjs/jsx'
 // at value position and the runtime evaluator's `object-literal` case
 // now merges it, so the seed classifies `derived` and SSRs identically
 // to Hono.
-export const renderDivergences: RenderDivergences = {
-  // #2883: `MojoFilterEmitter.identifier()` (expr/emitters.ts) resolves a
-  // `.filter()` predicate identifier against only the loop param and
-  // `localVarMap` — a bare-props-form renamed prop destructure (`const {
-  // fallbackLabel: skipLabel } = props`, the #2788 alias family) falls
-  // through to a bare `$skipLabel`, a Perl variable never declared in the
-  // generated `.html.ep`. Every row is filtered out (the fixture's
-  // reference expects only the non-matching row to survive). Unrelated to
-  // #2857's Go Template adapter fix that this fixture was added for — this
-  // fixture is a shared cross-adapter conformance fixture, not Go-specific.
-  'filter-predicate-renamed-prop': 'https://github.com/piconic-ai/barefootjs/issues/2883',
-}
+export const renderDivergences: RenderDivergences = {}

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -2249,12 +2249,6 @@
           }
         }
       },
-      "filter-predicate-renamed-prop": {
-        "mojolicious": {
-          "kind": "render",
-          "reason": "https://github.com/piconic-ai/barefootjs/issues/2883"
-        }
-      },
       "filter-typeof-predicate": {
         "blade": {
           "kind": "refusal",
@@ -3588,10 +3582,6 @@
       "filter-nested-find-predicate": {
         "description": "Filter predicate containing a nested .find() callback (#2038)",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/filter-nested-find-predicate.ts"
-      },
-      "filter-predicate-renamed-prop": {
-        "description": ".filter() predicate referencing a renamed prop destructure (#2857)",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/filter-predicate-renamed-prop.ts"
       },
       "filter-typeof-predicate": {
         "description": "Off-subset filter predicate (typeof) — JS-runtime faithful, DSL diagnostic",

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -305,7 +305,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 87,
+          "pass": 88,
           "total": 99,
           "gaps": [
             {
@@ -321,10 +321,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
-            },
-            {
-              "fixture": "filter-predicate-renamed-prop",
-              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -1271,7 +1267,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 94,
+          "pass": 95,
           "total": 103,
           "gaps": [
             {
@@ -1283,10 +1279,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
-            },
-            {
-              "fixture": "filter-predicate-renamed-prop",
-              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -1845,7 +1837,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 248,
+          "pass": 249,
           "total": 264,
           "gaps": [
             {
@@ -1867,10 +1859,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
-            },
-            {
-              "fixture": "filter-predicate-renamed-prop",
-              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -2741,7 +2729,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 347,
+          "pass": 348,
           "total": 367,
           "gaps": [
             {
@@ -2763,10 +2751,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
-            },
-            {
-              "fixture": "filter-predicate-renamed-prop",
-              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -3397,7 +3381,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 279,
+          "pass": 280,
           "total": 292,
           "gaps": [
             {
@@ -3406,10 +3390,6 @@
             },
             {
               "fixture": "fill-unsupported",
-              "issues": []
-            },
-            {
-              "fixture": "filter-predicate-renamed-prop",
               "issues": []
             },
             {
@@ -4219,7 +4199,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 190,
+          "pass": 191,
           "total": 209,
           "gaps": [
             {
@@ -4241,10 +4221,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2320"
               ]
-            },
-            {
-              "fixture": "filter-predicate-renamed-prop",
-              "issues": []
             },
             {
               "fixture": "filter-typeof-predicate",
@@ -4619,13 +4595,9 @@
           ]
         },
         "mojolicious": {
-          "pass": 79,
+          "pass": 80,
           "total": 83,
           "gaps": [
-            {
-              "fixture": "filter-predicate-renamed-prop",
-              "issues": []
-            },
             {
               "fixture": "preamble-cells",
               "issues": []
@@ -6901,14 +6873,8 @@
           "total": 11
         },
         "mojolicious": {
-          "pass": 10,
-          "total": 11,
-          "gaps": [
-            {
-              "fixture": "filter-predicate-renamed-prop",
-              "issues": []
-            }
-          ]
+          "pass": 11,
+          "total": 11
         },
         "twig": {
           "pass": 11,
@@ -8094,15 +8060,11 @@
           ]
         },
         "mojolicious": {
-          "pass": 123,
+          "pass": 124,
           "total": 129,
           "gaps": [
             {
               "fixture": "fill-unsupported",
-              "issues": []
-            },
-            {
-              "fixture": "filter-predicate-renamed-prop",
               "issues": []
             },
             {
@@ -8402,7 +8364,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 198,
+          "pass": 199,
           "total": 207,
           "gaps": [
             {
@@ -8411,10 +8373,6 @@
             },
             {
               "fixture": "fill-unsupported",
-              "issues": []
-            },
-            {
-              "fixture": "filter-predicate-renamed-prop",
               "issues": []
             },
             {


### PR DESCRIPTION
## Summary

Stacked on #2889 (independent fix, same bug-ticket sweep).

A `.filter()`/`.find()` predicate comparing against a bare-props-form BODY-destructured, RENAMED prop (`const { fallbackLabel: skipLabel } = props`, the #2788 alias family) lowered to Perl's numeric `!=`/`==` instead of string `ne`/`eq`. `'Alpha' != 'Alpha'` and `'Beta' != 'Alpha'` both numify to `0 != 0`, so every row was silently filtered out regardless of the real string value.

The issue's own diagnosis pointed at `MojoFilterEmitter.identifier()` never resolving the alias — investigation showed that's actually already correct (Mojo's stash derivation resolves `$skipLabel` for both emitters). The real gap: `collectStringValueNames`'s string-typed-name witness (which decides `eq`/`ne` vs `==`/`!=`) had no notion of this alias family at all, so the comparison fell through to numeric regardless of which variable name it saw.

`collectStringValueNames` now also resolves this alias family via the shared `resolveBodyDestructuredPropAliases` helper (already used by the #2788 top-level splice path), so both `MojoTopLevelEmitter` and `MojoFilterEmitter` read the same, now-correct witness. Un-pins the existing `filter-predicate-renamed-prop` conformance fixture's Mojo render divergence (`render-divergences.ts`).

Fixes https://github.com/piconic-ai/barefootjs/issues/2883.

## Test plan

- [x] `bun test packages/adapter-mojolicious/src/__tests__/mojo-adapter.test.ts -t 2883` — new regression test asserting `ne`/not `!=`.
- [x] `bun test packages/adapter-mojolicious` — 1871 pass / 40 skip (real Perl execution skipped, no Mojolicious in this sandbox) / 1 fail + 1 error, both confirmed pre-existing and unrelated (`vite.test.ts`'s `@barefootjs/vite` module-resolution gap, reproduces identically on unmodified `main`).
- [x] `bunx tsgo --noEmit -p packages/adapter-mojolicious/tsconfig.json` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166GL67BeXNZb4duYnnn6kt

---
_Generated by [Claude Code](https://claude.ai/code/session_0166GL67BeXNZb4duYnnn6kt)_