### PR TITLE
Fix #2898: Go template adapter bakes a conditional inside a static loop row

### DIFF
--- a/.changeset/mojo-xslate-boolean-static-loop-pin.md
+++ b/.changeset/mojo-xslate-boolean-static-loop-pin.md
@@ -1,0 +1,6 @@
+---
+"@barefootjs/mojolicious": patch
+"@barefootjs/xslate": patch
+---
+
+No behavior change. Documents a pre-existing, permanent limitation (#2911) in each adapter's own `conformance-pins.ts`: a `boolean` value anywhere inside a static loop array's item shape keeps the whole array unbakeable (`staticValueToPerl` deliberately refuses to serialize a boolean, since Perl has no boolean literal), surfaced by a new conformance fixture added alongside the Go template adapter's #2898/#2893 fixes.

--- a/.changeset/static-loop-boolean-attr-review-fixes.md
+++ b/.changeset/static-loop-boolean-attr-review-fixes.md
@@ -1,0 +1,7 @@
+---
+"@barefootjs/go-template": patch
+"@barefootjs/mojolicious": patch
+"@barefootjs/xslate": patch
+---
+
+Follow-up to #2898's static-loop-conditional fix, found during code review: `elementAttrEmitter`'s boolean-HTML-attribute path (`disabled`, `checked`, `hidden`, etc.) also routes through the same `convertConditionToGo` method #2898 taught to consult `staticLoopItemStack` — so an item-bound boolean attribute (`disabled={item.disabled}`) inside a Go template adapter's per-item unrolled static loop row, previously a silent divergence with no test coverage, is now also fixed and pinned with a regression fixture (`static-loop-item-boolean-attr`). That fixture surfaces the same pre-existing Mojolicious/Xslate boolean-in-static-array limitation #2911 already tracks, pinned identically to `static-loop-item-conditional`.

--- a/.changeset/static-loop-conditional-bake.md
+++ b/.changeset/static-loop-conditional-bake.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/go-template": patch
+---
+
+The Go template adapter's static-array per-item unroll (`analyzeBakeableStaticElementLoop`, #2224) no longer refuses a `.map()` row that contains a conditional (`{cond ? <a/> : <b/>}`) alongside static siblings. A conditional whose branches are themselves foldable now bakes: an item-bound condition (e.g. `item.active ? ... : ...`) resolves to a per-item Go literal, and an item-independent condition (e.g. a signal call like `flag()`) falls through to the adapter's normal reactive lowering unchanged. Previously this shape fell through to a generic BF101 "computed loop array" refusal (#2898).

--- a/packages/adapter-go-template/src/adapter/analysis/static-element-loop-bake.ts
+++ b/packages/adapter-go-template/src/adapter/analysis/static-element-loop-bake.ts
@@ -45,17 +45,14 @@
  *     `whenFalse` are themselves nullish (a `null`/`undefined` expression
  *     branch, matching `renderConditional`'s own empty-branch test) or
  *     foldable per this same walk, AND its condition classifies via
- *     `classifyBakedCondition` — either fully item-literal (evaluates via
- *     `evaluateStaticLiteral` against the item, one Go literal per item, no
- *     `{{if}}` in the emitted output) or item-INDEPENDENT (references none
- *     of the item's bound names — e.g. a signal call like `flag()` — so the
- *     normal reactive `renderConditional`/`convertConditionToGo` path
- *     handles it per item unmodified, since that path never depends on a
- *     `{{range}}` dot-context in the first place). A condition that mixes
- *     item-bound and item-independent names, or that can't be classified at
- *     all (`freeIdentifiers` returns `null`), bails the whole loop — baking
- *     one branch per item while leaving the other's markers/content out
- *     would desync from `renderConditional`'s slot-marker pairing.
+ *     `classifyBakedCondition` as item-literal (bakes to a Go literal
+ *     condition per item) or item-INDEPENDENT (falls through to the normal
+ *     reactive lowering unmodified — see that function's own docstring for
+ *     why each is safe). A condition that mixes item-bound and
+ *     item-independent names, or that can't be classified at all, bails the
+ *     whole loop — baking one branch per item while leaving the other's
+ *     markers/content out would desync from `renderConditional`'s
+ *     slot-marker pairing.
  *   - Every element attribute is `literal` / `boolean-attr` /
  *     `boolean-shorthand`, or a plain `expression` whose parsed kind is one
  *     of `identifier` / `member` / `index-access` / `literal`. An attribute
@@ -186,7 +183,7 @@ function isFoldableTree(nodes: readonly IRNode[]): boolean {
   return true
 }
 
-/** A conditional branch is foldable if it's the nullish sentinel `renderConditional` special-cases, or itself a foldable tree. */
+/** A conditional branch is foldable if it's a nullish (`null`/`undefined`) expression — `renderConditional` special-cases a nullish `whenFalse` with empty markers, and a nullish `whenTrue` renders as an empty string via the normal expression path — or itself a foldable tree. */
 function isFoldableBranch(node: IRNode): boolean {
   if (isNullishBranch(node)) return true
   return isFoldableTree([node])
@@ -236,8 +233,8 @@ function allExpressionsFoldFor(nodes: readonly IRNode[], bindings: ReadonlyMap<s
       if (node.clientOnly) continue // renderClientOnlyConditional: item-independent comment markers.
       const parsedCondition = node.parsedCondition ?? parseExpression(node.condition.trim())
       if (classifyBakedCondition(parsedCondition, bindings) === null) return false
-      if (!isNullishBranch(node.whenTrue) && !allExpressionsFoldFor([node.whenTrue], bindings)) return false
-      if (!isNullishBranch(node.whenFalse) && !allExpressionsFoldFor([node.whenFalse], bindings)) return false
+      const branchFolds = (branch: IRNode) => isNullishBranch(branch) || allExpressionsFoldFor([branch], bindings)
+      if (!branchFolds(node.whenTrue) || !branchFolds(node.whenFalse)) return false
       continue
     }
   }
@@ -252,18 +249,23 @@ function resolvesToScalar(expr: ParsedExpr, bindings: ReadonlyMap<string, unknow
 
 /**
  * A conditional's condition, classified for per-item baking (#2898):
- *   - `literal`: fully resolves via `evaluateStaticLiteral` against the
- *     item bindings — the SAME value for this one item on every render, so
- *     the caller substitutes the Go literal directly (`{{if true}}`) with no
- *     `{{if}}` runtime evaluation needed.
+ *   - `literal`: fully resolves via `evaluateStaticLiteral` against the item
+ *     bindings — the SAME value for this one item on every render, so the
+ *     caller substitutes the Go literal directly (`{{if true}}`) instead of
+ *     the runtime-evaluated condition.
  *   - `independent`: references none of the item's bound names at all (a
  *     signal call, an outer const, ...) — safe to fall through to the
  *     adapter's normal `renderConditionExpr` lowering unmodified, since that
  *     path never depends on the unrolled body's missing `{{range}}` dot
  *     context in the first place.
  *   - `null` (unclassifiable): the condition mixes item-bound and
- *     item-independent names, or `freeIdentifiers` can't analyze its shape.
- *     The caller must bail (loud refusal, not a guess).
+ *     item-independent names, `freeIdentifiers` can't analyze its shape, OR
+ *     it's item-bound but not literal-resolvable (e.g. `item.count > 0`,
+ *     `binary`/`logical` shapes `evaluateStaticLiteral` doesn't evaluate) —
+ *     the caller must bail (loud refusal, not a guess) rather than guess a
+ *     value. Not tracked as a separate capability gap: it's the same
+ *     `evaluateStaticLiteral` coverage boundary every other item-literal
+ *     bake in this module already accepts (`resolvesToScalar`, above).
  */
 export type BakedCondition = { kind: 'literal'; go: string } | { kind: 'independent' }
 

--- a/packages/adapter-go-template/src/adapter/analysis/static-element-loop-bake.ts
+++ b/packages/adapter-go-template/src/adapter/analysis/static-element-loop-bake.ts
@@ -37,10 +37,25 @@
  *   - The body is neither multi-root (`bodyIsMultiRoot`) nor a whole-item
  *     conditional (`bodyIsItemConditional`) — those need anchor-marker
  *     machinery this pass doesn't attempt to reproduce per item.
- *   - Every node anywhere in the body's IR tree is an `element`, `text`, or
- *     `expression` — a nested `loop`, `conditional`, `component`, `slot`,
+ *   - Every node anywhere in the body's IR tree is an `element`, `text`,
+ *     `expression`, or `conditional` — a nested `loop`, `component`, `slot`,
  *     `fragment`, `if-statement`, `provider`, or `async` bails the WHOLE
  *     loop (no partial unroll; a loud refusal beats silently wrong output).
+ *   - A `conditional` node (#2898) is foldable only when both `whenTrue` and
+ *     `whenFalse` are themselves nullish (a `null`/`undefined` expression
+ *     branch, matching `renderConditional`'s own empty-branch test) or
+ *     foldable per this same walk, AND its condition classifies via
+ *     `classifyBakedCondition` — either fully item-literal (evaluates via
+ *     `evaluateStaticLiteral` against the item, one Go literal per item, no
+ *     `{{if}}` in the emitted output) or item-INDEPENDENT (references none
+ *     of the item's bound names — e.g. a signal call like `flag()` — so the
+ *     normal reactive `renderConditional`/`convertConditionToGo` path
+ *     handles it per item unmodified, since that path never depends on a
+ *     `{{range}}` dot-context in the first place). A condition that mixes
+ *     item-bound and item-independent names, or that can't be classified at
+ *     all (`freeIdentifiers` returns `null`), bails the whole loop — baking
+ *     one branch per item while leaving the other's markers/content out
+ *     would desync from `renderConditional`'s slot-marker pairing.
  *   - Every element attribute is `literal` / `boolean-attr` /
  *     `boolean-shorthand`, or a plain `expression` whose parsed kind is one
  *     of `identifier` / `member` / `index-access` / `literal`. An attribute
@@ -68,6 +83,8 @@
 
 import {
   evaluateStaticLiteral,
+  freeIdentifiers,
+  parseExpression,
   resolveStaticLoopSource,
   type ConstantInfo,
   type IRElement,
@@ -156,13 +173,27 @@ function isFoldableTree(nodes: readonly IRNode[]): boolean {
         if (!isFoldableAttrs(node)) return false
         if (!isFoldableTree(node.children)) return false
         continue
+      case 'conditional':
+        if (node.clientOnly) continue // renderClientOnlyConditional: item-independent comment markers.
+        if (!isFoldableBranch(node.whenTrue) || !isFoldableBranch(node.whenFalse)) return false
+        continue
       default:
-        // 'conditional' | 'loop' | 'component' | 'slot' | 'fragment' |
-        // 'if-statement' | 'provider' | 'async' — none foldable per-item.
+        // 'loop' | 'component' | 'slot' | 'fragment' | 'if-statement' |
+        // 'provider' | 'async' — none foldable per-item.
         return false
     }
   }
   return true
+}
+
+/** A conditional branch is foldable if it's the nullish sentinel `renderConditional` special-cases, or itself a foldable tree. */
+function isFoldableBranch(node: IRNode): boolean {
+  if (isNullishBranch(node)) return true
+  return isFoldableTree([node])
+}
+
+function isNullishBranch(node: IRNode): boolean {
+  return node.type === 'expression' && (node.expr === 'null' || node.expr === 'undefined')
 }
 
 function isFoldableAttrs(element: IRElement): boolean {
@@ -199,6 +230,15 @@ function allExpressionsFoldFor(nodes: readonly IRNode[], bindings: ReadonlyMap<s
         if (!attr.value.parsed || !resolvesToScalar(attr.value.parsed, bindings)) return false
       }
       if (!allExpressionsFoldFor(node.children, bindings)) return false
+      continue
+    }
+    if (node.type === 'conditional') {
+      if (node.clientOnly) continue // renderClientOnlyConditional: item-independent comment markers.
+      const parsedCondition = node.parsedCondition ?? parseExpression(node.condition.trim())
+      if (classifyBakedCondition(parsedCondition, bindings) === null) return false
+      if (!isNullishBranch(node.whenTrue) && !allExpressionsFoldFor([node.whenTrue], bindings)) return false
+      if (!isNullishBranch(node.whenFalse) && !allExpressionsFoldFor([node.whenFalse], bindings)) return false
+      continue
     }
   }
   return true
@@ -208,4 +248,41 @@ function resolvesToScalar(expr: ParsedExpr, bindings: ReadonlyMap<string, unknow
   const resolved = evaluateStaticLiteral(expr, bindings)
   if (resolved === null) return false
   return scalarToGoLiteral(resolved.value) !== null
+}
+
+/**
+ * A conditional's condition, classified for per-item baking (#2898):
+ *   - `literal`: fully resolves via `evaluateStaticLiteral` against the
+ *     item bindings — the SAME value for this one item on every render, so
+ *     the caller substitutes the Go literal directly (`{{if true}}`) with no
+ *     `{{if}}` runtime evaluation needed.
+ *   - `independent`: references none of the item's bound names at all (a
+ *     signal call, an outer const, ...) — safe to fall through to the
+ *     adapter's normal `renderConditionExpr` lowering unmodified, since that
+ *     path never depends on the unrolled body's missing `{{range}}` dot
+ *     context in the first place.
+ *   - `null` (unclassifiable): the condition mixes item-bound and
+ *     item-independent names, or `freeIdentifiers` can't analyze its shape.
+ *     The caller must bail (loud refusal, not a guess).
+ */
+export type BakedCondition = { kind: 'literal'; go: string } | { kind: 'independent' }
+
+export function classifyBakedCondition(
+  expr: ParsedExpr,
+  bindings: ReadonlyMap<string, unknown>,
+): BakedCondition | null {
+  const resolved = evaluateStaticLiteral(expr, bindings)
+  if (resolved !== null) {
+    // A condition only needs its JS truthiness, not a printable value — so
+    // (unlike `resolvesToScalar`, used for text/attrs) a non-scalar or
+    // nullish resolved value still classifies, via the same truthiness Go's
+    // `{{if}}` and JS's `? :` already agree on for every other value kind.
+    return { kind: 'literal', go: resolved.value ? 'true' : 'false' }
+  }
+  const free = freeIdentifiers(expr)
+  if (free === null) return null
+  for (const name of bindings.keys()) {
+    if (free.has(name)) return null
+  }
+  return { kind: 'independent' }
 }

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -127,7 +127,7 @@ import { GO_TEMPLATE_PRIMITIVES } from "./lib/constants.ts"
 import { CompileState, resolveSignalParsedThroughSeedPlan } from "./lib/compile-state.ts"
 import { hasClientInteractivity, findNestedComponents } from "./analysis/component-tree.ts"
 import { analyzeBakeableStaticChildLoop, scalarToGoLiteral, type BakedStaticChildLoop } from "./analysis/static-child-loop-bake.ts"
-import { analyzeBakeableStaticElementLoop } from "./analysis/static-element-loop-bake.ts"
+import { analyzeBakeableStaticElementLoop, classifyBakedCondition } from "./analysis/static-element-loop-bake.ts"
 import type { GoEmitContext } from "./emit-context.ts"
 import { inlineLocalHelperCall } from "./expr/helper-inline.ts"
 import { lowerRegisteredAttrCall, lowerRegisteredCall, lowerRegisteredCallNode, lowerTemplateLiteralValue, lowerTernary, lowerValueOperand } from "./expr/url-builder.ts"
@@ -7004,6 +7004,33 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   ): { condition: string; preamble: string } {
     const trimmed = jsCondition.trim()
     const parsed = preParsed ?? parseExpression(trimmed)
+
+    // #2898: inside a #2224 per-item unrolled static-array loop body, there
+    // is no `{{range}}` dot-context for `renderConditionExpr`'s item-param
+    // resolution (`isCurrentLoopItem(...) → '.'`) to resolve against — so an
+    // item-bound condition (`item.active ? ... : ...`) must be baked to a Go
+    // literal per item here, the SAME as any other item-bound expression
+    // (see the `staticLoopItemStack` override in `convertExpressionToGo`).
+    // An item-INDEPENDENT condition (`flag()`, an outer const, ...) needs no
+    // such rewrite — it falls through to the normal path below unmodified,
+    // since `renderConditionExpr` never relies on a `{{range}}` dot-context
+    // for those. `analyzeBakeableStaticElementLoop`'s `classifyBakedCondition`
+    // call has already verified this resolves one way or the other for every
+    // item; a `null` classification here is the same invariant violation
+    // `convertExpressionToGo`'s override guards against, not a real path.
+    if (this.staticLoopItemStack.length > 0) {
+      const top = this.staticLoopItemStack[this.staticLoopItemStack.length - 1]
+      const classified = classifyBakedCondition(parsed, new Map([[top.param, top.item]]))
+      if (classified === null) {
+        this.staticLoopBakeFailed = true
+        return { condition: 'false', preamble: '' }
+      }
+      if (classified.kind === 'literal') {
+        return { condition: classified.go, preamble: '' }
+      }
+      // 'independent' — fall through to the normal lowering below.
+    }
+
     const support = isSupported(parsed)
 
     if (!support.supported) {

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -7005,19 +7005,14 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     const trimmed = jsCondition.trim()
     const parsed = preParsed ?? parseExpression(trimmed)
 
-    // #2898: inside a #2224 per-item unrolled static-array loop body, there
-    // is no `{{range}}` dot-context for `renderConditionExpr`'s item-param
-    // resolution (`isCurrentLoopItem(...) → '.'`) to resolve against — so an
-    // item-bound condition (`item.active ? ... : ...`) must be baked to a Go
-    // literal per item here, the SAME as any other item-bound expression
-    // (see the `staticLoopItemStack` override in `convertExpressionToGo`).
-    // An item-INDEPENDENT condition (`flag()`, an outer const, ...) needs no
-    // such rewrite — it falls through to the normal path below unmodified,
-    // since `renderConditionExpr` never relies on a `{{range}}` dot-context
-    // for those. `analyzeBakeableStaticElementLoop`'s `classifyBakedCondition`
-    // call has already verified this resolves one way or the other for every
-    // item; a `null` classification here is the same invariant violation
-    // `convertExpressionToGo`'s override guards against, not a real path.
+    // #2898: inside a #2224 per-item unrolled static-array loop body there is
+    // no `{{range}}` dot-context for an item-bound condition to resolve
+    // against, so it must bake to a Go literal here (same reasoning as the
+    // `staticLoopItemStack` override in `convertExpressionToGo`). An
+    // item-independent condition needs no such rewrite and falls through to
+    // the normal path below. `classifyBakedCondition` returning `null` here
+    // is the same pre-verified invariant `convertExpressionToGo`'s override
+    // guards against, not a real path.
     if (this.staticLoopItemStack.length > 0) {
       const top = this.staticLoopItemStack[this.staticLoopItemStack.length - 1]
       const classified = classifyBakedCondition(parsed, new Map([[top.param, top.item]]))
@@ -8180,6 +8175,12 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
         if (css !== null) return `style="${css}"`
       }
       if (isBooleanAttr(name) || value.presenceOrUndefined) {
+        // Every boolean-attribute value routes through `convertConditionToGo`
+        // even when it's a plain item-bound expression (`disabled={item.x}`),
+        // not a `conditional` IR node — so #2898's `staticLoopItemStack` check
+        // there also fixes this path inside an unrolled static loop row (was
+        // a pre-existing silent divergence; `static-loop-item-boolean-attr`
+        // is its regression fixture).
         const { condition: goCond, preamble } = this.convertConditionToGo(value.expr, value.parsed)
         // ARIA attributes are string-valued ("true"/"false"), not HTML5 presence
         // booleans — the truthy presence form renders as `aria-x="true"`

--- a/packages/adapter-go-template/src/conformance-pins.ts
+++ b/packages/adapter-go-template/src/conformance-pins.ts
@@ -116,22 +116,19 @@ export const conformancePins: ConformancePins = {
     severity: 'error',
     issue: 'https://github.com/piconic-ai/barefootjs/issues/2893',
   }],
-  // #2897/#2898: `analyzeBakeableStaticElementLoop`'s `isFoldableTree` bails
-  // the whole bake when the row contains a `conditional` node anywhere
-  // (`static-loop-conditional`, a partial conditional alongside static
-  // siblings — no nested loop involved) or a `loop` node (`static-nested-
-  // loop-conditional`, whose OUTER row contains a nested `.map()` — the
-  // SAME #2893 nested-loop trigger; its own row's conditional never gets a
-  // chance to matter, the nested loop alone already bails). Both fall
-  // through to the generic "computed loop array" BF101 refusal. Unrelated
-  // to #2897's own fix (a client-JS-only reactive-wiring gap) — this is a
-  // pre-existing Go-adapter SSR static-loop-baking scope boundary the new
-  // fixtures happened to be the first to exercise.
-  'static-loop-conditional': [{
-    code: 'BF101',
-    severity: 'error',
-    issue: 'https://github.com/piconic-ai/barefootjs/issues/2898',
-  }],
+  // #2893 (successor to #2897): `analyzeBakeableStaticElementLoop`'s
+  // `isFoldableTree` bails the whole bake when the row contains a nested
+  // `loop` node — `static-nested-loop-conditional`'s OUTER row has a nested
+  // `.map()`, the SAME #2893 nested-loop trigger; its own row's conditional
+  // never gets a chance to matter, the nested loop alone already bails.
+  // Falls through to the generic "computed loop array" BF101 refusal.
+  // Unrelated to #2897's own fix (a client-JS-only reactive-wiring gap) —
+  // this is a pre-existing Go-adapter SSR static-loop-baking scope boundary
+  // the new fixture happened to be the first to exercise. (The sibling
+  // `static-loop-conditional` shape — a `conditional` with no nested loop —
+  // graduated in #2898: `isFoldableTree` now allows a `conditional` node
+  // whose branches fold and whose condition classifies as item-literal or
+  // item-independent.)
   'static-nested-loop-conditional': [{
     code: 'BF101',
     severity: 'error',

--- a/packages/adapter-mojolicious/src/conformance-pins.ts
+++ b/packages/adapter-mojolicious/src/conformance-pins.ts
@@ -73,4 +73,20 @@ export const conformancePins: ConformancePins = {
   // resolves the primitive normally and never reaches this refusal (formerly
   // tracked as #2771, closed) — no open issue tracks further work.
   'namespace-import-primitive': [{ code: 'BF013', severity: 'error' }],
+  // #2911: `staticValueToPerl` (`adapter/lib/static-value.ts`) deliberately
+  // returns `null` for a `boolean` anywhere inside a static loop array's
+  // item shape — Perl has no native boolean literal, and baking `1`/`''`
+  // would diverge from JS's `String(true) === "true"` the moment that value
+  // is ever interpolated as text. This fixture's item shape has an `active:
+  // boolean` field (feeding a conditional, never interpolated as text
+  // itself), so the whole array fails to serialize and falls through to the
+  // generic "local computed value" BF101 refusal. Unrelated to #2898 (a
+  // Go-template-only fix) — this fixture happened to be the first to
+  // combine a boolean item field with a conditional in this adapter's own
+  // corpus.
+  'static-loop-item-conditional': [{
+    code: 'BF101',
+    severity: 'error',
+    issue: 'https://github.com/piconic-ai/barefootjs/issues/2911',
+  }],
 }

--- a/packages/adapter-mojolicious/src/conformance-pins.ts
+++ b/packages/adapter-mojolicious/src/conformance-pins.ts
@@ -89,4 +89,13 @@ export const conformancePins: ConformancePins = {
     severity: 'error',
     issue: 'https://github.com/piconic-ai/barefootjs/issues/2911',
   }],
+  // #2911: same trigger as `static-loop-item-conditional` above — this
+  // fixture's item shape has a `disabled: boolean` field (feeding a boolean
+  // HTML attribute rather than a conditional), found alongside it while
+  // reviewing #2898.
+  'static-loop-item-boolean-attr': [{
+    code: 'BF101',
+    severity: 'error',
+    issue: 'https://github.com/piconic-ai/barefootjs/issues/2911',
+  }],
 }

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -5536,6 +5536,39 @@
         "text"
       ]
     },
+    "static-loop-item-conditional-client": {
+      "kinds": [
+        "array-literal",
+        "identifier",
+        "literal",
+        "member"
+      ],
+      "axes": [
+        "literal:null"
+      ],
+      "contexts": [
+        "attribute",
+        "condition",
+        "loop",
+        "text"
+      ]
+    },
+    "static-loop-item-conditional-precomputed": {
+      "kinds": [
+        "identifier",
+        "literal",
+        "member"
+      ],
+      "axes": [
+        "literal:null"
+      ],
+      "contexts": [
+        "attribute",
+        "condition",
+        "loop",
+        "text"
+      ]
+    },
     "static-nested-loop-conditional": {
       "kinds": [
         "array-literal",
@@ -6476,17 +6509,17 @@
     }
   },
   "kindCounts": {
-    "array-literal": 107,
+    "array-literal": 108,
     "array-method": 71,
     "arrow": 74,
     "binary": 104,
     "call": 274,
     "conditional": 31,
-    "identifier": 378,
+    "identifier": 380,
     "index-access": 14,
-    "literal": 303,
+    "literal": 305,
     "logical": 49,
-    "member": 220,
+    "member": 222,
     "object-literal": 88,
     "template-literal": 31,
     "unary": 29,
@@ -6529,7 +6562,7 @@
     "binary:>": 11,
     "binary:>=": 1,
     "literal:boolean": 68,
-    "literal:null": 24,
+    "literal:null": 26,
     "literal:number": 136,
     "literal:string": 210,
     "logical:&&": 7,

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -5515,6 +5515,27 @@
         "text"
       ]
     },
+    "static-loop-item-conditional": {
+      "kinds": [
+        "array-literal",
+        "identifier",
+        "literal",
+        "member",
+        "object-literal"
+      ],
+      "axes": [
+        "literal:boolean",
+        "literal:null",
+        "literal:number",
+        "literal:string"
+      ],
+      "contexts": [
+        "attribute",
+        "condition",
+        "loop",
+        "text"
+      ]
+    },
     "static-nested-loop-conditional": {
       "kinds": [
         "array-literal",
@@ -6455,18 +6476,18 @@
     }
   },
   "kindCounts": {
-    "array-literal": 106,
+    "array-literal": 107,
     "array-method": 71,
     "arrow": 74,
     "binary": 104,
     "call": 274,
     "conditional": 31,
-    "identifier": 377,
+    "identifier": 378,
     "index-access": 14,
-    "literal": 302,
+    "literal": 303,
     "logical": 49,
-    "member": 219,
-    "object-literal": 87,
+    "member": 220,
+    "object-literal": 88,
     "template-literal": 31,
     "unary": 29,
     "unsupported": 50
@@ -6507,10 +6528,10 @@
     "binary:===": 54,
     "binary:>": 11,
     "binary:>=": 1,
-    "literal:boolean": 67,
-    "literal:null": 23,
-    "literal:number": 135,
-    "literal:string": 209,
+    "literal:boolean": 68,
+    "literal:null": 24,
+    "literal:number": 136,
+    "literal:string": 210,
     "logical:&&": 7,
     "logical:??": 41,
     "logical:||": 16,

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -5515,6 +5515,50 @@
         "text"
       ]
     },
+    "static-loop-item-boolean-attr": {
+      "kinds": [
+        "array-literal",
+        "identifier",
+        "literal",
+        "member",
+        "object-literal"
+      ],
+      "axes": [
+        "literal:boolean",
+        "literal:number",
+        "literal:string"
+      ],
+      "contexts": [
+        "attribute",
+        "loop",
+        "text"
+      ]
+    },
+    "static-loop-item-boolean-attr-client": {
+      "kinds": [
+        "array-literal",
+        "identifier",
+        "member"
+      ],
+      "axes": [],
+      "contexts": [
+        "attribute",
+        "loop",
+        "text"
+      ]
+    },
+    "static-loop-item-boolean-attr-precomputed": {
+      "kinds": [
+        "identifier",
+        "member"
+      ],
+      "axes": [],
+      "contexts": [
+        "attribute",
+        "loop",
+        "text"
+      ]
+    },
     "static-loop-item-conditional": {
       "kinds": [
         "array-literal",
@@ -6509,18 +6553,18 @@
     }
   },
   "kindCounts": {
-    "array-literal": 108,
+    "array-literal": 110,
     "array-method": 71,
     "arrow": 74,
     "binary": 104,
     "call": 274,
     "conditional": 31,
-    "identifier": 380,
+    "identifier": 383,
     "index-access": 14,
-    "literal": 305,
+    "literal": 306,
     "logical": 49,
-    "member": 222,
-    "object-literal": 88,
+    "member": 225,
+    "object-literal": 89,
     "template-literal": 31,
     "unary": 29,
     "unsupported": 50
@@ -6561,10 +6605,10 @@
     "binary:===": 54,
     "binary:>": 11,
     "binary:>=": 1,
-    "literal:boolean": 68,
+    "literal:boolean": 69,
     "literal:null": 26,
-    "literal:number": 136,
-    "literal:string": 210,
+    "literal:number": 137,
+    "literal:string": 211,
     "logical:&&": 7,
     "logical:??": 41,
     "logical:||": 16,

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -427,6 +427,8 @@ import { fixture as staticLoopConditional } from './static-loop-conditional'
 import { fixture as staticLoopConditionalPrecomputed } from './static-loop-conditional-precomputed'
 import { fixture as staticLoopConditionalClient } from './static-loop-conditional-client'
 import { fixture as staticLoopItemConditional } from './static-loop-item-conditional'
+import { fixture as staticLoopItemConditionalPrecomputed } from './static-loop-item-conditional-precomputed'
+import { fixture as staticLoopItemConditionalClient } from './static-loop-item-conditional-client'
 import { fixture as staticNestedLoopConditional } from './static-nested-loop-conditional'
 import { fixture as staticNestedLoopConditionalPrecomputed } from './static-nested-loop-conditional-precomputed'
 import { fixture as staticNestedLoopConditionalClient } from './static-nested-loop-conditional-client'
@@ -946,6 +948,8 @@ export const jsxFixtures: JSXFixture[] = [
   staticLoopConditionalPrecomputed,
   staticLoopConditionalClient,
   staticLoopItemConditional,
+  staticLoopItemConditionalPrecomputed,
+  staticLoopItemConditionalClient,
   staticNestedLoopConditional,
   staticNestedLoopConditionalPrecomputed,
   staticNestedLoopConditionalClient,

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -426,6 +426,7 @@ import { fixture as staticNestedLoopRefPrecomputed } from './static-nested-loop-
 import { fixture as staticLoopConditional } from './static-loop-conditional'
 import { fixture as staticLoopConditionalPrecomputed } from './static-loop-conditional-precomputed'
 import { fixture as staticLoopConditionalClient } from './static-loop-conditional-client'
+import { fixture as staticLoopItemConditional } from './static-loop-item-conditional'
 import { fixture as staticNestedLoopConditional } from './static-nested-loop-conditional'
 import { fixture as staticNestedLoopConditionalPrecomputed } from './static-nested-loop-conditional-precomputed'
 import { fixture as staticNestedLoopConditionalClient } from './static-nested-loop-conditional-client'
@@ -944,6 +945,7 @@ export const jsxFixtures: JSXFixture[] = [
   staticLoopConditional,
   staticLoopConditionalPrecomputed,
   staticLoopConditionalClient,
+  staticLoopItemConditional,
   staticNestedLoopConditional,
   staticNestedLoopConditionalPrecomputed,
   staticNestedLoopConditionalClient,

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -429,6 +429,9 @@ import { fixture as staticLoopConditionalClient } from './static-loop-conditiona
 import { fixture as staticLoopItemConditional } from './static-loop-item-conditional'
 import { fixture as staticLoopItemConditionalPrecomputed } from './static-loop-item-conditional-precomputed'
 import { fixture as staticLoopItemConditionalClient } from './static-loop-item-conditional-client'
+import { fixture as staticLoopItemBooleanAttr } from './static-loop-item-boolean-attr'
+import { fixture as staticLoopItemBooleanAttrPrecomputed } from './static-loop-item-boolean-attr-precomputed'
+import { fixture as staticLoopItemBooleanAttrClient } from './static-loop-item-boolean-attr-client'
 import { fixture as staticNestedLoopConditional } from './static-nested-loop-conditional'
 import { fixture as staticNestedLoopConditionalPrecomputed } from './static-nested-loop-conditional-precomputed'
 import { fixture as staticNestedLoopConditionalClient } from './static-nested-loop-conditional-client'
@@ -950,6 +953,9 @@ export const jsxFixtures: JSXFixture[] = [
   staticLoopItemConditional,
   staticLoopItemConditionalPrecomputed,
   staticLoopItemConditionalClient,
+  staticLoopItemBooleanAttr,
+  staticLoopItemBooleanAttrPrecomputed,
+  staticLoopItemBooleanAttrClient,
   staticNestedLoopConditional,
   staticNestedLoopConditionalPrecomputed,
   staticNestedLoopConditionalClient,

--- a/packages/adapter-tests/fixtures/static-loop-conditional-client.ts
+++ b/packages/adapter-tests/fixtures/static-loop-conditional-client.ts
@@ -1,16 +1,15 @@
 import { createFixture } from '../src/types'
 
 /**
- * `/* @client *​/` twin of `static-loop-conditional` (#2897 fix, #2898 Go
- * template refusal).
+ * `/* @client *​/` twin of `static-loop-conditional` (#2897 fix).
  *
  * The marker defers the whole loop to client evaluation, so SSR renders the
- * empty `<ul>` on EVERY adapter and no BF101 may fire — same suppression
- * contract as `filter-nested-callback-predicate-client.ts` /
- * `static-nested-loop-ref-client.ts`. Verifies the Go template adapter's
- * BF101 refusal (pinned in `conformance-pins.ts` for the non-@client
- * fixture, #2898) has a working escape, as its own diagnostic suggestion
- * claims.
+ * empty `<ul>` on EVERY adapter — same suppression contract as
+ * `filter-nested-callback-predicate-client.ts` / `static-nested-loop-ref-
+ * client.ts`. Originally authored to verify the Go template adapter's BF101
+ * refusal (#2898) had a working escape; #2898 later fixed the base fixture
+ * directly, so this twin is no longer required by the escape-coverage floor
+ * test — kept as its own standalone `/* @client *​/` suppression coverage.
  *
  * `items` is an EMPTY literal array (unlike the non-@client twin's
  * populated one) — CSR conformance compares `expectedHtml` against the

--- a/packages/adapter-tests/fixtures/static-loop-conditional-precomputed.ts
+++ b/packages/adapter-tests/fixtures/static-loop-conditional-precomputed.ts
@@ -18,6 +18,11 @@ import { createFixture } from '../src/types'
  * inside a LOCAL static array's row on the Go template adapter. What it
  * proves is that the refusal's first-listed escape genuinely works, full
  * SSR included.
+ *
+ * #2898 later fixed the base fixture directly (`isFoldableTree` now bakes a
+ * `conditional` node), so this twin is no longer required by the escape-
+ * coverage floor test — kept as its own standalone prop-derived-array
+ * coverage, same reasoning as `static-nested-loop-ref-precomputed`.
  */
 export const fixture = createFixture({
   id: 'static-loop-conditional-precomputed',

--- a/packages/adapter-tests/fixtures/static-loop-conditional.ts
+++ b/packages/adapter-tests/fixtures/static-loop-conditional.ts
@@ -37,14 +37,4 @@ export const spec: SharedFixtureSpec = {
   ],
 }
 
-export const fixture: JSXFixture = {
-  ...defineSharedFixture(spec),
-  // Go template adapter refuses this shape with BF101 (#2898 — the row's
-  // conditional isn't foldable by the static-loop bake); the diagnostic's
-  // own suggestion names a prop-precompute/@client escape, verified by the
-  // twins below.
-  escapes: [
-    { kind: 'prop-precompute', fixture: 'static-loop-conditional-precomputed' },
-    { kind: 'client-directive', fixture: 'static-loop-conditional-client' },
-  ],
-}
+export const fixture: JSXFixture = defineSharedFixture(spec)

--- a/packages/adapter-tests/fixtures/static-loop-item-boolean-attr-client.ts
+++ b/packages/adapter-tests/fixtures/static-loop-item-boolean-attr-client.ts
@@ -1,0 +1,35 @@
+import { createFixture } from '../src/types'
+
+/**
+ * `/* @client *​/` twin of `static-loop-item-boolean-attr` — the marker
+ * defers the whole loop to client evaluation, so SSR renders the empty
+ * `<ul>` on EVERY adapter and no BF101 may fire, same suppression contract
+ * as `static-loop-item-conditional-client.ts`.
+ *
+ * `items` is an EMPTY literal array (unlike the non-@client twin's
+ * populated one) — CSR conformance compares `expectedHtml` against the
+ * POST-HYDRATION DOM, not raw SSR output, and an empty array keeps SSR and
+ * post-hydration state identical.
+ */
+export const fixture = createFixture({
+  id: 'static-loop-item-boolean-attr-client',
+  description: 'static array + item-bound boolean attribute + /* @client */ suppresses the BF101 refusal (#2898, #2911)',
+  source: `
+type Item = { id: number; label: string; disabled: boolean }
+export function StaticLoopItemBooleanAttrClient() {
+  const items: Item[] = []
+  return (
+    <ul>
+      {/* @client */ items.map(item => (
+        <li key={item.id}>
+          <button type="button" disabled={item.disabled}>{item.label}</button>
+        </li>
+      ))}
+    </ul>
+  )
+}
+`,
+  expectedHtml: `
+    <ul bf-s="test" bf="s2"></ul>
+  `,
+})

--- a/packages/adapter-tests/fixtures/static-loop-item-boolean-attr-precomputed.ts
+++ b/packages/adapter-tests/fixtures/static-loop-item-boolean-attr-precomputed.ts
@@ -1,0 +1,42 @@
+import { createFixture } from '../src/types'
+
+/**
+ * `prop-precompute` twin of `static-loop-item-boolean-attr` — the base
+ * refuses on the Go template adapter's `#2898` pre-fix history and on
+ * Mojolicious/Xslate (`#2911`, a boolean item field) because `items` is a
+ * component-scope LOCAL const. A prop-derived array skips static-bake
+ * analysis entirely on every adapter (each renders its normal runtime loop
+ * instead), so moving `items` to a prop escapes both refusal families with
+ * full SSR.
+ */
+export const fixture = createFixture({
+  id: 'static-loop-item-boolean-attr-precomputed',
+  description: 'prop-precompute twin of static-loop-item-boolean-attr — items moved to a prop, full SSR (#2898, #2911)',
+  source: `
+type Item = { id: number; label: string; disabled: boolean }
+
+export function StaticLoopItemBooleanAttrPrecomputed(props: { items: Item[] }) {
+  return (
+    <ul>
+      {props.items.map(item => (
+        <li key={item.id}>
+          <button type="button" disabled={item.disabled}>{item.label}</button>
+        </li>
+      ))}
+    </ul>
+  )
+}
+`,
+  props: {
+    items: [
+      { id: 1, label: 'Alpha', disabled: true },
+      { id: 2, label: 'Beta', disabled: false },
+    ],
+  },
+  expectedHtml: `
+    <ul bf-s="test" bf="s2">
+      <li data-key="1"><button bf="s1" disabled type="button"><!--bf:s0-->Alpha<!--/--></button></li>
+      <li data-key="2"><button bf="s1" type="button"><!--bf:s0-->Beta<!--/--></button></li>
+    </ul>
+  `,
+})

--- a/packages/adapter-tests/fixtures/static-loop-item-boolean-attr.ts
+++ b/packages/adapter-tests/fixtures/static-loop-item-boolean-attr.ts
@@ -1,0 +1,55 @@
+import { createFixture } from '../src/types'
+
+/**
+ * A static array's `.map()` row sets a boolean HTML attribute (`disabled`)
+ * from the item itself. Found during #2898's review: `elementAttrEmitter`'s
+ * `emitExpression` routes EVERY boolean-attribute value (`isBooleanAttr(name)`,
+ * `go-template-adapter.ts`) through `convertConditionToGo` — the SAME method
+ * #2898 taught to consult `staticLoopItemStack` — even when the attribute's
+ * own expression is a plain member read (`item.disabled`), not a `conditional`
+ * IR node. `analyzeBakeableStaticElementLoop`'s `isFoldableAttrs` already
+ * accepted this shape pre-#2898 (a `member`-kind attr expression is on its
+ * allowlist), so it reached the per-item unrolled render path — where, before
+ * #2898, `convertConditionToGo` had no unrolled-body awareness at all and
+ * resolved `item` through the normal (wrong, no-`{{range}}`) dot-context
+ * lowering, a PRE-EXISTING silent divergence #2898 fixes as a side effect of
+ * its `staticLoopItemStack` check, not something #2898 set out to fix.
+ *
+ * Also refuses on Mojolicious and Xslate, for the SAME #2911 reason as
+ * `static-loop-item-conditional`: the item shape's `disabled: boolean`
+ * field makes the whole array unbakeable on those two Perl-backed
+ * adapters. Escape twins below mirror that fixture's.
+ */
+export const fixture = createFixture({
+  id: 'static-loop-item-boolean-attr',
+  description: "static array's .map() row boolean attribute keyed off the item itself renders per item (#2898)",
+  escapes: [
+    { kind: 'prop-precompute', fixture: 'static-loop-item-boolean-attr-precomputed' },
+    { kind: 'client-directive', fixture: 'static-loop-item-boolean-attr-client' },
+  ],
+  source: `
+type Item = { id: number; label: string; disabled: boolean }
+
+export function StaticLoopItemBooleanAttr() {
+  const items: Item[] = [
+    { id: 1, label: 'Alpha', disabled: true },
+    { id: 2, label: 'Beta', disabled: false },
+  ]
+  return (
+    <ul>
+      {items.map(item => (
+        <li key={item.id}>
+          <button type="button" disabled={item.disabled}>{item.label}</button>
+        </li>
+      ))}
+    </ul>
+  )
+}
+`,
+  expectedHtml: `
+    <ul bf-s="test" bf="s2">
+      <li data-key="1"><button bf="s1" disabled type="button"><!--bf:s0-->Alpha<!--/--></button></li>
+      <li data-key="2"><button bf="s1" type="button"><!--bf:s0-->Beta<!--/--></button></li>
+    </ul>
+  `,
+})

--- a/packages/adapter-tests/fixtures/static-loop-item-conditional-client.ts
+++ b/packages/adapter-tests/fixtures/static-loop-item-conditional-client.ts
@@ -1,0 +1,40 @@
+import { createFixture } from '../src/types'
+
+/**
+ * `/* @client *​/` twin of `static-loop-item-conditional` — the marker
+ * defers the whole loop to client evaluation, so SSR renders the empty
+ * `<ul>` on EVERY adapter and no BF101 may fire (#2898's Go template gap,
+ * #2911's Mojolicious/Xslate boolean-in-static-array gap alike) — same
+ * suppression contract as `static-loop-conditional-client.ts`.
+ *
+ * `items` is an EMPTY literal array (unlike the non-@client twin's
+ * populated one) — CSR conformance compares `expectedHtml` against the
+ * POST-HYDRATION DOM, not raw SSR output, and `/* @client *​/` genuinely
+ * renders the loop client-side once hydrated. A populated array would
+ * hydrate to real `<li>` content, diverging from the empty SSR markup this
+ * fixture pins. Empty keeps SSR and post-hydration state identical.
+ */
+export const fixture = createFixture({
+  id: 'static-loop-item-conditional-client',
+  description: 'static array + item-bound conditional + /* @client */ suppresses the BF101 refusal (#2898, #2911)',
+  source: `
+type Item = { id: number; label: string; active: boolean; tag: string | null }
+export function StaticLoopItemConditionalClient() {
+  const items: Item[] = []
+  return (
+    <ul>
+      {/* @client */ items.map(item => (
+        <li key={item.id}>
+          <span>{item.label}</span>
+          {item.active ? <b>on</b> : <i>off</i>}
+          {item.tag ? <em>tagged</em> : null}
+        </li>
+      ))}
+    </ul>
+  )
+}
+`,
+  expectedHtml: `
+    <ul bf-s="test" bf="s3"></ul>
+  `,
+})

--- a/packages/adapter-tests/fixtures/static-loop-item-conditional-precomputed.ts
+++ b/packages/adapter-tests/fixtures/static-loop-item-conditional-precomputed.ts
@@ -1,0 +1,61 @@
+import { createFixture } from '../src/types'
+
+/**
+ * `prop-precompute` twin of `static-loop-item-conditional` — the SECOND
+ * escape kind the BF101 diagnostic claims, alongside
+ * `static-loop-item-conditional-client`.
+ *
+ * The base fixture refuses on TWO adapters, for two unrelated reasons:
+ *   - Go template (graduated in #2898, no longer refuses).
+ *   - Mojolicious / Xslate (#2911): both Perl-backed adapters' own
+ *     `staticValueToPerl` deliberately refuses to bake a `boolean` value
+ *     anywhere inside a static array's item shape — Perl has no boolean
+ *     literal. That refusal keys off the array being a LOCAL CONST
+ *     (`this.localConstants`); a PROP-derived array skips compile-time
+ *     baking entirely and flows through the adapter's normal runtime
+ *     `{{range}}`-equivalent loop, where a boolean field is just ordinary
+ *     Perl truthy/falsy data — no literal serialization involved.
+ * Moving `items` to a prop escapes both, with full SSR.
+ */
+export const fixture = createFixture({
+  id: 'static-loop-item-conditional-precomputed',
+  description: 'prop-precompute twin of static-loop-item-conditional — items moved to a prop, full SSR (#2898, #2911)',
+  source: `
+type Item = { id: number; label: string; active: boolean; tag: string | null }
+
+export function StaticLoopItemConditionalPrecomputed(props: { items: Item[] }) {
+  return (
+    <ul>
+      {props.items.map(item => (
+        <li key={item.id}>
+          <span>{item.label}</span>
+          {item.active ? <b>on</b> : <i>off</i>}
+          {item.tag ? <em>tagged</em> : null}
+        </li>
+      ))}
+    </ul>
+  )
+}
+`,
+  props: {
+    items: [
+      { id: 1, label: 'Alpha', active: true, tag: 'x' },
+      { id: 2, label: 'Beta', active: false, tag: null },
+    ],
+  },
+  expectedHtml: `
+    <ul bf-s="test" bf="s3">
+      <li data-key="1">
+        <span><!--bf:s0-->Alpha<!--/--></span>
+        <b bf-c="s1">on</b>
+        <em bf-c="s2">tagged</em>
+      </li>
+      <li data-key="2">
+        <span><!--bf:s0-->Beta<!--/--></span>
+        <i bf-c="s1">off</i>
+        <!--bf-cond-start:s2-->
+        <!--bf-cond-end:s2-->
+      </li>
+    </ul>
+  `,
+})

--- a/packages/adapter-tests/fixtures/static-loop-item-conditional.ts
+++ b/packages/adapter-tests/fixtures/static-loop-item-conditional.ts
@@ -8,21 +8,34 @@ import { createFixture } from '../src/types'
  * which must resolve to a per-item Go literal at bake time rather than fall
  * through to the normal reactive `{{if}}` lowering (there is no `{{range}}`
  * dot-context inside a #2224 per-item unrolled body for `item` to resolve
- * against). Also covers a per-item conditional's `null` branch (`item.note`)
- * — a `resolved.value` of `null` must still classify as `literal` (Go
- * `false`), matching JS truthiness rather than `resolvesToScalar`'s
- * text/attr-value notion of "printable".
+ * against).
+ *
+ * Also covers a per-item condition that resolves to `null` (`item.tag`) —
+ * `evaluateStaticLiteral` returning `{ value: null }` must still classify
+ * as `literal` (Go `false`), matching JS truthiness rather than
+ * `resolvesToScalar`'s text/attr-value notion of "printable". Deliberately
+ * keeps that branch's OWN content static (`<em>tagged</em>`, no `{item.tag}`
+ * interpolation): `allExpressionsFoldFor` requires BOTH branches of a
+ * conditional to resolve for EVERY item regardless of which one a given
+ * item's condition selects (`renderConditional` always renders both arms
+ * into `{{if}}…{{else}}…{{end}}` — Go never evaluates the unselected arm's
+ * actions at request time, but the per-item bake still needs valid Go text
+ * for it). A branch whose own content depends on the SAME nullable field
+ * driving the condition (`item.tag ? <em>{item.tag}</em> : null`) would
+ * correctly bail the whole loop for the item where that field is null,
+ * since printing `null` isn't a resolvable scalar — that is a real BF101
+ * refusal shape, not this fixture's.
  */
 export const fixture = createFixture({
   id: 'static-loop-item-conditional',
   description: "static array's .map() row conditional keyed off the item itself bakes to a per-item Go literal (#2898)",
   source: `
-type Item = { id: number; label: string; active: boolean; note: string | null }
+type Item = { id: number; label: string; active: boolean; tag: string | null }
 
 export function StaticLoopItemConditional() {
   const items: Item[] = [
-    { id: 1, label: 'Alpha', active: true, note: 'first' },
-    { id: 2, label: 'Beta', active: false, note: null },
+    { id: 1, label: 'Alpha', active: true, tag: 'x' },
+    { id: 2, label: 'Beta', active: false, tag: null },
   ]
   return (
     <ul>
@@ -30,7 +43,7 @@ export function StaticLoopItemConditional() {
         <li key={item.id}>
           <span>{item.label}</span>
           {item.active ? <b>on</b> : <i>off</i>}
-          {item.note ? <em>{item.note}</em> : null}
+          {item.tag ? <em>tagged</em> : null}
         </li>
       ))}
     </ul>
@@ -38,11 +51,11 @@ export function StaticLoopItemConditional() {
 }
 `,
   expectedHtml: `
-    <ul bf-s="test" bf="s4">
+    <ul bf-s="test" bf="s3">
       <li data-key="1">
         <span><!--bf:s0-->Alpha<!--/--></span>
         <b bf-c="s1">on</b>
-        <em bf-c="s2"><!--bf:s3-->first<!--/--></em>
+        <em bf-c="s2">tagged</em>
       </li>
       <li data-key="2">
         <span><!--bf:s0-->Beta<!--/--></span>

--- a/packages/adapter-tests/fixtures/static-loop-item-conditional.ts
+++ b/packages/adapter-tests/fixtures/static-loop-item-conditional.ts
@@ -1,0 +1,55 @@
+import { createFixture } from '../src/types'
+
+/**
+ * `static-loop-conditional` (#2898) covers an ITEM-INDEPENDENT condition
+ * (a signal call, same value for every row). This fixture covers the other
+ * half `classifyBakedCondition` (`static-element-loop-bake.ts`) has to
+ * classify: a condition that reads the LOOP ITEM itself (`item.active`),
+ * which must resolve to a per-item Go literal at bake time rather than fall
+ * through to the normal reactive `{{if}}` lowering (there is no `{{range}}`
+ * dot-context inside a #2224 per-item unrolled body for `item` to resolve
+ * against). Also covers a per-item conditional's `null` branch (`item.note`)
+ * — a `resolved.value` of `null` must still classify as `literal` (Go
+ * `false`), matching JS truthiness rather than `resolvesToScalar`'s
+ * text/attr-value notion of "printable".
+ */
+export const fixture = createFixture({
+  id: 'static-loop-item-conditional',
+  description: "static array's .map() row conditional keyed off the item itself bakes to a per-item Go literal (#2898)",
+  source: `
+type Item = { id: number; label: string; active: boolean; note: string | null }
+
+export function StaticLoopItemConditional() {
+  const items: Item[] = [
+    { id: 1, label: 'Alpha', active: true, note: 'first' },
+    { id: 2, label: 'Beta', active: false, note: null },
+  ]
+  return (
+    <ul>
+      {items.map(item => (
+        <li key={item.id}>
+          <span>{item.label}</span>
+          {item.active ? <b>on</b> : <i>off</i>}
+          {item.note ? <em>{item.note}</em> : null}
+        </li>
+      ))}
+    </ul>
+  )
+}
+`,
+  expectedHtml: `
+    <ul bf-s="test" bf="s4">
+      <li data-key="1">
+        <span><!--bf:s0-->Alpha<!--/--></span>
+        <b bf-c="s1">on</b>
+        <em bf-c="s2"><!--bf:s3-->first<!--/--></em>
+      </li>
+      <li data-key="2">
+        <span><!--bf:s0-->Beta<!--/--></span>
+        <i bf-c="s1">off</i>
+        <!--bf-cond-start:s2-->
+        <!--bf-cond-end:s2-->
+      </li>
+    </ul>
+  `,
+})

--- a/packages/adapter-tests/fixtures/static-loop-item-conditional.ts
+++ b/packages/adapter-tests/fixtures/static-loop-item-conditional.ts
@@ -25,10 +25,21 @@ import { createFixture } from '../src/types'
  * correctly bail the whole loop for the item where that field is null,
  * since printing `null` isn't a resolvable scalar — that is a real BF101
  * refusal shape, not this fixture's.
+ *
+ * Refuses on Mojolicious and Xslate too, for an UNRELATED reason (#2911):
+ * both Perl-backed adapters' own static-array bake deliberately refuses a
+ * `boolean` value anywhere in the item shape (`active: boolean` here) —
+ * Perl has no boolean literal. The diagnostic's own suggestion names a
+ * prop-precompute/@client escape on every refusing adapter, verified by
+ * the twins below.
  */
 export const fixture = createFixture({
   id: 'static-loop-item-conditional',
   description: "static array's .map() row conditional keyed off the item itself bakes to a per-item Go literal (#2898)",
+  escapes: [
+    { kind: 'prop-precompute', fixture: 'static-loop-item-conditional-precomputed' },
+    { kind: 'client-directive', fixture: 'static-loop-item-conditional-client' },
+  ],
   source: `
 type Item = { id: number; label: string; active: boolean; tag: string | null }
 

--- a/packages/adapter-tests/generated-data-points.json
+++ b/packages/adapter-tests/generated-data-points.json
@@ -2653,6 +2653,14 @@
       }
     }
   ],
+  "static-loop-item-boolean-attr-precomputed": [
+    {
+      "name": "gen:items:empty",
+      "props": {
+        "items": []
+      }
+    }
+  ],
   "static-loop-item-conditional-precomputed": [
     {
       "name": "gen:items:empty",

--- a/packages/adapter-tests/generated-data-points.json
+++ b/packages/adapter-tests/generated-data-points.json
@@ -2653,6 +2653,14 @@
       }
     }
   ],
+  "static-loop-item-conditional-precomputed": [
+    {
+      "name": "gen:items:empty",
+      "props": {
+        "items": []
+      }
+    }
+  ],
   "static-nested-loop-conditional-precomputed": [
     {
       "name": "gen:rows:empty",

--- a/packages/adapter-xslate/src/conformance-pins.ts
+++ b/packages/adapter-xslate/src/conformance-pins.ts
@@ -96,4 +96,13 @@ export const conformancePins: ConformancePins = {
     severity: 'error',
     issue: 'https://github.com/piconic-ai/barefootjs/issues/2911',
   }],
+  // #2911: same trigger as `static-loop-item-conditional` above — this
+  // fixture's item shape has a `disabled: boolean` field (feeding a boolean
+  // HTML attribute rather than a conditional), found alongside it while
+  // reviewing #2898.
+  'static-loop-item-boolean-attr': [{
+    code: 'BF101',
+    severity: 'error',
+    issue: 'https://github.com/piconic-ai/barefootjs/issues/2911',
+  }],
 }

--- a/packages/adapter-xslate/src/conformance-pins.ts
+++ b/packages/adapter-xslate/src/conformance-pins.ts
@@ -80,4 +80,20 @@ export const conformancePins: ConformancePins = {
   // resolves the primitive normally and never reaches this refusal (formerly
   // tracked as #2771, closed) — no open issue tracks further work.
   'namespace-import-primitive': [{ code: 'BF013', severity: 'error' }],
+  // #2911: `staticValueToPerl` (`adapter/lib/static-value.ts`) deliberately
+  // returns `null` for a `boolean` anywhere inside a static loop array's
+  // item shape — Perl has no native boolean literal, and baking `1`/`''`
+  // would diverge from JS's `String(true) === "true"` the moment that value
+  // is ever interpolated as text. This fixture's item shape has an `active:
+  // boolean` field (feeding a conditional, never interpolated as text
+  // itself), so the whole array fails to serialize and falls through to the
+  // generic "local computed value" BF101 refusal. Unrelated to #2898 (a
+  // Go-template-only fix) — this fixture happened to be the first to
+  // combine a boolean item field with a conditional in this adapter's own
+  // corpus.
+  'static-loop-item-conditional': [{
+    code: 'BF101',
+    severity: 'error',
+    issue: 'https://github.com/piconic-ai/barefootjs/issues/2911',
+  }],
 }

--- a/packages/compat/src/__tests__/compat-engine.test.ts
+++ b/packages/compat/src/__tests__/compat-engine.test.ts
@@ -50,20 +50,20 @@ describe('compileForCompat', () => {
     // source), #2700 (a `derived` object-literal signal/memo the
     // constructor-time baker can't reproduce, `signal-object-spread-init`),
     // #2805 (a named jsx-children prop routed into a child's rest bag,
-    // `jsx-element-prop-rest-bag-dynamic`), #2893 (a nested `.map()`
+    // `jsx-element-prop-rest-bag-dynamic`), and #2893 (a nested `.map()`
     // inside a static outer array's row, `static-nested-loop-ref` AND
     // `static-nested-loop-conditional` — the latter `unescapable`-pinned
-    // to the same issue rather than re-proving the identical escape), and
-    // #2898 (a conditional inside a static array's row with no nested loop,
-    // `static-loop-conditional`) surface here even though this test only
-    // exercises the nested-filter-callback shape. Three pins are no longer
-    // among them, each because the shape
-    // got a real lowering rather than a narrower refusal: #2319
-    // (dangerous-inner-html-dynamic → a faithful raw-output lowering),
-    // #2208 (static-array-children → the loop-source gate bakes a
-    // fully-static array-of-objects const), and #2448 (loop-row child prop
+    // to the same issue rather than re-proving the identical escape)
+    // surface here even though this test only exercises the
+    // nested-filter-callback shape. Four pins are no longer among them,
+    // each because the shape got a real lowering rather than a narrower
+    // refusal: #2319 (dangerous-inner-html-dynamic → a faithful raw-output
+    // lowering), #2208 (static-array-children → the loop-source gate bakes
+    // a fully-static array-of-objects const), #2448 (loop-row child prop
     // override feeding a derived field → the child rebuilds itself per row
-    // through `bf_reprops`). See `go-template`'s `conformance-pins.ts`.
+    // through `bf_reprops`), and #2898 (a conditional inside a static
+    // array's row with no nested loop → `isFoldableTree` now bakes it).
+    // See `go-template`'s `conformance-pins.ts`.
     expect(cell.diagnostics).toEqual([
       {
         code: 'BF101',
@@ -74,7 +74,6 @@ describe('compileForCompat', () => {
           'https://github.com/piconic-ai/barefootjs/issues/2700',
           'https://github.com/piconic-ai/barefootjs/issues/2805',
           'https://github.com/piconic-ai/barefootjs/issues/2893',
-          'https://github.com/piconic-ai/barefootjs/issues/2898',
         ],
       },
     ])

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-conformance section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. This answers, per fixture and per adapter, whether the construct WORKS — not just whether it compiles. A construct works either as written (✓) or with a documented `/* @client */` comment (✓†, a verified, supported escape — most refusals have one). Fixtures absent from the table below work on every adapter — most as written, some via that documented escape; the headline says how many of each. Listed fixtures need attention somewhere: a bare diagnostic code is still-open debt with no escape yet, a code led by ✗ owes no escape at all (by design), and ≠ means the fixture compiles clean but its rendered output diverges from the reference.",
-    "totalFixtures": 400,
+    "totalFixtures": 402,
     "fixtures": {
       "date-method-uncatalogued": {
         "blade": {
@@ -3479,6 +3479,34 @@
           }
         }
       },
+      "static-loop-item-conditional": {
+        "mojolicious": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2911"
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "static-loop-item-conditional-precomputed"
+          }
+        },
+        "xslate": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2911"
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "static-loop-item-conditional-precomputed"
+          }
+        }
+      },
       "static-nested-loop-conditional": {
         "go-template": {
           "kind": "refusal",
@@ -3681,6 +3709,10 @@
         "description": "Static-array loop with childComponent body materialises rendered children on CSR (#1268)",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-array-from-props-with-component.ts"
       },
+      "static-loop-item-conditional": {
+        "description": "static array's .map() row conditional keyed off the item itself bakes to a per-item Go literal…",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-loop-item-conditional.ts"
+      },
       "static-nested-loop-conditional": {
         "description": "a static outer array + depth-1 inner loop row conditional swaps live, not frozen at its SSR-time…",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-nested-loop-conditional.ts"
@@ -3748,6 +3780,10 @@
       "static-array-from-props-with-component-precomputed": {
         "description": "prop-precompute twin of static-array-from-props-with-component — child components render at SSR…",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-array-from-props-with-component-precomputed.ts"
+      },
+      "static-loop-item-conditional-precomputed": {
+        "description": "prop-precompute twin of static-loop-item-conditional — items moved to a prop, full SSR (#2898,…",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-loop-item-conditional-precomputed.ts"
       },
       "static-nested-loop-conditional-precomputed": {
         "description": "prop-precompute twin of static-nested-loop-conditional — rows moved to a prop, full SSR (#2893)",

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-conformance section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. This answers, per fixture and per adapter, whether the construct WORKS — not just whether it compiles. A construct works either as written (✓) or with a documented `/* @client */` comment (✓†, a verified, supported escape — most refusals have one). Fixtures absent from the table below work on every adapter — most as written, some via that documented escape; the headline says how many of each. Listed fixtures need attention somewhere: a bare diagnostic code is still-open debt with no escape yet, a code led by ✗ owes no escape at all (by design), and ≠ means the fixture compiles clean but its rendered output diverges from the reference.",
-    "totalFixtures": 399,
+    "totalFixtures": 400,
     "fixtures": {
       "date-method-uncatalogued": {
         "blade": {
@@ -3479,21 +3479,6 @@
           }
         }
       },
-      "static-loop-conditional": {
-        "go-template": {
-          "kind": "refusal",
-          "codes": [
-            "BF101"
-          ],
-          "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2898"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "static-loop-conditional-precomputed"
-          }
-        }
-      },
       "static-nested-loop-conditional": {
         "go-template": {
           "kind": "refusal",
@@ -3696,10 +3681,6 @@
         "description": "Static-array loop with childComponent body materialises rendered children on CSR (#1268)",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-array-from-props-with-component.ts"
       },
-      "static-loop-conditional": {
-        "description": "a static array's .map() row conditional swaps live, not frozen at its SSR-time value (#2897)",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-loop-conditional.ts"
-      },
       "static-nested-loop-conditional": {
         "description": "a static outer array + depth-1 inner loop row conditional swaps live, not frozen at its SSR-time…",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-nested-loop-conditional.ts"
@@ -3767,10 +3748,6 @@
       "static-array-from-props-with-component-precomputed": {
         "description": "prop-precompute twin of static-array-from-props-with-component — child components render at SSR…",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-array-from-props-with-component-precomputed.ts"
-      },
-      "static-loop-conditional-precomputed": {
-        "description": "prop-precompute twin of static-loop-conditional — items moved to a prop, full SSR (#2898)",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-loop-conditional-precomputed.ts"
       },
       "static-nested-loop-conditional-precomputed": {
         "description": "prop-precompute twin of static-nested-loop-conditional — rows moved to a prop, full SSR (#2893)",

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-conformance section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. This answers, per fixture and per adapter, whether the construct WORKS — not just whether it compiles. A construct works either as written (✓) or with a documented `/* @client */` comment (✓†, a verified, supported escape — most refusals have one). Fixtures absent from the table below work on every adapter — most as written, some via that documented escape; the headline says how many of each. Listed fixtures need attention somewhere: a bare diagnostic code is still-open debt with no escape yet, a code led by ✗ owes no escape at all (by design), and ≠ means the fixture compiles clean but its rendered output diverges from the reference.",
-    "totalFixtures": 402,
+    "totalFixtures": 405,
     "fixtures": {
       "date-method-uncatalogued": {
         "blade": {
@@ -3479,6 +3479,34 @@
           }
         }
       },
+      "static-loop-item-boolean-attr": {
+        "mojolicious": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2911"
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "static-loop-item-boolean-attr-precomputed"
+          }
+        },
+        "xslate": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2911"
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "static-loop-item-boolean-attr-precomputed"
+          }
+        }
+      },
       "static-loop-item-conditional": {
         "mojolicious": {
           "kind": "refusal",
@@ -3709,6 +3737,10 @@
         "description": "Static-array loop with childComponent body materialises rendered children on CSR (#1268)",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-array-from-props-with-component.ts"
       },
+      "static-loop-item-boolean-attr": {
+        "description": "static array's .map() row boolean attribute keyed off the item itself renders per item (#2898)",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-loop-item-boolean-attr.ts"
+      },
       "static-loop-item-conditional": {
         "description": "static array's .map() row conditional keyed off the item itself bakes to a per-item Go literal…",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-loop-item-conditional.ts"
@@ -3780,6 +3812,10 @@
       "static-array-from-props-with-component-precomputed": {
         "description": "prop-precompute twin of static-array-from-props-with-component — child components render at SSR…",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-array-from-props-with-component-precomputed.ts"
+      },
+      "static-loop-item-boolean-attr-precomputed": {
+        "description": "prop-precompute twin of static-loop-item-boolean-attr — items moved to a prop, full SSR (#2898,…",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-loop-item-boolean-attr-precomputed.ts"
       },
       "static-loop-item-conditional-precomputed": {
         "description": "prop-precompute twin of static-loop-item-conditional — items moved to a prop, full SSR (#2898,…",

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -131,7 +131,7 @@
           ]
         },
         "go-template": {
-          "pass": 91,
+          "pass": 92,
           "total": 106,
           "gaps": [
             {
@@ -181,12 +181,6 @@
             {
               "fixture": "some-typeof-predicate",
               "issues": []
-            },
-            {
-              "fixture": "static-loop-conditional",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2898"
-              ]
             },
             {
               "fixture": "static-nested-loop-conditional",
@@ -761,7 +755,7 @@
           ]
         },
         "go-template": {
-          "pass": 63,
+          "pass": 64,
           "total": 74,
           "gaps": [
             {
@@ -799,12 +793,6 @@
             {
               "fixture": "some-typeof-predicate",
               "issues": []
-            },
-            {
-              "fixture": "static-loop-conditional",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2898"
-              ]
             },
             {
               "fixture": "static-nested-loop-conditional",
@@ -1621,7 +1609,7 @@
           ]
         },
         "go-template": {
-          "pass": 254,
+          "pass": 255,
           "total": 274,
           "gaps": [
             {
@@ -1698,12 +1686,6 @@
               "fixture": "static-array-from-props-with-component",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2321"
-              ]
-            },
-            {
-              "fixture": "static-loop-conditional",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2898"
               ]
             },
             {
@@ -2477,7 +2459,7 @@
           ]
         },
         "go-template": {
-          "pass": 352,
+          "pass": 353,
           "total": 377,
           "gaps": [
             {
@@ -2576,12 +2558,6 @@
               "fixture": "static-array-from-props-with-component",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2321"
-              ]
-            },
-            {
-              "fixture": "static-loop-conditional",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2898"
               ]
             },
             {
@@ -3267,7 +3243,7 @@
           ]
         },
         "go-template": {
-          "pass": 285,
+          "pass": 286,
           "total": 302,
           "gaps": [
             {
@@ -3326,12 +3302,6 @@
               "fixture": "static-array-from-props-with-component",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2321"
-              ]
-            },
-            {
-              "fixture": "static-loop-conditional",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2898"
               ]
             },
             {
@@ -3995,7 +3965,7 @@
           ]
         },
         "go-template": {
-          "pass": 195,
+          "pass": 196,
           "total": 219,
           "gaps": [
             {
@@ -4090,12 +4060,6 @@
               "fixture": "static-array-from-props-with-component",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2321"
-              ]
-            },
-            {
-              "fixture": "static-loop-conditional",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2898"
               ]
             },
             {
@@ -4631,7 +4595,7 @@
           ]
         },
         "go-template": {
-          "pass": 80,
+          "pass": 81,
           "total": 87,
           "gaps": [
             {
@@ -4648,12 +4612,6 @@
               "fixture": "static-array-from-props",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2321"
-              ]
-            },
-            {
-              "fixture": "static-loop-conditional",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2898"
               ]
             },
             {
@@ -4967,7 +4925,7 @@
           ]
         },
         "go-template": {
-          "pass": 25,
+          "pass": 26,
           "total": 29,
           "gaps": [
             {
@@ -4979,12 +4937,6 @@
             {
               "fixture": "preamble-cells",
               "issues": []
-            },
-            {
-              "fixture": "static-loop-conditional",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2898"
-              ]
             },
             {
               "fixture": "static-nested-loop-conditional",
@@ -7901,7 +7853,7 @@
           ]
         },
         "go-template": {
-          "pass": 61,
+          "pass": 62,
           "total": 67,
           "gaps": [
             {
@@ -7922,12 +7874,6 @@
               "fixture": "signal-object-spread-init",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2700"
-              ]
-            },
-            {
-              "fixture": "static-loop-conditional",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2898"
               ]
             },
             {
@@ -8132,7 +8078,7 @@
           ]
         },
         "go-template": {
-          "pass": 127,
+          "pass": 128,
           "total": 135,
           "gaps": [
             {
@@ -8150,12 +8096,6 @@
             {
               "fixture": "reduce-typeof-body",
               "issues": []
-            },
-            {
-              "fixture": "static-loop-conditional",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2898"
-              ]
             },
             {
               "fixture": "static-nested-loop-conditional",
@@ -8406,7 +8346,7 @@
           ]
         },
         "go-template": {
-          "pass": 199,
+          "pass": 200,
           "total": 209,
           "gaps": [
             {
@@ -8447,12 +8387,6 @@
               "fixture": "static-array-from-props-with-component",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2321"
-              ]
-            },
-            {
-              "fixture": "static-loop-conditional",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2898"
               ]
             }
           ]
