### PR TITLE
Fix #2798: nested .map() over plain elements inside a static outer row is unwired

### DIFF
--- a/.changeset/static-nested-loop-bindings-2798.md
+++ b/.changeset/static-nested-loop-bindings-2798.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Fix #2798: a static (non-signal) array's nested `.map()` over PLAIN ELEMENTS (not child components) inside a static outer row wired up nothing at all — no `ref` invocation, no reactive text or attribute effect — even though the outer row's own bindings, and a depth-N CHILD COMPONENT inner loop, were already faithfully wired. `buildStaticArrayChildInitsPlan`'s `elem.innerLoops` pass only ever ran for a matching nested child component (`innerComps.length === 0` skipped the loop entirely), so a plain-element inner loop's row stayed frozen at its SSR-baked value. The same `inner-loop-nested` double-`forEach` shape now also wires the inner loop's own reactive attrs/texts/refs, scoped to depth-1 nesting under a plain-element-rooted outer item (deeper nesting remains a documented known limitation — `NestedLoop` has no parent link to thread a second offset through).

--- a/packages/adapter-go-template/src/conformance-pins.ts
+++ b/packages/adapter-go-template/src/conformance-pins.ts
@@ -101,4 +101,19 @@ export const conformancePins: ConformancePins = {
   // resolves the primitive normally and never reaches this refusal (formerly
   // tracked as #2771, closed) — no open issue tracks further work.
   'namespace-import-primitive': [{ code: 'BF013', severity: 'error' }],
+  // #2893: `analyzeBakeableStaticElementLoop`'s static-array bake (Go's only
+  // path to bind a static/non-signal array as a loop source — `html/template`
+  // has no slice literal syntax) bails the WHOLE loop when the body contains
+  // a nested `loop` node (module docstring, `static-element-loop-bake.ts`).
+  // This fixture's outer static array's row has a nested `.map()` over
+  // `item.children`, so it falls through to the generic "computed loop
+  // array" BF101 refusal. Unrelated to #2798's own fix (a client-JS-only
+  // ref/reactive-binding gap) — this is a pre-existing Go-adapter SSR
+  // static-loop-baking scope boundary the new fixture happened to be the
+  // first to exercise.
+  'static-nested-loop-ref': [{
+    code: 'BF101',
+    severity: 'error',
+    issue: 'https://github.com/piconic-ai/barefootjs/issues/2893',
+  }],
 }

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -5455,6 +5455,60 @@
       "axes": [],
       "contexts": []
     },
