### PR TITLE
docs: add existing-project retrofit guide to the Hono adapter page

### DIFF
--- a/docs/core/adapters/hono-adapter.md
+++ b/docs/core/adapters/hono-adapter.md
@@ -126,7 +126,7 @@ export function Counter(__allProps: { initial?: number } & { __instanceId?: stri
 A build-time post-processing step injects `useRequestContext()` calls into generated templates. `BfScripts` renders the collected `<script>` tags:
 
 ```tsx
-import { BfScripts } from '@barefootjs/hono'
+import { BfScripts } from '@barefootjs/hono/scripts'
 
 export function Layout({ children }) {
   return (
@@ -212,3 +212,164 @@ export default defineConfig({
   }),
 })
 ```
+
+## Adding to an Existing Project
+
+The scaffold (`npm create barefootjs@latest`) is one way to reach the layout described above; this section is the other — retrofitting an existing Hono + Cloudflare Workers app that already renders with `hono/jsx-renderer` and deploys with `wrangler deploy`. The end state is the same as the scaffold's, so a freshly scaffolded project is a valid reference to diff against once you're done.
+
+The one structural change worth understanding up front: `barefoot()` compiles **individual components** — each `.tsx` under `components` becomes an SSR template under `templates` plus hydration JS under `build.outDir`. It does not bundle the server app into a single file. If the existing project pre-bundles its SSR entry with a whole-app Vite bundler (e.g. `@hono/vite-build`), that step is not replaced by a BarefootJS equivalent — it goes away, and wrangler's own esbuild bundling of the server entry takes over (step 4).
+
+### 1. Install
+
+```sh
+npm install @barefootjs/client @barefootjs/hono @barefootjs/jsx @barefootjs/shared
+npm install -D @barefootjs/vite
+```
+
+### 2. `tsconfig.json` — the `@/components/*` path mapping
+
+Components are imported by the server through a path alias with **two** targets, compiled output first:
+
+```json
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "@barefootjs/hono/jsx",
+    "baseUrl": ".",
+    "paths": {
+      "@/components/*": ["./dist/components/*", "./components/*"]
+    }
+  },
+  "exclude": ["node_modules", "dist/components"]
+}
+```
+
+Both entries name the same logical component; TypeScript (and wrangler, which honors `paths`) tries them in order and takes the first that resolves:
+
+- `./dist/components/*` — the compiled SSR template written by `barefoot()` (`templates`), carrying the hydration markers and script collection described in Output Format and Script Collection above. Listed first so the server picks it up whenever it exists.
+- `./components/*` — the raw source. Fallback so editor tooling and type-checking resolve imports before the first `vite build` / `vite dev` has produced anything.
+
+`dist/components` is excluded from `include` so the compiled templates aren't type-checked as a second copy of the source. Keep whatever else your existing `compilerOptions` already has (`types`, `strict`, …); only `jsx`, `jsxImportSource`, `baseUrl`, `paths`, and the `exclude` entry are BarefootJS-specific.
+
+### 3. `vite.config.ts` — the `barefoot()` plugin
+
+Three things matter for a retrofit: `components` (where the source lives), `templates` (a build output directory the server imports from through the mapping in step 2), and stock Vite config for the client-asset output. Everything else — bundling, hashing, chunking, minification, the dev server — is unmodified Vite.
+
+```ts
+// vite.config.ts
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vite'
+import { barefoot } from '@barefootjs/hono/vite'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+
+export default defineConfig({
+  // Public URL prefix of the client build; must match the path Workers
+  // Assets serves `build.outDir` under (see wrangler.jsonc in step 4).
+  base: '/components/',
+  resolve: {
+    // Mirrors tsconfig's `@/components/*` mapping. Vite's dev-server
+    // dependency pre-scan parses raw source before this plugin's own
+    // `transform` hook runs and knows nothing about tsconfig `paths`,
+    // so the alias is required. Point it at the SOURCE tree, not at
+    // `dist/components`.
+    alias: {
+      '@/components': resolve(HERE, 'components'),
+    },
+  },
+  // `build.outDir` lives inside `public/`. With Vite's default
+  // `publicDir` the rest of `public/` (CSS, favicon, …) would be copied
+  // into `public/components` on every build for nothing — Workers
+  // Assets already serves `public/` as-is.
+  publicDir: false,
+  build: {
+    outDir: 'public/components',   // hydration JS → served by Workers Assets
+    emptyOutDir: true,
+  },
+  plugins: barefoot({
+    components: ['components'],    // .tsx source directories to compile
+    templates: 'dist/components',  // compiled SSR templates → imported by the server, never served
+  }),
+})
+```
+
+`adapterOptions` (see Options above) is available but not needed for a basic setup. The `assets` / `assetsOutputFile` options exist for exposing hand-written non-component scripts' bundled URLs and are unrelated to a retrofit.
+
+If the project already has a `vite.config.ts` for a whole-app SSR bundler, the `barefoot()` config generally replaces that plugin's entry rather than sitting next to it, since the single-file server build is no longer produced (step 4).
+
+### 4. `wrangler.jsonc` — point `main` at the uncompiled server entry
+
+```jsonc
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "my-app",
+  // The uncompiled entry, not a pre-bundled SSR output. Wrangler's own
+  // esbuild-based bundler compiles it at dev/deploy time and follows
+  // the tsconfig `paths` mapping into dist/components/.
+  "main": "server.tsx",
+  "compatibility_date": "2025-01-01",
+  // Static assets (CSS, generated client JS, manifest) are served
+  // directly by Workers Assets. The Worker handles everything else.
+  "assets": {
+    "directory": "./public"
+  }
+}
+```
+
+Previously `main` pointed at whatever single-file bundle the SSR build step produced. That step is what this migration removes: `barefoot()` only compiles components, so there is no bundled server artifact to point at anymore. Wrangler bundles `server.tsx` natively — resolving `@/components/*` to the compiled templates under `dist/components/` via the tsconfig mapping — so the server entry stays ordinary TypeScript source in the repository.
+
+`assets.directory` must cover `build.outDir` from step 3 and must not include `templates` (see above).
+
+When removing the whole-app bundler, also check for any configuration it required elsewhere (its own build script, output paths referenced by `package.json` scripts or CI) so nothing keeps expecting the old bundle to exist.
+
+### 5. Render `<BfScripts />` once in the page shell
+
+`BfScripts` (from `@barefootjs/hono/scripts`) emits the `<script>` tags that load each compiled component's hydration JS exactly once per page, however many instances are rendered (see Script Collection above). It belongs once in the layout your existing `jsxRenderer` already defines, not inside individual components:
+
+```tsx
+import { jsxRenderer } from 'hono/jsx-renderer'
+import { BfScripts } from '@barefootjs/hono/scripts'
+
+export const renderer = jsxRenderer(({ children, title }) => (
+  <html lang="en">
+    <head>
+      <meta charset="UTF-8" />
+      <title>{title ?? 'My app'}</title>
+    </head>
+    <body>
+      {children}
+      <BfScripts />
+    </body>
+  </html>
+))
+```
+
+Any existing `ContextRenderer` module augmentation and stylesheet links stay as they are.
+
+### 6. Import components through the alias
+
+Server routes import compiled components via `@/components/*` rather than a relative path into the source tree, so the dist-first resolution from step 2 applies:
+
+```tsx
+// server.tsx
+import { Hono } from 'hono'
+import { renderer } from './renderer'
+import { Counter } from '@/components/Counter'
+
+const app = new Hono()
+app.use('*', renderer)
+app.get('/', (c) => c.render(<main><Counter /></main>, { title: 'My app' }))
+export default app
+```
+
+Existing plain Hono JSX components can stay where they are and be moved under `components/` one at a time; only files under a `components` directory are compiled.
+
+### 7. Smoke test
+
+```sh
+npx vite build      # writes dist/components/ (templates) and public/components/ (hydration JS)
+npx wrangler dev    # or: npx wrangler deploy
+```
+
+Then load a page that renders a converted `"use client"` component and confirm it hydrates — the rendered element carries a `bf` marker attribute (see Output Format above) and the component responds to interaction. During development, run `vite dev` alongside `wrangler dev` so `dist/components/` keeps regenerating on change.


### PR DESCRIPTION
## Summary

- Fixes #2690. Only the from-scratch `npm create barefootjs@latest` scaffold path was documented; adding BarefootJS to an existing Hono/Cloudflare Workers project required reverse-engineering the scaffold's `vite.config.ts`/`wrangler.jsonc`/`tsconfig.json`.
- Adds a new "Adding to an Existing Project" section to `docs/core/adapters/hono-adapter.md`, walking through: installing the packages, the `@/components/*` tsconfig `paths` convention (dist-first, source fallback), the `barefoot()` Vite plugin's `components`/`templates` options plus the matching `resolve.alias`/`build.outDir` setup, and — the core of the issue — why `wrangler.jsonc`'s `main` must point at the uncompiled server entry (e.g. `server.tsx`) instead of a pre-bundled SSR output, since `barefoot()` only compiles individual components rather than bundling the whole server app.
- Also fixes the existing "Script Collection" section's `BfScripts` import example, which pointed at `@barefootjs/hono` instead of the `@barefootjs/hono/scripts` subpath it's actually exported from (verified against `packages/adapter-hono/src/index.ts` and real usage in `site/*/renderer.tsx`).

## Test plan

- [x] `bun test packages/jsx/src/__tests__/doc-examples.test.ts` — all `tsx` fences in `docs/core/**` (including the new ones added here) mechanically compile via the doc-examples contract test. 224 pass, 0 fail.
- [x] Checked the new/changed prose against the Vale `Barefoot.Naming` rule (`BarefootJS` used consistently; no `BareFootJS`/`Barefoot.js`/`BarefootJs` variants).
- [x] Verified the `BfScripts` import-path fix against `packages/adapter-hono/src/index.ts`'s export comment and real call sites in `site/core/renderer.tsx` / `site/ui/renderer.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELEDYmsRrHZmoDcTk3CENC

---
_Generated by [Claude Code](https://claude.ai/code/session_01ELEDYmsRrHZmoDcTk3CENC)_