@@ -9672,7 +9606,7 @@
           ]
         },
         "go-template": {
-          "pass": 17,
+          "pass": 18,
           "total": 21,
           "gaps": [
             {
@@ -9684,12 +9618,6 @@
             {
               "fixture": "preamble-cells",
               "issues": []
-            },
-            {
-              "fixture": "static-loop-conditional",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2898"
-              ]
             },
             {
               "fixture": "static-nested-loop-conditional",

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -14,15 +14,15 @@
   ],
   "kinds": {
     "array-literal": {
-      "total": 106,
+      "total": 108,
       "cells": {
         "hono": {
-          "pass": 106,
-          "total": 106
+          "pass": 108,
+          "total": 108
         },
         "blade": {
-          "pass": 94,
-          "total": 106,
+          "pass": 96,
+          "total": 108,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -79,8 +79,8 @@
           ]
         },
         "erb": {
-          "pass": 95,
-          "total": 106,
+          "pass": 97,
+          "total": 108,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -131,8 +131,8 @@
           ]
         },
         "go-template": {
-          "pass": 92,
-          "total": 106,
+          "pass": 94,
+          "total": 108,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -201,8 +201,8 @@
           ]
         },
         "jinja": {
-          "pass": 94,
-          "total": 106,
+          "pass": 96,
+          "total": 108,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -259,8 +259,8 @@
           ]
         },
         "minijinja": {
-          "pass": 94,
-          "total": 106,
+          "pass": 96,
+          "total": 108,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -317,8 +317,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 95,
-          "total": 106,
+          "pass": 96,
+          "total": 108,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -363,14 +363,20 @@
               "issues": []
             },
             {
+              "fixture": "static-loop-item-conditional",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2911"
+              ]
+            },
+            {
               "fixture": "tag-cloud",
               "issues": []
             }
           ]
         },
         "twig": {
-          "pass": 94,
-          "total": 106,
+          "pass": 96,
+          "total": 108,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -427,8 +433,8 @@
           ]
         },
         "xslate": {
-          "pass": 94,
-          "total": 106,
+          "pass": 95,
+          "total": 108,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -477,6 +483,12 @@
             {
               "fixture": "some-typeof-predicate",
               "issues": []
+            },
+            {
+              "fixture": "static-loop-item-conditional",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2911"
+              ]
             },
             {
               "fixture": "tag-cloud",
@@ -2246,11 +2258,11 @@
       }
     },
     "identifier": {
-      "total": 377,
+      "total": 380,
       "cells": {
         "hono": {
-          "pass": 373,
-          "total": 377,
+          "pass": 376,
+          "total": 380,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2273,8 +2285,8 @@
           ]
         },
         "blade": {
-          "pass": 357,
-          "total": 377,
+          "pass": 360,
+          "total": 380,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2369,8 +2381,8 @@
           ]
         },
         "erb": {
-          "pass": 358,
-          "total": 377,
+          "pass": 361,
+          "total": 380,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2459,8 +2471,8 @@
           ]
         },
         "go-template": {
-          "pass": 353,
-          "total": 377,
+          "pass": 356,
+          "total": 380,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2579,8 +2591,8 @@
           ]
         },
         "jinja": {
-          "pass": 357,
-          "total": 377,
+          "pass": 360,
+          "total": 380,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2675,8 +2687,8 @@
           ]
         },
         "minijinja": {
-          "pass": 357,
-          "total": 377,
+          "pass": 360,
+          "total": 380,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2771,8 +2783,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 358,
-          "total": 377,
+          "pass": 360,
+          "total": 380,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2855,14 +2867,20 @@
               ]
             },
             {
+              "fixture": "static-loop-item-conditional",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2911"
+              ]
+            },
+            {
               "fixture": "tag-cloud",
               "issues": []
             }
           ]
         },
         "twig": {
-          "pass": 357,
-          "total": 377,
+          "pass": 360,
+          "total": 380,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2957,8 +2975,8 @@
           ]
         },
         "xslate": {
-          "pass": 357,
-          "total": 377,
+          "pass": 359,
+          "total": 380,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3044,6 +3062,12 @@
               "fixture": "static-array-from-props-with-component",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
+            },
+            {
+              "fixture": "static-loop-item-conditional",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2911"
               ]
             },
             {
@@ -3118,11 +3142,11 @@
       }
     },
     "literal": {
-      "total": 302,
+      "total": 305,
       "cells": {
         "hono": {
-          "pass": 301,
-          "total": 302,
+          "pass": 304,
+          "total": 305,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -3131,8 +3155,8 @@
           ]
         },
         "blade": {
-          "pass": 290,
-          "total": 302,
+          "pass": 293,
+          "total": 305,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3187,8 +3211,8 @@
           ]
         },
         "erb": {
-          "pass": 290,
-          "total": 302,
+          "pass": 293,
+          "total": 305,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3243,8 +3267,8 @@
           ]
         },
         "go-template": {
-          "pass": 286,
-          "total": 302,
+          "pass": 289,
+          "total": 305,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3323,8 +3347,8 @@
           ]
         },
         "jinja": {
-          "pass": 290,
-          "total": 302,
+          "pass": 293,
+          "total": 305,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3379,8 +3403,8 @@
           ]
         },
         "minijinja": {
-          "pass": 290,
-          "total": 302,
+          "pass": 293,
+          "total": 305,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3435,8 +3459,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 290,
-          "total": 302,
+          "pass": 292,
+          "total": 305,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3485,14 +3509,20 @@
               ]
             },
             {
+              "fixture": "static-loop-item-conditional",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2911"
+              ]
+            },
+            {
               "fixture": "tag-cloud",
               "issues": []
             }
           ]
         },
         "twig": {
-          "pass": 290,
-          "total": 302,
+          "pass": 293,
+          "total": 305,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3547,8 +3577,8 @@
           ]
         },
         "xslate": {
-          "pass": 290,
-          "total": 302,
+          "pass": 292,
+          "total": 305,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3594,6 +3624,12 @@
               "fixture": "static-array-from-props-with-component",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
+            },
+            {
+              "fixture": "static-loop-item-conditional",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2911"
               ]
             },
             {
@@ -3764,11 +3800,11 @@
       }
     },
     "member": {
-      "total": 219,
+      "total": 222,
       "cells": {
         "hono": {
-          "pass": 216,
-          "total": 219,
+          "pass": 219,
+          "total": 222,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3787,8 +3823,8 @@
           ]
         },
         "blade": {
-          "pass": 200,
-          "total": 219,
+          "pass": 203,
+          "total": 222,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3879,8 +3915,8 @@
           ]
         },
         "erb": {
-          "pass": 201,
-          "total": 219,
+          "pass": 204,
+          "total": 222,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3965,8 +4001,8 @@
           ]
         },
         "go-template": {
-          "pass": 196,
-          "total": 219,
+          "pass": 199,
+          "total": 222,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4081,8 +4117,8 @@
           ]
         },
         "jinja": {
-          "pass": 200,
-          "total": 219,
+          "pass": 203,
+          "total": 222,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4173,8 +4209,8 @@
           ]
         },
         "minijinja": {
-          "pass": 200,
-          "total": 219,
+          "pass": 203,
+          "total": 222,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4265,8 +4301,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 201,
-          "total": 219,
+          "pass": 203,
+          "total": 222,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4345,14 +4381,20 @@
               ]
             },
             {
+              "fixture": "static-loop-item-conditional",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2911"
+              ]
+            },
+            {
               "fixture": "tag-cloud",
               "issues": []
             }
           ]
         },
         "twig": {
-          "pass": 200,
-          "total": 219,
+          "pass": 203,
+          "total": 222,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4443,8 +4485,8 @@
           ]
         },
         "xslate": {
-          "pass": 200,
-          "total": 219,
+          "pass": 202,
+          "total": 222,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4529,6 +4571,12 @@
               ]
             },
             {
+              "fixture": "static-loop-item-conditional",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2911"
+              ]
+            },
+            {
               "fixture": "tag-cloud",
               "issues": []
             }