+    "static-nested-loop-ref": {
+      "kinds": [
+        "array-literal",
+        "call",
+        "identifier",
+        "literal",
+        "member",
+        "object-literal",
+        "unsupported"
+      ],
+      "axes": [
+        "literal:number"
+      ],
+      "contexts": [
+        "attribute",
+        "loop",
+        "text"
+      ]
+    },
+    "static-nested-loop-ref-client": {
+      "kinds": [
+        "array-literal",
+        "call",
+        "identifier",
+        "literal",
+        "member",
+        "unsupported"
+      ],
+      "axes": [
+        "literal:number"
+      ],
+      "contexts": [
+        "attribute",
+        "loop",
+        "text"
+      ]
+    },
+    "static-nested-loop-ref-precomputed": {
+      "kinds": [
+        "call",
+        "identifier",
+        "literal",
+        "member",
+        "unsupported"
+      ],
+      "axes": [
+        "literal:number"
+      ],
+      "contexts": [
+        "attribute",
+        "loop",
+        "text"
+      ]
+    },
     "string-concat-plus": {
       "kinds": [
         "binary",
@@ -6265,21 +6319,21 @@
     }
   },
   "kindCounts": {
-    "array-literal": 99,
+    "array-literal": 101,
     "array-method": 71,
     "arrow": 72,
     "binary": 103,
-    "call": 264,
+    "call": 267,
     "conditional": 31,
-    "identifier": 367,
+    "identifier": 370,
     "index-access": 14,
-    "literal": 292,
+    "literal": 295,
     "logical": 49,
-    "member": 209,
-    "object-literal": 83,
+    "member": 212,
+    "object-literal": 84,
     "template-literal": 31,
     "unary": 27,
-    "unsupported": 47
+    "unsupported": 50
   },
   "axisCounts": {
     "array-method:at": 2,
@@ -6319,7 +6373,7 @@
     "binary:>=": 1,
     "literal:boolean": 61,
     "literal:null": 23,
-    "literal:number": 129,
+    "literal:number": 132,
     "literal:string": 207,
     "logical:&&": 7,
     "logical:??": 41,

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -420,6 +420,8 @@ import { fixture as nestedLoopOuterBinding } from './nested-loop-outer-binding'
 import { fixture as nestedLoopTripleDepth } from './nested-loop-triple-depth'
 import { fixture as nestedLoopRefConst } from './nested-loop-ref-const'
 import { fixture as staticNestedLoopRef } from './static-nested-loop-ref'
+import { fixture as staticNestedLoopRefClient } from './static-nested-loop-ref-client'
+import { fixture as staticNestedLoopRefPrecomputed } from './static-nested-loop-ref-precomputed'
 import { fixture as nestedLoopIndependentSignal } from './nested-loop-independent-signal'
 import { fixture as keyedLoopPureIndexReorder } from './keyed-loop-pure-index-reorder'
 import { fixture as ternaryTemplateLiteralBranch } from './ternary-template-literal-branch'
@@ -929,6 +931,8 @@ export const jsxFixtures: JSXFixture[] = [
   nestedLoopTripleDepth,
   nestedLoopRefConst,
   staticNestedLoopRef,
+  staticNestedLoopRefClient,
+  staticNestedLoopRefPrecomputed,
   nestedLoopIndependentSignal,
   keyedLoopPureIndexReorder,
   ternaryTemplateLiteralBranch,

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -419,6 +419,7 @@ import { fixture as nestedMapIndexKey } from './nested-map-index-key'
 import { fixture as nestedLoopOuterBinding } from './nested-loop-outer-binding'
 import { fixture as nestedLoopTripleDepth } from './nested-loop-triple-depth'
 import { fixture as nestedLoopRefConst } from './nested-loop-ref-const'
+import { fixture as staticNestedLoopRef } from './static-nested-loop-ref'
 import { fixture as nestedLoopIndependentSignal } from './nested-loop-independent-signal'
 import { fixture as keyedLoopPureIndexReorder } from './keyed-loop-pure-index-reorder'
 import { fixture as ternaryTemplateLiteralBranch } from './ternary-template-literal-branch'
@@ -927,6 +928,7 @@ export const jsxFixtures: JSXFixture[] = [
   nestedLoopOuterBinding,
   nestedLoopTripleDepth,
   nestedLoopRefConst,
+  staticNestedLoopRef,
   nestedLoopIndependentSignal,
   keyedLoopPureIndexReorder,
   ternaryTemplateLiteralBranch,

--- a/packages/adapter-tests/fixtures/nested-loop-ref-const.ts
+++ b/packages/adapter-tests/fixtures/nested-loop-ref-const.ts
@@ -13,12 +13,17 @@ import { createFixture } from '../src/types'
  * the first inner row constructs.
  *
  * `items` MUST be signal-backed, not a plain literal array: a literal array
- * routes through the hoisted static-array fast path, which never splices in
- * a ref call site at ANY depth (a separate, pre-existing gap — see #2798) —
- * that path would make this fixture pass regardless of whether #2750's fix
- * is present, defeating the whole point. Only the dynamic `mapArray`/
- * row-construction path (taken for a signal-backed array) emits the ref call
- * site this fixture exists to pin.
+ * routes through the hoisted static-array fast path. #2798 fixed that path's
+ * DEPTH-1 nested `.map()` (a plain-element inner loop directly inside the
+ * static outer row now wires its own ref/reactive-text/reactive-attr
+ * bindings, `buildInnerLoopNestedPlan` in `plan/build-static-array-child-
+ * init.ts`), but this fixture's shape is DEPTH-2 (`row.children.map(child
+ * => <span ref={trackMount}>...)` nested two levels inside the outer
+ * `.map()`) — out of #2798's scope (`NestedLoop` has no parent link to
+ * thread a second offset through), so a literal array here would still
+ * silently drop the ref. Using a signal-backed array instead routes through
+ * the dynamic `mapArray`/row-construction path regardless of depth, which is
+ * what this fixture exists to pin — #2750's bug, not #2798's.
  *
  * `ref` is a no-op here — this fixture's only concern is that the referenced
  * const is DECLARED and CALLABLE, not what it does once called, so no body

--- a/packages/adapter-tests/fixtures/static-nested-loop-ref-client.ts
+++ b/packages/adapter-tests/fixtures/static-nested-loop-ref-client.ts
@@ -1,0 +1,40 @@
+import { createFixture } from '../src/types'
+
+/**
+ * `/* @client *​/` twin of `static-nested-loop-ref` (#2798 fix, #2893 Go
+ * template refusal).
+ *
+ * The marker defers the whole outer loop to client evaluation, so SSR
+ * renders the empty `<ul>` on EVERY adapter and no BF101 may fire — same
+ * suppression contract as `filter-nested-callback-predicate-client.ts`.
+ * Verifies the Go template adapter's BF101 refusal (pinned in
+ * `conformance-pins.ts` for the non-@client fixture, #2893) has a working
+ * escape, as its own diagnostic suggestion claims.
+ */
+export const fixture = createFixture({
+  id: 'static-nested-loop-ref-client',
+  description: 'static outer array + nested inner .map() + /* @client */ suppresses the Go template BF101 refusal (#2893)',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function StaticNestedLoopRefClient() {
+  const items = [{ id: 1, children: [{ id: 11 }, { id: 12 }] }]
+  const [count] = createSignal(0)
+  const trackMount = (el: Element) => { el.setAttribute('data-tracked', '1') }
+  return (
+    <ul>
+      {/* @client */ items.map(item => (
+        <li key={item.id}>
+          {item.children.map(child => (
+            <span key={child.id} ref={trackMount}>{child.id}:{count()}</span>
+          ))}
+        </li>
+      ))}
+    </ul>
+  )
+}
+`,
+  expectedHtml: `
+    <ul bf-s="test" bf="s4"></ul>
+  `,
+})

--- a/packages/adapter-tests/fixtures/static-nested-loop-ref-client.ts
+++ b/packages/adapter-tests/fixtures/static-nested-loop-ref-client.ts
@@ -10,6 +10,15 @@ import { createFixture } from '../src/types'
  * Verifies the Go template adapter's BF101 refusal (pinned in
  * `conformance-pins.ts` for the non-@client fixture, #2893) has a working
  * escape, as its own diagnostic suggestion claims.
+ *
+ * `items` is an EMPTY literal array (unlike the non-@client twin's
+ * populated one) — CSR conformance compares `expectedHtml` against the
+ * POST-HYDRATION DOM, not raw SSR output, and `/* @client *​/` genuinely
+ * renders the loop client-side once hydrated. A populated array would
+ * hydrate to real `<li>`/`<span>` content, diverging from the empty SSR
+ * markup this fixture pins. Empty keeps SSR and post-hydration state
+ * identical, matching `filter-nested-callback-predicate-client.ts`'s
+ * same empty-signal precedent.
  */
 export const fixture = createFixture({
   id: 'static-nested-loop-ref-client',
@@ -17,8 +26,9 @@ export const fixture = createFixture({
   source: `
 'use client'
 import { createSignal } from '@barefootjs/client'
+type Item = { id: number; children: { id: number }[] }
 export function StaticNestedLoopRefClient() {
-  const items = [{ id: 1, children: [{ id: 11 }, { id: 12 }] }]
+  const items: Item[] = []
   const [count] = createSignal(0)
   const trackMount = (el: Element) => { el.setAttribute('data-tracked', '1') }
   return (

--- a/packages/adapter-tests/fixtures/static-nested-loop-ref-precomputed.ts
+++ b/packages/adapter-tests/fixtures/static-nested-loop-ref-precomputed.ts
@@ -1,0 +1,55 @@
+import { createFixture } from '../src/types'
+
+/**
+ * `prop-precompute` twin of `static-nested-loop-ref` (#2893) — the SECOND
+ * escape kind the Go template BF101 diagnostic claims, alongside
+ * `static-nested-loop-ref-client`.
+ *
+ * The base refuses on the Go template adapter because `items` is a
+ * component-scope LOCAL const — `analyzeBakeableStaticElementLoop`'s
+ * static-loop bake can't unroll the nested inner `.map()`, and the
+ * generic "local computed value" BF101 fallback fires. That refusal keys
+ * specifically on `this.state.localConstants` (`go-template-adapter.ts`),
+ * so it never fires for a PROP at all — a prop binds as an ordinary Go
+ * struct field, same as `static-array-from-props-precomputed`'s twin.
+ * Moving the array to a prop escapes with full SSR (contrast with the
+ * `-client` twin, which renders the loop host empty until hydration).
+ *
+ * This does NOT fix #2893 — the compiler still cannot bake a nested
+ * inner `.map()` inside a LOCAL static array's row on the Go template
+ * adapter. What it proves is that the refusal's first-listed escape
+ * genuinely works, full SSR included.
+ */
+export const fixture = createFixture({
+  id: 'static-nested-loop-ref-precomputed',
+  description: 'prop-precompute twin of static-nested-loop-ref — items moved to a prop, full SSR (#2893)',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+
+type Child = { id: number }
+type Item = { id: number; children: Child[] }
+
+export function StaticNestedLoopRefPrecomputed(props: { items: Item[] }) {
+  const [count] = createSignal(0)
+  const trackMount = (el: Element) => { el.setAttribute('data-tracked', '1') }
+  return (
+    <ul>
+      {props.items.map(item => (
+        <li key={item.id}>
+          {item.children.map(child => (
+            <span key={child.id} ref={trackMount}>{child.id}:{count()}</span>
+          ))}
+        </li>
+      ))}
+    </ul>
+  )
+}
+`,
+  props: {
+    items: [{ id: 1, children: [{ id: 11 }, { id: 12 }] }],
+  },
+  expectedHtml: `
+    <ul bf-s="test" bf="s4"><li bf="s3" data-key="1"><span bf="s2" data-key-1="11"><!--bf:s0-->11<!--/-->:<!--bf:s1-->0<!--/--></span><span bf="s2" data-key-1="12"><!--bf:s0-->12<!--/-->:<!--bf:s1-->0<!--/--></span></li></ul>
+  `,
+})

--- a/packages/adapter-tests/fixtures/static-nested-loop-ref.ts
+++ b/packages/adapter-tests/fixtures/static-nested-loop-ref.ts
@@ -53,4 +53,11 @@ export function StaticNestedLoopRef() {
   expectedHtml: `
     <ul bf-s="test" bf="s4"><li bf="s3" data-key="1"><span bf="s2" data-key-1="11"><!--bf:s0-->11<!--/-->:<!--bf:s1-->0<!--/--></span><span bf="s2" data-key-1="12"><!--bf:s0-->12<!--/-->:<!--bf:s1-->0<!--/--></span></li></ul>
   `,
+  // Go template adapter refuses this shape with BF101 (#2893 — its own
+  // static-loop-baking can't unroll a nested inner .map()); the diagnostic's
+  // own suggestion names a /* @client */ escape, verified by the twin below.
+  escapes: [
+    { kind: 'prop-precompute', fixture: 'static-nested-loop-ref-precomputed' },
+    { kind: 'client-directive', fixture: 'static-nested-loop-ref-client' },
+  ],
 })

--- a/packages/adapter-tests/fixtures/static-nested-loop-ref.ts
+++ b/packages/adapter-tests/fixtures/static-nested-loop-ref.ts
@@ -1,0 +1,56 @@
+import { createFixture } from '../src/types'
+
+/**
+ * #2798 — a static (non-signal) array's `.map()` invokes a `ref`
+ * callback on each row, and reactively updates a signal-derived text,
+ * on the TOP-LEVEL row (`buildStaticLoopPlan`). But a nested `.map()`
+ * INSIDE a static outer row's item, over PLAIN ELEMENTS (not child
+ * components), reached `elem.innerLoops` processing only when it had
+ * matching depth-N child components — `buildStaticArrayChildInitsPlan`
+ * skipped a plain-element inner loop entirely
+ * (`innerComps.length === 0` continue), so the row was silently
+ * frozen: no ref invocation, no reactive text/attr effect, even though
+ * both the OUTER row's own bindings and a depth-N CHILD COMPONENT
+ * inner loop were faithfully wired.
+ *
+ * `items` is a plain literal array (not signal-backed) specifically to
+ * take the static fast path — contrast with `nested-loop-ref-const.ts`
+ * (#2750), which needs a signal-backed array because ITS shape is
+ * depth-2, past this fix's depth-1 scope.
+ *
+ * `expectedHtml` is unaffected by the fix — SSR never runs a `ref`
+ * callback at all (a `ref`'s DOM mutation only exists client-side, the
+ * same reasoning `nested-loop-ref-const.ts` documents), and this
+ * fixture's `data-key`/text markup was already correct pre-fix. The
+ * regression pin is the emitted client JS shape, asserted directly in
+ * `packages/jsx/src/__tests__/issue-2798-static-nested-loop-bindings.test.ts`
+ * (this fixture proves the SAME source compiles to correct SSR markup
+ * across every adapter; that test proves the client JS wiring).
+ */
+export const fixture = createFixture({
+  id: 'static-nested-loop-ref',
+  description: 'a ref callback and a signal-derived text inside a nested .map() under a static (non-signal) outer array are wired up (#2798)',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function StaticNestedLoopRef() {
+  const items = [{ id: 1, children: [{ id: 11 }, { id: 12 }] }]
+  const [count] = createSignal(0)
+  const trackMount = (el: Element) => { el.setAttribute('data-tracked', '1') }
+  return (
+    <ul>
+      {items.map(item => (
+        <li key={item.id}>
+          {item.children.map(child => (
+            <span key={child.id} ref={trackMount}>{child.id}:{count()}</span>
+          ))}
+        </li>
+      ))}
+    </ul>
+  )
+}
+`,
+  expectedHtml: `
+    <ul bf-s="test" bf="s4"><li bf="s3" data-key="1"><span bf="s2" data-key-1="11"><!--bf:s0-->11<!--/-->:<!--bf:s1-->0<!--/--></span><span bf="s2" data-key-1="12"><!--bf:s0-->12<!--/-->:<!--bf:s1-->0<!--/--></span></li></ul>
+  `,
+})

--- a/packages/adapter-tests/generated-data-points.json
+++ b/packages/adapter-tests/generated-data-points.json
@@ -2645,6 +2645,14 @@
       }
     }
   ],
+  "static-nested-loop-ref-precomputed": [
+    {
+      "name": "gen:items:empty",
+      "props": {
+        "items": []
+      }
+    }
+  ],
   "string-concat-plus": [
     {
       "name": "gen:name:markup",

--- a/packages/compat/src/__tests__/compat-engine.test.ts
+++ b/packages/compat/src/__tests__/compat-engine.test.ts
@@ -49,16 +49,17 @@ describe('compileForCompat', () => {
     // successor to #2038), #2321 (static-array-from-props computed loop
     // source), #2700 (a `derived` object-literal signal/memo the
     // constructor-time baker can't reproduce, `signal-object-spread-init`),
-    // and #2805 (a named jsx-children prop routed into a child's rest bag,
-    // `jsx-element-prop-rest-bag-dynamic`) surface here even though this
-    // test only exercises the nested-filter-callback shape. Three pins are
-    // no longer among them, each because the shape got a real lowering
-    // rather than a narrower refusal: #2319 (dangerous-inner-html-dynamic →
-    // a faithful raw-output lowering), #2208 (static-array-children → the
-    // loop-source gate bakes a fully-static array-of-objects const), and
-    // #2448 (loop-row child prop override feeding a derived field → the
-    // child rebuilds itself per row through `bf_reprops`). See
-    // `go-template`'s `conformance-pins.ts`.
+    // #2805 (a named jsx-children prop routed into a child's rest bag,
+    // `jsx-element-prop-rest-bag-dynamic`), and #2893 (a nested `.map()`
+    // inside a static outer array's row, `static-nested-loop-ref`) surface
+    // here even though this test only exercises the nested-filter-callback
+    // shape. Three pins are no longer among them, each because the shape
+    // got a real lowering rather than a narrower refusal: #2319
+    // (dangerous-inner-html-dynamic → a faithful raw-output lowering),
+    // #2208 (static-array-children → the loop-source gate bakes a
+    // fully-static array-of-objects const), and #2448 (loop-row child prop
+    // override feeding a derived field → the child rebuilds itself per row
+    // through `bf_reprops`). See `go-template`'s `conformance-pins.ts`.
     expect(cell.diagnostics).toEqual([
       {
         code: 'BF101',
@@ -68,6 +69,7 @@ describe('compileForCompat', () => {
           'https://github.com/piconic-ai/barefootjs/issues/2321',
           'https://github.com/piconic-ai/barefootjs/issues/2700',
           'https://github.com/piconic-ai/barefootjs/issues/2805',
+          'https://github.com/piconic-ai/barefootjs/issues/2893',
         ],
       },
     ])

--- a/packages/jsx/src/__tests__/issue-2798-static-nested-loop-bindings.test.ts
+++ b/packages/jsx/src/__tests__/issue-2798-static-nested-loop-bindings.test.ts
@@ -1,0 +1,127 @@
+/**
+ * #2798: a static (non-signal) array's `.map()` faithfully invokes a
+ * `ref` callback, and reactively updates a signal-derived text, on the
+ * TOP-LEVEL row (`buildStaticLoopPlan`'s `childRefs`/`texts`). But a
+ * nested `.map()` INSIDE a static outer row's item — a plain element,
+ * not a child component — reached `elem.innerLoops` processing only
+ * when it had matching depth-N CHILD COMPONENTS
+ * (`buildStaticArrayChildInitsPlan`'s `innerComps.length === 0`
+ * skip). A plain-element inner loop under a static outer array had
+ * NOTHING wired: no ref invocation, no reactive-text/attr effect — the
+ * whole row was silently frozen at its SSR-baked value.
+ *
+ * (The issue's own repro — a TOP-LEVEL static loop with a `ref` — was
+ * already fixed by the time this was investigated; that shape is
+ * pinned here too as regression armor against the issue's own
+ * misdiagnosis being reintroduced.)
+ */
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../index'
+import { HonoAdapter } from '../../../adapter-hono/src/adapter/index'
+
+function compileClientJs(source: string): string {
+  const result = compileJSX(source, 'test.tsx', { adapter: new HonoAdapter() })
+  expect(result.errors.filter(e => e.severity === 'error')).toHaveLength(0)
+  const clientJs = result.files.find(f => f.type === 'clientJs')
+  if (!clientJs) throw new Error('No client JS emitted')
+  return clientJs.content
+}
+
+describe('static array ref/reactive bindings (#2798)', () => {
+  test('top-level static loop still invokes a ref on each row (regression armor)', () => {
+    const source = `
+'use client'
+export function StaticRefCase() {
+  const items = [{ id: 1 }, { id: 2 }]
+  const trackMount = (el: Element) => { el.setAttribute('data-tracked', '1') }
+  return (
+    <ul>
+      {items.map(item => (
+        <li key={item.id} ref={trackMount}>{item.id}</li>
+      ))}
+    </ul>
+  )
+}
+`
+    const js = compileClientJs(source)
+    expect(js).toContain('(trackMount)(')
+  })
+
+  test('a static outer loop with a nested .map() invokes the inner ref on each row', () => {
+    const source = `
+'use client'
+export function StaticNestedRefCase() {
+  const items = [{ id: 1, children: [{ id: 11 }, { id: 12 }] }]
+  const trackMount = (el: Element) => { el.setAttribute('data-tracked', '1') }
+  return (
+    <ul>
+      {items.map(item => (
+        <li key={item.id}>
+          {item.children.map(child => (
+            <span key={child.id} ref={trackMount}>{child.id}</span>
+          ))}
+        </li>
+      ))}
+    </ul>
+  )
+}
+`
+    const js = compileClientJs(source)
+    // Double forEach (outer item, inner child), with the ref invoked
+    // inside the inner one.
+    expect(js).toContain('items.forEach((item, __idx) => {')
+    expect(js).toContain('item.children.forEach((child, __innerIdx) => {')
+    expect(js).toContain('(trackMount)(')
+  })
+
+  test('a static outer loop with a nested .map() reactively updates a signal-derived inner text', () => {
+    const source = `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function StaticNestedSignalCase() {
+  const items = [{ id: 1, children: [{ id: 11 }, { id: 12 }] }]
+  const [count] = createSignal(0)
+  return (
+    <ul>
+      {items.map(item => (
+        <li key={item.id}>
+          {item.children.map(child => (
+            <span key={child.id}>{child.id}:{count()}</span>
+          ))}
+        </li>
+      ))}
+    </ul>
+  )
+}
+`
+    const js = compileClientJs(source)
+    // Pre-fix, this text was frozen at its SSR-baked value — no
+    // `createEffect` at all inside the inner forEach body.
+    expect(js).toMatch(/createEffect\(\(\) => \{ __bfw_\w+\('s\d+', String\(count\(\)\)\) \}\)/)
+  })
+
+  test('a static outer loop with a nested .map() wires a reactive attr on the inner element', () => {
+    const source = `
+'use client'
+import { createSignal } from '@barefootjs/client'
+export function StaticNestedAttrCase() {
+  const items = [{ id: 1, children: [{ id: 11 }, { id: 12 }] }]
+  const [sel] = createSignal(11)
+  return (
+    <ul>
+      {items.map(item => (
+        <li key={item.id}>
+          {item.children.map(child => (
+            <span key={child.id} data-active={child.id === sel()}>{child.id}</span>
+          ))}
+        </li>
+      ))}
+    </ul>
+  )
+}
+`
+    const js = compileClientJs(source)
+    expect(js).toContain('data-active')
+    expect(js).toMatch(/createEffect\(\(\) => \{/)
+  })
+})

--- a/packages/jsx/src/ir-to-client-js/plan/build-static-array-child-init.ts
+++ b/packages/jsx/src/ir-to-client-js/plan/build-static-array-child-init.ts
@@ -18,7 +18,7 @@
  */
 
 import type { IRLoopChildComponent, MapCallbackPreamble } from '../../types.ts'
-import type { ClientJsContext, NestedLoop, TopLevelLoop } from '../types.ts'
+import type { ClientJsContext, LoopChildReactiveAttr, NestedLoop, TopLevelLoop } from '../types.ts'
 import { quotePropName, varSlotId, attrValueToString, buildLoopChildIndexExpr } from '../utils.ts'
 import { jsxChildrenPropGetterExpr, renderPreamble, irToHtmlTemplate } from '../html-template.ts'
 
@@ -34,7 +34,7 @@ function staticPreludeStatements(preamble: MapCallbackPreamble | undefined): str
       })]
     : []
 }
-import { buildCompSelector } from '../control-flow/shared.ts'
+import { buildCompSelector, buildStaticChildRefBindings } from '../control-flow/shared.ts'
 
 /** The inline prop shape carried on `IRLoopChildComponent.props`. */
 type LoopChildCompProp = IRLoopChildComponent['props'][number]
@@ -66,25 +66,47 @@ export function buildStaticArrayChildInitsPlan(
         if (comp.loopDepth) continue // handled in inner-loop pass
         plans.push(buildOuterNestedPlan(elem, comp))
       }
+    }
 
-      if (elem.innerLoops) {
-        for (const innerLoop of elem.innerLoops) {
-          const innerComps = elem.nestedComponents.filter(c =>
-            (c.loopDepth ?? 0) === innerLoop.depth && c.innerLoopArray === innerLoop.array,
-          )
-          if (innerComps.length === 0) continue
-          // Component-rooted outer item (#1725): the inner `.map()` lives
-          // inside the child component's JSX children. The element-offset
-          // addressing of `inner-loop-nested` can't reach a fragment-rooted
-          // passthrough's flattened items, so use the document-order zip
-          // shape instead.
-          plans.push(
-            elem.childComponent
-              ? buildComponentRootedInnerLoopPlan(elem, innerLoop, innerComps)
-              : buildInnerLoopNestedPlan(elem, innerLoop, innerComps),
-          )
-        }
+    if (!elem.innerLoops) continue
+
+    for (const innerLoop of elem.innerLoops) {
+      const innerComps = (elem.nestedComponents ?? []).filter(c =>
+        (c.loopDepth ?? 0) === innerLoop.depth && c.innerLoopArray === innerLoop.array,
+      )
+
+      if (elem.childComponent) {
+        // Component-rooted outer item (#1725): the inner `.map()` lives
+        // inside the child component's JSX children. The element-offset
+        // addressing of `inner-loop-nested` can't reach a fragment-rooted
+        // passthrough's flattened items, so use the document-order zip
+        // shape instead. (Plain-element bindings on a component-rooted
+        // inner loop aren't addressed by this shape either — out of scope
+        // here, same as this shape's existing filter/sort limitation.)
+        if (innerComps.length === 0) continue
+        plans.push(buildComponentRootedInnerLoopPlan(elem, innerLoop, innerComps))
+        continue
       }
+
+      // Plain-element-rooted outer item: `inner-loop-nested`'s element-offset
+      // addressing also wires up a plain element's own reactive attrs/texts/
+      // refs inside the inner loop (#2798) — previously this whole pass only
+      // ever ran for depth-N CHILD COMPONENTS (gated behind
+      // `elem.nestedComponents.length > 0` with an `innerComps.length === 0`
+      // skip), so a static outer array's nested `.map()` over plain elements
+      // wired up NOTHING: no ref invocation, no reactive text/attr effect,
+      // even though the outer row's OWN bindings at this same depth-0 level
+      // are faithfully wired (`buildStaticLoopPlan`'s `childRefs`/`texts`/
+      // `attrsBySlot`). Scoped to depth 1 — `NestedLoop` has no parent link
+      // to thread a second offset through for depth ≥ 2, and the inner
+      // array expression there reads the depth-1 param, so a flat emission
+      // would `ReferenceError`; deeper nesting stays a known limitation.
+      if (innerLoop.depth !== 1) continue
+      const hasPlainBindings = innerLoop.bindings.refs.length > 0
+        || innerLoop.bindings.reactiveTexts.length > 0
+        || innerLoop.bindings.reactiveAttrs.length > 0
+      if (innerComps.length === 0 && !hasPlainBindings) continue
+      plans.push(buildInnerLoopNestedPlan(elem, innerLoop, innerComps))
     }
   }
 
@@ -147,6 +169,21 @@ function buildInnerLoopNestedPlan(
     propsExpr: buildStaticPropsExpr(comp.props),
   }))
 
+  // Plain-element bindings (#2798) — grouped/passed the same way
+  // `buildStaticLoopPlan` handles the OUTER row's own bindings: `forEach`
+  // binds the param as the raw item value, so texts/attrs stay unwrapped
+  // (no signal-accessor rewrite) and refs go through
+  // `buildStaticChildRefBindings`, not `buildChildRefBindings`.
+  const attrsBySlotMap = new Map<string, LoopChildReactiveAttr[]>()
+  for (const attr of innerLoop.bindings.reactiveAttrs) {
+    let bucket = attrsBySlotMap.get(attr.childSlotId)
+    if (!bucket) {
+      bucket = []
+      attrsBySlotMap.set(attr.childSlotId, bucket)
+    }
+    bucket.push(attr)
+  }
+
   return {
     kind: 'inner-loop-nested',
     containerVar: `_${varSlotId(elem.slotId)}`,
@@ -163,6 +200,9 @@ function buildInnerLoopNestedPlan(
     innerPreludeStatements: staticPreludeStatements(innerLoop.preamble),
     depth: innerLoop.depth,
     comps,
+    attrsBySlot: [...attrsBySlotMap].map(([slotId, attrs]) => [slotId, attrs] as const),
+    texts: innerLoop.bindings.reactiveTexts,
+    refs: buildStaticChildRefBindings(innerLoop.bindings.refs),
   }
 }
 

--- a/packages/jsx/src/ir-to-client-js/plan/static-array-child-init.ts
+++ b/packages/jsx/src/ir-to-client-js/plan/static-array-child-init.ts
@@ -7,7 +7,9 @@
  *   - `outer-nested`       — depth 0 の `nestedComponents`。outer forEach で
  *                            `__iterEl.querySelector(...)` 経由で initChild。
  *   - `inner-loop-nested`  — depth > 0 の `nestedComponents`。outer + inner
- *                            forEach の二重ループで initChild。
+ *                            forEach の二重ループで initChild。同じ二重ループで
+ *                            プレーン要素の ref / reactive text / reactive attr
+ *                            も配線する (#2798、depth 1 のみ)。
  *   - `component-rooted-inner-loop`
  *                          — outer の loop item root が **child component**
  *                            (`loop.childComponent`) で、その JSX children に
@@ -24,6 +26,8 @@
  */
 
 import type { PreludeStatements } from '../control-flow/plan/inner-loop.ts'
+import type { LoopChildRefBinding } from '../control-flow/plan/loop.ts'
+import type { LoopChildReactiveAttr, LoopChildReactiveText } from '../types.ts'
 
 /** Pre-built `{ name: value, ... }` props object expression. */
 export type PropsExpr = string
@@ -143,6 +147,20 @@ export interface InnerLoopNestedInitPlan {
   depth: number
   /** Per-component initialisers emitted inside the inner forEach body. */
   comps: readonly InnerLoopComp[]
+  /**
+   * Reactive attrs on plain elements inside this inner loop's body,
+   * grouped by child slot id (#2798 — a static outer array's nested
+   * `.map()` over plain elements used to wire up NOTHING: no refs, no
+   * reactive text/attr effects, since the whole `elem.innerLoops` pass
+   * only ever ran for depth-N CHILD COMPONENTS). Only populated for a
+   * depth-1 inner loop under a plain-element-rooted outer item — see
+   * `buildStaticArrayChildInitsPlan`'s docstring.
+   */
+  attrsBySlot: ReadonlyArray<readonly [string, readonly LoopChildReactiveAttr[]]>
+  /** Reactive text interpolations inside this inner loop's body (#2798). */
+  texts: readonly LoopChildReactiveText[]
+  /** Imperative ref callbacks on elements inside this inner loop's body (#2798). */
+  refs: readonly LoopChildRefBinding[]
 }
 
 /**

--- a/packages/jsx/src/ir-to-client-js/stringify/static-array-child-init.ts
+++ b/packages/jsx/src/ir-to-client-js/stringify/static-array-child-init.ts
@@ -58,6 +58,10 @@ import type {
   StaticArrayChildInitsPlan,
 } from '../plan/static-array-child-init.ts'
 import { nameForRegistryRef } from '../component-scope.ts'
+import { varSlotId } from '../utils.ts'
+import { emitDedupedAttrUpdate, DEDUP_STORE_DECL } from '../emit-reactive.ts'
+import { claimPlanLiteral, claimWriterVarName, type ClaimSlotSpec } from '../control-flow/stringify/claim-plan.ts'
+import { emitLoopChildRefs } from '../control-flow/stringify/loop.ts'
 
 export function stringifyStaticArrayChildInits(
   lines: string[],
@@ -142,6 +146,9 @@ function emitInnerLoopNested(lines: string[], plan: InnerLoopNestedInitPlan): vo
     innerPreludeStatements,
     depth,
     comps,
+    attrsBySlot,
+    texts,
+    refs,
   } = plan
   lines.push(`  // Initialize inner-loop components in static array (depth ${depth})`)
   lines.push(`  if (${containerVar}) {`)
@@ -174,6 +181,38 @@ function emitInnerLoopNested(lines: string[], plan: InnerLoopNestedInitPlan): vo
     lines.push(`        const ${compElVar} = qsaChildScope(__innerEl, ${comp.selector})`)
     lines.push(`        if (${compElVar}) initChild('${nameForRegistryRef(comp.componentName)}', ${compElVar}, ${comp.propsExpr})`)
   })
+  // Plain-element reactive attrs / texts / refs inside this inner loop's
+  // body (#2798) — mirrors `stringifyStaticLoop`'s own per-row wiring for
+  // the OUTER static loop, one nesting level in. `forEach` binds
+  // `innerParam` as the raw item value, so `texts`/`attrsBySlot`
+  // expressions stay unwrapped, same as the outer row.
+  if (attrsBySlot.length > 0) lines.push(`        ${DEDUP_STORE_DECL}`)
+  let ordinal = 0
+  for (const [slotId, attrs] of attrsBySlot) {
+    const varName = `__t_${varSlotId(slotId)}`
+    lines.push(`        const ${varName} = qsa(__innerEl, '[bf="${slotId}"]')`)
+    lines.push(`        if (${varName}) {`)
+    for (const attr of attrs) {
+      lines.push(`          createEffect(() => {`)
+      for (const stmt of emitDedupedAttrUpdate(varName, attr.attrName, attr.expression, attr, ordinal++)) {
+        lines.push(`            ${stmt}`)
+      }
+      lines.push(`          })`)
+    }
+    lines.push(`        }`)
+  }
+  if (texts.length > 0) {
+    const slots: ClaimSlotSpec[] = texts.map(t => ({ id: t.slotId, kind: 'text', path: [] }))
+    const writer = claimWriterVarName(slots, varSlotId)
+    lines.push(`        const ${writer} = lazySlots(__innerEl, ${claimPlanLiteral(slots)})`)
+    for (const text of texts) {
+      lines.push(`        createEffect(() => { ${writer}('${text.slotId}', String(${text.expression})) })`)
+    }
+  }
+  // Ref callbacks fire on every forEach iteration — initial mount and any
+  // future array-change-driven re-iteration. For a static array the array
+  // is non-reactive, so refs effectively fire once per item (#1244).
+  emitLoopChildRefs(lines, refs, { indent: '        ', elVar: '__innerEl', bodyIsMultiRoot: false })
   lines.push(`      })`)
   lines.push(`    })`)
   lines.push(`  }`)

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-conformance section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. This answers, per fixture and per adapter, whether the construct WORKS — not just whether it compiles. A construct works either as written (✓) or with a documented `/* @client */` comment (✓†, a verified, supported escape — most refusals have one). Fixtures absent from the table below work on every adapter — most as written, some via that documented escape; the headline says how many of each. Listed fixtures need attention somewhere: a bare diagnostic code is still-open debt with no escape yet, a code led by ✗ owes no escape at all (by design), and ≠ means the fixture compiles clean but its rendered output diverges from the reference.",
-    "totalFixtures": 389,
+    "totalFixtures": 390,
     "fixtures": {
       "date-method-uncatalogued": {
         "blade": {

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-conformance section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. This answers, per fixture and per adapter, whether the construct WORKS — not just whether it compiles. A construct works either as written (✓) or with a documented `/* @client */` comment (✓†, a verified, supported escape — most refusals have one). Fixtures absent from the table below work on every adapter — most as written, some via that documented escape; the headline says how many of each. Listed fixtures need attention somewhere: a bare diagnostic code is still-open debt with no escape yet, a code led by ✗ owes no escape at all (by design), and ≠ means the fixture compiles clean but its rendered output diverges from the reference.",
-    "totalFixtures": 390,
+    "totalFixtures": 392,
     "fixtures": {
       "date-method-uncatalogued": {
         "blade": {
@@ -3479,6 +3479,21 @@
           }
         }
       },
+      "static-nested-loop-ref": {
+        "go-template": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2893"
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "static-nested-loop-ref-precomputed"
+          }
+        }
+      },
       "tag-cloud": {
         "blade": {
           "kind": "refusal",
@@ -3651,6 +3666,10 @@
         "description": "Static-array loop with childComponent body materialises rendered children on CSR (#1268)",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-array-from-props-with-component.ts"
       },
+      "static-nested-loop-ref": {
+        "description": "a ref callback and a signal-derived text inside a nested .map() under a static (non-signal) outer…",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-nested-loop-ref.ts"
+      },
       "tag-cloud": {
         "description": "flatMap block-body tag list — hydration adoption, in-place leaf patch, add, and remove",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/tag-cloud.ts"
@@ -3710,6 +3729,10 @@
       "static-array-from-props-with-component-precomputed": {
         "description": "prop-precompute twin of static-array-from-props-with-component — child components render at SSR…",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-array-from-props-with-component-precomputed.ts"
+      },
+      "static-nested-loop-ref-precomputed": {
+        "description": "prop-precompute twin of static-nested-loop-ref — items moved to a prop, full SSR (#2893)",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-nested-loop-ref-precomputed.ts"
       }
     }
   },

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -14,15 +14,15 @@
   ],
   "kinds": {
     "array-literal": {
-      "total": 99,
+      "total": 101,
       "cells": {
         "hono": {
-          "pass": 99,
-          "total": 99
+          "pass": 101,
+          "total": 101
         },
         "blade": {
-          "pass": 87,
-          "total": 99,
+          "pass": 89,
+          "total": 101,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -79,8 +79,8 @@
           ]
         },
         "erb": {
-          "pass": 88,
-          "total": 99,
+          "pass": 90,
+          "total": 101,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -131,8 +131,8 @@
           ]
         },
         "go-template": {
-          "pass": 87,
-          "total": 99,
+          "pass": 88,
+          "total": 101,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -183,14 +183,20 @@
               "issues": []
             },
             {
+              "fixture": "static-nested-loop-ref",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2893"
+              ]
+            },
+            {
               "fixture": "tag-cloud",
               "issues": []
             }
           ]
         },
         "jinja": {
-          "pass": 87,
-          "total": 99,
+          "pass": 89,
+          "total": 101,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -247,8 +253,8 @@
           ]
         },
         "minijinja": {
-          "pass": 87,
-          "total": 99,
+          "pass": 89,
+          "total": 101,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -305,8 +311,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 88,
-          "total": 99,
+          "pass": 90,
+          "total": 101,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -357,8 +363,8 @@
           ]
         },
         "twig": {
-          "pass": 87,
-          "total": 99,
+          "pass": 89,
+          "total": 101,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -415,8 +421,8 @@
           ]
         },
         "xslate": {
-          "pass": 87,
-          "total": 99,
+          "pass": 89,
+          "total": 101,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1418,11 +1424,11 @@
       }
     },
     "call": {
-      "total": 264,
+      "total": 267,
       "cells": {
         "hono": {
-          "pass": 262,
-          "total": 264,
+          "pass": 265,
+          "total": 267,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1437,8 +1443,8 @@
           ]
         },
         "blade": {
-          "pass": 248,
-          "total": 264,
+          "pass": 251,
+          "total": 267,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1517,8 +1523,8 @@
           ]
         },
         "erb": {
-          "pass": 249,
-          "total": 264,
+          "pass": 252,
+          "total": 267,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1591,8 +1597,8 @@
           ]
         },
         "go-template": {
-          "pass": 247,
-          "total": 264,
+          "pass": 249,
+          "total": 267,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1671,14 +1677,20 @@
               ]
             },
             {
+              "fixture": "static-nested-loop-ref",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2893"
+              ]
+            },
+            {
               "fixture": "tag-cloud",
               "issues": []
             }
           ]
         },
         "jinja": {
-          "pass": 248,
-          "total": 264,
+          "pass": 251,
+          "total": 267,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1757,8 +1769,8 @@
           ]
         },
         "minijinja": {
-          "pass": 248,
-          "total": 264,
+          "pass": 251,
+          "total": 267,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1837,8 +1849,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 249,
-          "total": 264,
+          "pass": 252,
+          "total": 267,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1911,8 +1923,8 @@
           ]
         },
         "twig": {
-          "pass": 248,
-          "total": 264,
+          "pass": 251,
+          "total": 267,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1991,8 +2003,8 @@
           ]
         },
         "xslate": {
-          "pass": 248,
-          "total": 264,
+          "pass": 251,
+          "total": 267,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2216,11 +2228,11 @@
       }
     },
     "identifier": {
-      "total": 367,
+      "total": 370,
       "cells": {
         "hono": {
-          "pass": 363,
-          "total": 367,
+          "pass": 366,
+          "total": 370,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2243,8 +2255,8 @@
           ]
         },
         "blade": {
-          "pass": 347,
-          "total": 367,
+          "pass": 350,
+          "total": 370,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2339,8 +2351,8 @@
           ]
         },
         "erb": {
-          "pass": 348,
-          "total": 367,
+          "pass": 351,
+          "total": 370,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2429,8 +2441,8 @@
           ]
         },
         "go-template": {
-          "pass": 345,
-          "total": 367,
+          "pass": 347,
+          "total": 370,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2531,14 +2543,20 @@
               ]
             },
             {
+              "fixture": "static-nested-loop-ref",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2893"
+              ]
+            },
+            {
               "fixture": "tag-cloud",
               "issues": []
             }
           ]
         },
         "jinja": {
-          "pass": 347,
-          "total": 367,
+          "pass": 350,
+          "total": 370,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2633,8 +2651,8 @@
           ]
         },
         "minijinja": {
-          "pass": 347,
-          "total": 367,
+          "pass": 350,
+          "total": 370,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2729,8 +2747,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 348,
-          "total": 367,
+          "pass": 351,
+          "total": 370,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2819,8 +2837,8 @@
           ]
         },
         "twig": {
-          "pass": 347,
-          "total": 367,
+          "pass": 350,
+          "total": 370,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2915,8 +2933,8 @@
           ]
         },
         "xslate": {
-          "pass": 347,
-          "total": 367,
+          "pass": 350,
+          "total": 370,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3076,11 +3094,11 @@
       }
     },
     "literal": {
-      "total": 292,
+      "total": 295,
       "cells": {
         "hono": {
-          "pass": 291,
-          "total": 292,
+          "pass": 294,
+          "total": 295,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -3089,8 +3107,8 @@
           ]
         },
         "blade": {
-          "pass": 280,
-          "total": 292,
+          "pass": 283,
+          "total": 295,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3145,8 +3163,8 @@
           ]
         },
         "erb": {
-          "pass": 280,
-          "total": 292,
+          "pass": 283,
+          "total": 295,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3201,8 +3219,8 @@
           ]
         },
         "go-template": {
-          "pass": 278,
-          "total": 292,
+          "pass": 280,
+          "total": 295,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3263,14 +3281,20 @@
               ]
             },
             {
+              "fixture": "static-nested-loop-ref",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2893"
+              ]
+            },
+            {
               "fixture": "tag-cloud",
               "issues": []
             }
           ]
         },
         "jinja": {
-          "pass": 280,
-          "total": 292,
+          "pass": 283,
+          "total": 295,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3325,8 +3349,8 @@
           ]
         },
         "minijinja": {
-          "pass": 280,
-          "total": 292,
+          "pass": 283,
+          "total": 295,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3381,8 +3405,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 280,
-          "total": 292,
+          "pass": 283,
+          "total": 295,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3437,8 +3461,8 @@
           ]
         },
         "twig": {
-          "pass": 280,
-          "total": 292,
+          "pass": 283,
+          "total": 295,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3493,8 +3517,8 @@
           ]
         },
         "xslate": {
-          "pass": 280,
-          "total": 292,
+          "pass": 283,
+          "total": 295,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3710,11 +3734,11 @@
       }
     },
     "member": {
-      "total": 209,
+      "total": 212,
       "cells": {
         "hono": {
-          "pass": 206,
-          "total": 209,
+          "pass": 209,
+          "total": 212,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3733,8 +3757,8 @@
           ]
         },
         "blade": {
-          "pass": 190,
-          "total": 209,
+          "pass": 193,
+          "total": 212,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3825,8 +3849,8 @@
           ]
         },
         "erb": {
-          "pass": 191,
-          "total": 209,
+          "pass": 194,
+          "total": 212,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3911,8 +3935,8 @@
           ]
         },
         "go-template": {
-          "pass": 188,
-          "total": 209,
+          "pass": 190,
+          "total": 212,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4009,14 +4033,20 @@
               ]
             },
             {
+              "fixture": "static-nested-loop-ref",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2893"
+              ]
+            },
+            {
               "fixture": "tag-cloud",
               "issues": []
             }
           ]
         },
         "jinja": {
-          "pass": 190,
-          "total": 209,
+          "pass": 193,
+          "total": 212,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4107,8 +4137,8 @@
           ]
         },
         "minijinja": {
-          "pass": 190,
-          "total": 209,
+          "pass": 193,
+          "total": 212,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4199,8 +4229,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 191,
-          "total": 209,
+          "pass": 194,
+          "total": 212,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4285,8 +4315,8 @@
           ]
         },
         "twig": {
-          "pass": 190,
-          "total": 209,
+          "pass": 193,
+          "total": 212,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4377,8 +4407,8 @@
           ]
         },
         "xslate": {
-          "pass": 190,
-          "total": 209,
+          "pass": 193,
+          "total": 212,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4482,15 +4512,15 @@
       }
     },
     "object-literal": {
-      "total": 83,
+      "total": 84,
       "cells": {
         "hono": {
-          "pass": 83,
-          "total": 83
+          "pass": 84,
+          "total": 84
         },
         "blade": {
-          "pass": 80,
-          "total": 83,
+          "pass": 81,
+          "total": 84,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4509,8 +4539,8 @@
           ]
         },
         "erb": {
-          "pass": 80,
-          "total": 83,
+          "pass": 81,
+          "total": 84,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4530,7 +4560,7 @@
         },
         "go-template": {
           "pass": 79,
-          "total": 83,
+          "total": 84,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4549,14 +4579,20 @@
               ]
             },
             {
+              "fixture": "static-nested-loop-ref",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2893"
+              ]
+            },
+            {
               "fixture": "tag-cloud",
               "issues": []
             }
           ]
         },
         "jinja": {
-          "pass": 80,
-          "total": 83,
+          "pass": 81,
+          "total": 84,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4575,8 +4611,8 @@
           ]
         },
         "minijinja": {
-          "pass": 80,
-          "total": 83,
+          "pass": 81,
+          "total": 84,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4595,8 +4631,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 80,
-          "total": 83,
+          "pass": 81,
+          "total": 84,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4615,8 +4651,8 @@
           ]
         },
         "twig": {
-          "pass": 80,
-          "total": 83,
+          "pass": 81,
+          "total": 84,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4635,8 +4671,8 @@
           ]
         },
         "xslate": {
-          "pass": 80,
-          "total": 83,
+          "pass": 81,
+          "total": 84,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4950,15 +4986,15 @@
       }
     },
     "unsupported": {
-      "total": 47,
+      "total": 50,
       "cells": {
         "hono": {
-          "pass": 47,
-          "total": 47
+          "pass": 50,
+          "total": 50
         },
         "blade": {
-          "pass": 37,
-          "total": 47,
+          "pass": 40,
+          "total": 50,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -5007,8 +5043,8 @@
           ]
         },
         "erb": {
-          "pass": 37,
-          "total": 47,
+          "pass": 40,
+          "total": 50,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -5057,8 +5093,8 @@
           ]
         },
         "go-template": {
-          "pass": 37,
-          "total": 47,
+          "pass": 39,
+          "total": 50,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -5101,14 +5137,20 @@
               ]
             },
             {
+              "fixture": "static-nested-loop-ref",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2893"
+              ]
+            },
+            {
               "fixture": "tag-cloud",
               "issues": []
             }
           ]
         },
         "jinja": {
-          "pass": 37,
-          "total": 47,
+          "pass": 40,
+          "total": 50,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -5157,8 +5199,8 @@
           ]
         },
         "minijinja": {
-          "pass": 37,
-          "total": 47,
+          "pass": 40,
+          "total": 50,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -5207,8 +5249,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 37,
-          "total": 47,
+          "pass": 40,
+          "total": 50,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -5257,8 +5299,8 @@
           ]
         },
         "twig": {
-          "pass": 37,
-          "total": 47,
+          "pass": 40,
+          "total": 50,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -5307,8 +5349,8 @@
           ]
         },
         "xslate": {
-          "pass": 37,
-          "total": 47,
+          "pass": 40,
+          "total": 50,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -7923,15 +7965,15 @@
       }
     },
     "literal:number": {
-      "total": 129,
+      "total": 132,
       "cells": {
         "hono": {
-          "pass": 129,
-          "total": 129
+          "pass": 132,
+          "total": 132
         },
         "blade": {
-          "pass": 124,
-          "total": 129,
+          "pass": 127,
+          "total": 132,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7956,8 +7998,8 @@
           ]
         },
         "erb": {
-          "pass": 124,
-          "total": 129,
+          "pass": 127,
+          "total": 132,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -7982,8 +8024,8 @@
           ]
         },
         "go-template": {
-          "pass": 124,
-          "total": 129,
+          "pass": 126,
+          "total": 132,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8002,14 +8044,20 @@
               "issues": []
             },
             {
+              "fixture": "static-nested-loop-ref",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2893"
+              ]
+            },
+            {
               "fixture": "tag-cloud",
               "issues": []
             }
           ]
         },
         "jinja": {
-          "pass": 124,
-          "total": 129,
+          "pass": 127,
+          "total": 132,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8034,8 +8082,8 @@
           ]
         },
         "minijinja": {
-          "pass": 124,
-          "total": 129,
+          "pass": 127,
+          "total": 132,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8060,8 +8108,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 124,
-          "total": 129,
+          "pass": 127,
+          "total": 132,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8086,8 +8134,8 @@
           ]
         },
         "twig": {
-          "pass": 124,
-          "total": 129,
+          "pass": 127,
+          "total": 132,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8112,8 +8160,8 @@
           ]
         },
         "xslate": {
-          "pass": 124,
-          "total": 129,
+          "pass": 127,
+          "total": 132,
           "gaps": [
             {
               "fixture": "fill-unsupported",


### PR DESCRIPTION
## Summary

Stacked on #2890 (independent fix, same bug-ticket sweep).

A static (non-signal) array's nested `.map()` over PLAIN ELEMENTS (not child components) inside a static outer row wired up nothing at all — no `ref` invocation, no reactive text or attribute effect — even though the outer row's own bindings, and a depth-N CHILD COMPONENT inner loop, were already faithfully wired. `buildStaticArrayChildInitsPlan`'s `elem.innerLoops` pass only ever ran when it found a matching nested CHILD COMPONENT (`innerComps.length === 0` skipped the loop entirely), so a plain-element inner loop's row stayed frozen at its SSR-baked value: neither a `ref` callback nor a signal-derived text/attr inside it ever updated.

The issue's own repro (a TOP-LEVEL static loop with a `ref`) turned out to already work correctly — that's pinned here as regression armor against the issue's own misdiagnosis being reintroduced. The real, still-open gap was one level deeper.

The existing `inner-loop-nested` double-`forEach` shape (`plan/build-static-array-child-init.ts`, `stringify/static-array-child-init.ts`) now also wires the inner loop's own reactive attrs/texts/refs, scoped to depth-1 nesting under a plain-element-rooted outer item — `NestedLoop` has no parent link to thread a second offset through for deeper nesting, so that stays a documented known limitation (`nested-loop-ref-const.ts`'s docstring updated to describe the current, narrower gap accurately).

Fixes https://github.com/piconic-ai/barefootjs/issues/2798.

## Test plan

- [x] `bun test packages/jsx/src/__tests__/issue-2798-static-nested-loop-bindings.test.ts` — new unit tests: top-level static ref (regression armor), nested-static ref invocation, nested-static reactive text, nested-static reactive attr.
- [x] `bun test packages/jsx/src/__tests__/nested-loop-plain.test.ts packages/jsx/src/__tests__/nested-loop-index-param.test.ts packages/jsx/src/__tests__/compiler-stress-1244.test.ts` — 104 pass / 3 todo / 0 fail, no regressions.
- [x] New conformance fixture `static-nested-loop-ref` added and registered; `expectedHtml` regenerated from the Hono reference via `generate-expected-html.ts` (unaffected by the fix — SSR never runs a `ref`, matching `nested-loop-ref-const.ts`'s precedent). `git status --short` confirmed clean after regeneration (no unrelated fixture drift).
- [x] `bun test packages/jsx` — full suite, 3367 pass / 5 fail, all 5 failures confirmed pre-existing and unrelated (see #2889's PR description).
- [x] `bunx tsgo --noEmit -p packages/jsx/tsconfig.json` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166GL67BeXNZb4duYnnn6kt

---
_Generated by [Claude Code](https://claude.ai/code/session_0166GL67BeXNZb4duYnnn6kt)_