@@ -4548,15 +4596,15 @@
       }
     },
     "object-literal": {
-      "total": 87,
+      "total": 88,
       "cells": {
         "hono": {
-          "pass": 87,
-          "total": 87
+          "pass": 88,
+          "total": 88
         },
         "blade": {
-          "pass": 84,
-          "total": 87,
+          "pass": 85,
+          "total": 88,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4575,8 +4623,8 @@
           ]
         },
         "erb": {
-          "pass": 84,
-          "total": 87,
+          "pass": 85,
+          "total": 88,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4595,8 +4643,8 @@
           ]
         },
         "go-template": {
-          "pass": 81,
-          "total": 87,
+          "pass": 82,
+          "total": 88,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4633,8 +4681,8 @@
           ]
         },
         "jinja": {
-          "pass": 84,
-          "total": 87,
+          "pass": 85,
+          "total": 88,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4653,8 +4701,8 @@
           ]
         },
         "minijinja": {
-          "pass": 84,
-          "total": 87,
+          "pass": 85,
+          "total": 88,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4674,7 +4722,7 @@
         },
         "mojolicious": {
           "pass": 84,
-          "total": 87,
+          "total": 88,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4687,14 +4735,20 @@
               ]
             },
             {
+              "fixture": "static-loop-item-conditional",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2911"
+              ]
+            },
+            {
               "fixture": "tag-cloud",
               "issues": []
             }
           ]
         },
         "twig": {
-          "pass": 84,
-          "total": 87,
+          "pass": 85,
+          "total": 88,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4714,7 +4768,7 @@
         },
         "xslate": {
           "pass": 84,
-          "total": 87,
+          "total": 88,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4724,6 +4778,12 @@
               "fixture": "static-array-from-props",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
+            },
+            {
+              "fixture": "static-loop-item-conditional",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2911"
               ]
             },
             {
@@ -7812,11 +7872,11 @@
       }
     },
     "literal:boolean": {
-      "total": 67,
+      "total": 68,
       "cells": {
         "hono": {
-          "pass": 66,
-          "total": 67,
+          "pass": 67,
+          "total": 68,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -7825,8 +7885,8 @@
           ]
         },
         "blade": {
-          "pass": 65,
-          "total": 67,
+          "pass": 66,
+          "total": 68,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -7839,8 +7899,8 @@
           ]
         },
         "erb": {
-          "pass": 65,
-          "total": 67,
+          "pass": 66,
+          "total": 68,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -7853,8 +7913,8 @@
           ]
         },
         "go-template": {
-          "pass": 62,
-          "total": 67,
+          "pass": 63,
+          "total": 68,
           "gaps": [
             {
               "fixture": "jsx-element-prop-rest-bag-dynamic",
@@ -7885,8 +7945,8 @@
           ]
         },
         "jinja": {
-          "pass": 65,
-          "total": 67,
+          "pass": 66,
+          "total": 68,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -7899,8 +7959,8 @@
           ]
         },
         "minijinja": {
-          "pass": 65,
-          "total": 67,
+          "pass": 66,
+          "total": 68,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -7914,7 +7974,7 @@
         },
         "mojolicious": {
           "pass": 65,
-          "total": 67,
+          "total": 68,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -7923,12 +7983,18 @@
             {
               "fixture": "preamble-cells",
               "issues": []
+            },
+            {
+              "fixture": "static-loop-item-conditional",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2911"
+              ]
             }
           ]
         },
         "twig": {
-          "pass": 65,
-          "total": 67,
+          "pass": 66,
+          "total": 68,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -7942,7 +8008,7 @@
         },
         "xslate": {
           "pass": 65,
-          "total": 67,
+          "total": 68,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -7951,6 +8017,12 @@
             {
               "fixture": "preamble-cells",
               "issues": []
+            },
+            {
+              "fixture": "static-loop-item-conditional",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2911"
+              ]
             }
           ]
         }
@@ -7968,43 +8040,59 @@
       }
     },
     "literal:null": {
-      "total": 23,
+      "total": 26,
       "cells": {
         "hono": {
-          "pass": 23,
-          "total": 23
+          "pass": 26,
+          "total": 26
         },
         "blade": {
-          "pass": 23,
-          "total": 23
+          "pass": 26,
+          "total": 26
         },
         "erb": {
-          "pass": 23,
-          "total": 23
+          "pass": 26,
+          "total": 26
         },
         "go-template": {
-          "pass": 23,
-          "total": 23
+          "pass": 26,
+          "total": 26
         },
         "jinja": {
-          "pass": 23,
-          "total": 23
+          "pass": 26,
+          "total": 26
         },
         "minijinja": {
-          "pass": 23,
-          "total": 23
+          "pass": 26,
+          "total": 26
         },
         "mojolicious": {
-          "pass": 23,
-          "total": 23
+          "pass": 25,
+          "total": 26,
+          "gaps": [
+            {
+              "fixture": "static-loop-item-conditional",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2911"
+              ]
+            }
+          ]
         },
         "twig": {
-          "pass": 23,
-          "total": 23
+          "pass": 26,
+          "total": 26
         },
         "xslate": {
-          "pass": 23,
-          "total": 23
+          "pass": 25,
+          "total": 26,
+          "gaps": [
+            {
+              "fixture": "static-loop-item-conditional",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2911"
+              ]
+            }
+          ]
         }
       },
       "source": {
@@ -8019,15 +8107,15 @@
       }
     },
     "literal:number": {
-      "total": 135,
+      "total": 136,
       "cells": {
         "hono": {
-          "pass": 135,
-          "total": 135
+          "pass": 136,
+          "total": 136
         },
         "blade": {
-          "pass": 130,
-          "total": 135,
+          "pass": 131,
+          "total": 136,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8052,8 +8140,8 @@
           ]
         },
         "erb": {
-          "pass": 130,
-          "total": 135,
+          "pass": 131,
+          "total": 136,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8078,8 +8166,8 @@
           ]
         },
         "go-template": {
-          "pass": 128,
-          "total": 135,
+          "pass": 129,
+          "total": 136,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8116,8 +8204,8 @@
           ]
         },
         "jinja": {
-          "pass": 130,
-          "total": 135,
+          "pass": 131,
+          "total": 136,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8142,8 +8230,8 @@
           ]
         },
         "minijinja": {
-          "pass": 130,
-          "total": 135,
+          "pass": 131,
+          "total": 136,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8169,7 +8257,7 @@
         },
         "mojolicious": {
           "pass": 130,
-          "total": 135,
+          "total": 136,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8188,14 +8276,20 @@
               "issues": []
             },
             {
+              "fixture": "static-loop-item-conditional",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2911"
+              ]
+            },
+            {
               "fixture": "tag-cloud",
               "issues": []
             }
           ]
         },
         "twig": {
-          "pass": 130,
-          "total": 135,
+          "pass": 131,
+          "total": 136,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8221,7 +8315,7 @@
         },
         "xslate": {
           "pass": 130,
-          "total": 135,
+          "total": 136,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8238,6 +8332,12 @@
             {
               "fixture": "reduce-typeof-body",
               "issues": []
+            },
+            {
+              "fixture": "static-loop-item-conditional",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2911"
+              ]
             },
             {
               "fixture": "tag-cloud",
@@ -8259,15 +8359,15 @@
       }
     },
     "literal:string": {
-      "total": 209,
+      "total": 210,
       "cells": {
         "hono": {
-          "pass": 209,
-          "total": 209
+          "pass": 210,
+          "total": 210
         },
         "blade": {
-          "pass": 201,
-          "total": 209,
+          "pass": 202,
+          "total": 210,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8306,8 +8406,8 @@
           ]
         },
         "erb": {
-          "pass": 201,
-          "total": 209,
+          "pass": 202,
+          "total": 210,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8346,8 +8446,8 @@
           ]
         },
         "go-template": {
-          "pass": 200,
-          "total": 209,
+          "pass": 201,
+          "total": 210,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8392,8 +8492,8 @@
           ]
         },
         "jinja": {
-          "pass": 201,
-          "total": 209,
+          "pass": 202,
+          "total": 210,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8432,8 +8532,8 @@
           ]
         },
         "minijinja": {
-          "pass": 201,
-          "total": 209,
+          "pass": 202,
+          "total": 210,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8473,7 +8573,7 @@
         },
         "mojolicious": {
           "pass": 201,
-          "total": 209,
+          "total": 210,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8508,12 +8608,18 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
+            },
+            {
+              "fixture": "static-loop-item-conditional",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2911"
+              ]
             }
           ]
         },
         "twig": {
-          "pass": 201,
-          "total": 209,
+          "pass": 202,
+          "total": 210,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8553,7 +8659,7 @@
         },
         "xslate": {
           "pass": 201,
-          "total": 209,
+          "total": 210,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8587,6 +8693,12 @@
               "fixture": "static-array-from-props-with-component",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
+            },
+            {
+              "fixture": "static-loop-item-conditional",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2911"
               ]
             }
           ]

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -14,15 +14,15 @@
   ],
   "kinds": {
     "array-literal": {
-      "total": 108,
+      "total": 110,
       "cells": {
         "hono": {
-          "pass": 108,
-          "total": 108
+          "pass": 110,
+          "total": 110
         },
         "blade": {
-          "pass": 96,
-          "total": 108,
+          "pass": 98,
+          "total": 110,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -79,8 +79,8 @@
           ]
         },
         "erb": {
-          "pass": 97,
-          "total": 108,
+          "pass": 99,
+          "total": 110,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -131,8 +131,8 @@
           ]
         },
         "go-template": {
-          "pass": 94,
-          "total": 108,
+          "pass": 96,
+          "total": 110,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -201,8 +201,8 @@
           ]
         },
         "jinja": {
-          "pass": 96,
-          "total": 108,
+          "pass": 98,
+          "total": 110,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -259,8 +259,8 @@
           ]
         },
         "minijinja": {
-          "pass": 96,
-          "total": 108,
+          "pass": 98,
+          "total": 110,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -317,8 +317,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 96,
-          "total": 108,
+          "pass": 97,
+          "total": 110,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -363,6 +363,12 @@
               "issues": []
             },
             {
+              "fixture": "static-loop-item-boolean-attr",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2911"
+              ]
+            },
+            {
               "fixture": "static-loop-item-conditional",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2911"
@@ -375,8 +381,8 @@
           ]
         },
         "twig": {
-          "pass": 96,
-          "total": 108,
+          "pass": 98,
+          "total": 110,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -433,8 +439,8 @@
           ]
         },
         "xslate": {
-          "pass": 95,
-          "total": 108,
+          "pass": 96,
+          "total": 110,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -483,6 +489,12 @@
             {
               "fixture": "some-typeof-predicate",
               "issues": []
+            },
+            {
+              "fixture": "static-loop-item-boolean-attr",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2911"
+              ]
             },
             {
               "fixture": "static-loop-item-conditional",
@@ -2258,11 +2270,11 @@
       }
     },
     "identifier": {
-      "total": 380,
+      "total": 383,
       "cells": {
         "hono": {
-          "pass": 376,
-          "total": 380,
+          "pass": 379,
+          "total": 383,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2285,8 +2297,8 @@
           ]
         },
         "blade": {
-          "pass": 360,
-          "total": 380,
+          "pass": 363,
+          "total": 383,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2381,8 +2393,8 @@
           ]
         },
         "erb": {
-          "pass": 361,
-          "total": 380,
+          "pass": 364,
+          "total": 383,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2471,8 +2483,8 @@
           ]
         },
         "go-template": {
-          "pass": 356,
-          "total": 380,
+          "pass": 359,
+          "total": 383,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2591,8 +2603,8 @@
           ]
         },
         "jinja": {
-          "pass": 360,
-          "total": 380,
+          "pass": 363,
+          "total": 383,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2687,8 +2699,8 @@
           ]
         },
         "minijinja": {
-          "pass": 360,
-          "total": 380,
+          "pass": 363,
+          "total": 383,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2783,8 +2795,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 360,
-          "total": 380,
+          "pass": 362,
+          "total": 383,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2867,6 +2879,12 @@
               ]
             },
             {
+              "fixture": "static-loop-item-boolean-attr",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2911"
+              ]
+            },
+            {
               "fixture": "static-loop-item-conditional",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2911"
@@ -2879,8 +2897,8 @@
           ]
         },
         "twig": {
-          "pass": 360,
-          "total": 380,
+          "pass": 363,
+          "total": 383,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2975,8 +2993,8 @@
           ]
         },
         "xslate": {
-          "pass": 359,
-          "total": 380,
+          "pass": 361,
+          "total": 383,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3062,6 +3080,12 @@
               "fixture": "static-array-from-props-with-component",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
+            },
+            {
+              "fixture": "static-loop-item-boolean-attr",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2911"
               ]
             },
             {
@@ -3142,11 +3166,11 @@
       }
     },
     "literal": {
-      "total": 305,
+      "total": 306,
       "cells": {
         "hono": {
-          "pass": 304,
-          "total": 305,
+          "pass": 305,
+          "total": 306,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -3155,8 +3179,8 @@
           ]
         },
         "blade": {
-          "pass": 293,
-          "total": 305,
+          "pass": 294,
+          "total": 306,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3211,8 +3235,8 @@
           ]
         },
         "erb": {
-          "pass": 293,
-          "total": 305,
+          "pass": 294,
+          "total": 306,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3267,8 +3291,8 @@
           ]
         },
         "go-template": {
-          "pass": 289,
-          "total": 305,
+          "pass": 290,
+          "total": 306,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3347,8 +3371,8 @@
           ]
         },
         "jinja": {
-          "pass": 293,
-          "total": 305,
+          "pass": 294,
+          "total": 306,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3403,8 +3427,8 @@
           ]
         },
         "minijinja": {
-          "pass": 293,
-          "total": 305,
+          "pass": 294,
+          "total": 306,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3460,7 +3484,7 @@
         },
         "mojolicious": {
           "pass": 292,
-          "total": 305,
+          "total": 306,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3509,6 +3533,12 @@
               ]
             },
             {
+              "fixture": "static-loop-item-boolean-attr",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2911"
+              ]
+            },
+            {
               "fixture": "static-loop-item-conditional",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2911"
@@ -3521,8 +3551,8 @@
           ]
         },
         "twig": {
-          "pass": 293,
-          "total": 305,
+          "pass": 294,
+          "total": 306,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3578,7 +3608,7 @@
         },
         "xslate": {
           "pass": 292,
-          "total": 305,
+          "total": 306,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3624,6 +3654,12 @@
               "fixture": "static-array-from-props-with-component",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
+            },
+            {
+              "fixture": "static-loop-item-boolean-attr",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2911"
               ]
             },
             {
@@ -3800,11 +3836,11 @@
       }
     },
     "member": {
-      "total": 222,
+      "total": 225,
       "cells": {
         "hono": {
-          "pass": 219,
-          "total": 222,
+          "pass": 222,
+          "total": 225,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3823,8 +3859,8 @@
           ]
         },
         "blade": {
-          "pass": 203,
-          "total": 222,
+          "pass": 206,
+          "total": 225,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3915,8 +3951,8 @@
           ]
         },
         "erb": {
-          "pass": 204,
-          "total": 222,
+          "pass": 207,
+          "total": 225,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4001,8 +4037,8 @@
           ]
         },
         "go-template": {
-          "pass": 199,
-          "total": 222,
+          "pass": 202,
+          "total": 225,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4117,8 +4153,8 @@
           ]
         },
         "jinja": {
-          "pass": 203,
-          "total": 222,
+          "pass": 206,
+          "total": 225,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4209,8 +4245,8 @@
           ]
         },
         "minijinja": {
-          "pass": 203,
-          "total": 222,
+          "pass": 206,
+          "total": 225,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4301,8 +4337,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 203,
-          "total": 222,
+          "pass": 205,
+          "total": 225,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4381,6 +4417,12 @@
               ]
             },
             {
+              "fixture": "static-loop-item-boolean-attr",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2911"
+              ]
+            },
+            {
               "fixture": "static-loop-item-conditional",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2911"
@@ -4393,8 +4435,8 @@
           ]
         },
         "twig": {
-          "pass": 203,
-          "total": 222,
+          "pass": 206,
+          "total": 225,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4485,8 +4527,8 @@
           ]
         },
         "xslate": {
-          "pass": 202,
-          "total": 222,
+          "pass": 204,
+          "total": 225,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4571,6 +4613,12 @@
               ]
             },
             {
+              "fixture": "static-loop-item-boolean-attr",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2911"
+              ]
+            },
+            {
               "fixture": "static-loop-item-conditional",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2911"
@@ -4596,15 +4644,15 @@
       }
     },
     "object-literal": {
-      "total": 88,
+      "total": 89,
       "cells": {
         "hono": {
-          "pass": 88,
-          "total": 88
+          "pass": 89,
+          "total": 89
         },
         "blade": {
-          "pass": 85,
-          "total": 88,
+          "pass": 86,
+          "total": 89,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4623,8 +4671,8 @@
           ]
         },
         "erb": {
-          "pass": 85,
-          "total": 88,
+          "pass": 86,
+          "total": 89,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4643,8 +4691,8 @@
           ]
         },
         "go-template": {
-          "pass": 82,
-          "total": 88,
+          "pass": 83,
+          "total": 89,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4681,8 +4729,8 @@
           ]
         },
         "jinja": {
-          "pass": 85,
-          "total": 88,
+          "pass": 86,
+          "total": 89,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4701,8 +4749,8 @@
           ]
         },
         "minijinja": {
-          "pass": 85,
-          "total": 88,
+          "pass": 86,
+          "total": 89,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4722,7 +4770,7 @@
         },
         "mojolicious": {
           "pass": 84,
-          "total": 88,
+          "total": 89,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4732,6 +4780,12 @@
               "fixture": "static-array-from-props",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
+            },
+            {
+              "fixture": "static-loop-item-boolean-attr",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2911"
               ]
             },
             {
@@ -4747,8 +4801,8 @@
           ]
         },
         "twig": {
-          "pass": 85,
-          "total": 88,
+          "pass": 86,
+          "total": 89,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4768,7 +4822,7 @@
         },
         "xslate": {
           "pass": 84,
-          "total": 88,
+          "total": 89,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4778,6 +4832,12 @@
               "fixture": "static-array-from-props",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
+            },
+            {
+              "fixture": "static-loop-item-boolean-attr",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2911"
               ]
             },
             {
@@ -7872,11 +7932,11 @@
       }
     },
     "literal:boolean": {
-      "total": 68,
+      "total": 69,
       "cells": {
         "hono": {
-          "pass": 67,
-          "total": 68,
+          "pass": 68,
+          "total": 69,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -7885,8 +7945,8 @@
           ]
         },
         "blade": {
-          "pass": 66,
-          "total": 68,
+          "pass": 67,
+          "total": 69,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -7899,8 +7959,8 @@
           ]
         },
         "erb": {
-          "pass": 66,
-          "total": 68,
+          "pass": 67,
+          "total": 69,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -7913,8 +7973,8 @@
           ]
         },
         "go-template": {
-          "pass": 63,
-          "total": 68,
+          "pass": 64,
+          "total": 69,
           "gaps": [
             {
               "fixture": "jsx-element-prop-rest-bag-dynamic",
@@ -7945,8 +8005,8 @@
           ]
         },
         "jinja": {
-          "pass": 66,
-          "total": 68,
+          "pass": 67,
+          "total": 69,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -7959,8 +8019,8 @@
           ]
         },
         "minijinja": {
-          "pass": 66,
-          "total": 68,
+          "pass": 67,
+          "total": 69,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -7974,7 +8034,7 @@
         },
         "mojolicious": {
           "pass": 65,
-          "total": 68,
+          "total": 69,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -7985,6 +8045,12 @@
               "issues": []
             },
             {
+              "fixture": "static-loop-item-boolean-attr",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2911"
+              ]
+            },
+            {
               "fixture": "static-loop-item-conditional",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2911"
@@ -7993,8 +8059,8 @@
           ]
         },
         "twig": {
-          "pass": 66,
-          "total": 68,
+          "pass": 67,
+          "total": 69,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -8008,7 +8074,7 @@
         },
         "xslate": {
           "pass": 65,
-          "total": 68,
+          "total": 69,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -8017,6 +8083,12 @@
             {
               "fixture": "preamble-cells",
               "issues": []
+            },
+            {
+              "fixture": "static-loop-item-boolean-attr",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2911"
+              ]
             },
             {
               "fixture": "static-loop-item-conditional",
@@ -8107,15 +8179,15 @@
       }
     },
     "literal:number": {
-      "total": 136,
+      "total": 137,
       "cells": {
         "hono": {
-          "pass": 136,
-          "total": 136
+          "pass": 137,
+          "total": 137
         },
         "blade": {
-          "pass": 131,
-          "total": 136,
+          "pass": 132,
+          "total": 137,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8140,8 +8212,8 @@
           ]
         },
         "erb": {
-          "pass": 131,
-          "total": 136,
+          "pass": 132,
+          "total": 137,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8166,8 +8238,8 @@
           ]
         },
         "go-template": {
-          "pass": 129,
-          "total": 136,
+          "pass": 130,
+          "total": 137,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8204,8 +8276,8 @@
           ]
         },
         "jinja": {
-          "pass": 131,
-          "total": 136,
+          "pass": 132,
+          "total": 137,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8230,8 +8302,8 @@
           ]
         },
         "minijinja": {
-          "pass": 131,
-          "total": 136,
+          "pass": 132,
+          "total": 137,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8257,7 +8329,7 @@
         },
         "mojolicious": {
           "pass": 130,
-          "total": 136,
+          "total": 137,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8276,6 +8348,12 @@
               "issues": []
             },
             {
+              "fixture": "static-loop-item-boolean-attr",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2911"
+              ]
+            },
+            {
               "fixture": "static-loop-item-conditional",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2911"
@@ -8288,8 +8366,8 @@
           ]
         },
         "twig": {
-          "pass": 131,
-          "total": 136,
+          "pass": 132,
+          "total": 137,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8315,7 +8393,7 @@
         },
         "xslate": {
           "pass": 130,
-          "total": 136,
+          "total": 137,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8332,6 +8410,12 @@
             {
               "fixture": "reduce-typeof-body",
               "issues": []
+            },
+            {
+              "fixture": "static-loop-item-boolean-attr",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2911"
+              ]
             },
             {
               "fixture": "static-loop-item-conditional",
@@ -8359,15 +8443,15 @@
       }
     },
     "literal:string": {
-      "total": 210,
+      "total": 211,
       "cells": {
         "hono": {
-          "pass": 210,
-          "total": 210
+          "pass": 211,
+          "total": 211
         },
         "blade": {
-          "pass": 202,
-          "total": 210,
+          "pass": 203,
+          "total": 211,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8406,8 +8490,8 @@
           ]
         },
         "erb": {
-          "pass": 202,
-          "total": 210,
+          "pass": 203,
+          "total": 211,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8446,8 +8530,8 @@
           ]
         },
         "go-template": {
-          "pass": 201,
-          "total": 210,
+          "pass": 202,
+          "total": 211,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8492,8 +8576,8 @@
           ]
         },
         "jinja": {
-          "pass": 202,
-          "total": 210,
+          "pass": 203,
+          "total": 211,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8532,8 +8616,8 @@
           ]
         },
         "minijinja": {
-          "pass": 202,
-          "total": 210,
+          "pass": 203,
+          "total": 211,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8573,7 +8657,7 @@
         },
         "mojolicious": {
           "pass": 201,
-          "total": 210,
+          "total": 211,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8610,6 +8694,12 @@
               ]
             },
             {
+              "fixture": "static-loop-item-boolean-attr",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2911"
+              ]
+            },
+            {
               "fixture": "static-loop-item-conditional",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2911"
@@ -8618,8 +8708,8 @@
           ]
         },
         "twig": {
-          "pass": 202,
-          "total": 210,
+          "pass": 203,
+          "total": 211,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8659,7 +8749,7 @@
         },
         "xslate": {
           "pass": 201,
-          "total": 210,
+          "total": 211,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8693,6 +8783,12 @@
               "fixture": "static-array-from-props-with-component",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
+            },
+            {
+              "fixture": "static-loop-item-boolean-attr",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2911"
               ]
             },
             {


### PR DESCRIPTION
## Summary

- `analyzeBakeableStaticElementLoop`'s `isFoldableTree` (`packages/adapter-go-template/src/adapter/analysis/static-element-loop-bake.ts`) used to bail the WHOLE per-item unroll when a static loop's row contained a `conditional` node anywhere, falling through to a generic BF101 "computed loop array" refusal.
- Now allows a `conditional` node through when both branches fold (recursing the same structural/per-item passes already used for plain elements) and the condition classifies via a new `classifyBakedCondition`:
  - **item-literal** (resolves via `evaluateStaticLiteral` against the row's item, e.g. `item.active ? ... : ...`) bakes to a Go `true`/`false` literal per item — the same substitution every other item-bound expression already gets inside the unrolled body, since there is no `{{range}}` dot-context for a live condition to resolve against there.
  - **item-independent** (references none of the item's bound names, e.g. a signal call like `flag()`) falls through to the adapter's normal `renderConditionExpr` lowering unmodified — that path never depended on the missing dot-context in the first place.
  - anything else (mixed item-bound/independent names, or an unclassifiable shape) still bails the whole loop, loudly.
- Graduates the `static-loop-conditional` conformance fixture off its BF101 pin (`conformance-pins.ts`) and updates `compat-engine.test.ts`'s expected issue-URL union accordingly.
- Adds a new `static-loop-item-conditional` fixture covering the item-literal + null-branch half of `classifyBakedCondition` (subset-conformance's same-PR coverage rule).

Fixes https://github.com/piconic-ai/barefootjs/issues/2898

## Test plan

- [x] `bun run packages/adapter-tests/scripts/generate-expected-html.ts` — regenerated `static-loop-conditional` + new `static-loop-item-conditional` expected HTML from the Hono reference adapter; `git status --short` clean beyond the intended fixture changes.
- [x] `tsgo --noEmit` on `packages/adapter-go-template` — clean.
- [ ] `bun test packages/adapter-go-template/src` — running; will confirm green before marking ready for review.
- [ ] CI

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JoiEowwf1mVvYywj5AesY

---
_Generated by [Claude Code](https://claude.ai/code/session_016JoiEowwf1mVvYywj5AesY)_