### PR TITLE
docs: close gaps in the existing-project retrofit guide found by dry-run

### DIFF
--- a/docs/core/adapters/hono-adapter.md
+++ b/docs/core/adapters/hono-adapter.md
@@ -226,6 +226,8 @@ npm install @barefootjs/client @barefootjs/hono @barefootjs/jsx @barefootjs/shar
 npm install -D @barefootjs/vite
 ```
 
+These packages currently peer-depend on `vite ^6.0.0` and `typescript ^5.0.0`. If the existing project is already on a newer major of either, plain `npm install` fails with an `ERESOLVE` dependency-tree error — install with `--legacy-peer-deps`, or pin `typescript` down to `^5` (the `vite` peer range is the more conservative one in practice; a newer `vite` alone tends to work). A `typescript` major above `^5` is the one that actually matters at runtime: `vite build` can fail at config-load time with `TypeError: ts.createPrinter is not a function` (or similar) rather than a clear version error, because `@barefootjs/vite` calls into the `typescript` package's compiler API directly.
+
 ### 2. `tsconfig.json` — the `@/components/*` path mapping
 
 Components are imported by the server through a path alias with **two** targets, compiled output first:
@@ -306,7 +308,10 @@ If the project already has a `vite.config.ts` for a whole-app SSR bundler, the `
   "name": "my-app",
   // The uncompiled entry, not a pre-bundled SSR output. Wrangler's own
   // esbuild-based bundler compiles it at dev/deploy time and follows
-  // the tsconfig `paths` mapping into dist/components/.
+  // the tsconfig `paths` mapping into dist/components/. `server.tsx`
+  // here is illustrative — point `main` at wherever your app's Hono
+  // entry file already lives (e.g. `src/index.tsx`); don't create a
+  // new file at this path.
   "main": "server.tsx",
   "compatibility_date": "2025-01-01",
   // Static assets (CSS, generated client JS, manifest) are served
@@ -317,7 +322,7 @@ If the project already has a `vite.config.ts` for a whole-app SSR bundler, the `
 }
 ```
 
-Previously `main` pointed at whatever single-file bundle the SSR build step produced. That step is what this migration removes: `barefoot()` only compiles components, so there is no bundled server artifact to point at anymore. Wrangler bundles `server.tsx` natively — resolving `@/components/*` to the compiled templates under `dist/components/` via the tsconfig mapping — so the server entry stays ordinary TypeScript source in the repository.
+Previously `main` pointed at whatever single-file bundle the SSR build step produced. That step is what this migration removes: `barefoot()` only compiles components, so there is no bundled server artifact to point at anymore. Wrangler bundles the existing entry file natively — resolving `@/components/*` to the compiled templates under `dist/components/` via the tsconfig mapping — so the server entry stays ordinary TypeScript source in the repository, at whatever path it already had.
 
 `assets.directory` must cover `build.outDir` from step 3 and must not include `templates` (see above).
 
@@ -362,6 +367,8 @@ app.use('*', renderer)
 app.get('/', (c) => c.render(<main><Counter /></main>, { title: 'My app' }))
 export default app
 ```
+
+`import { renderer } from './renderer'` assumes the `jsxRenderer` from step 5 lives in its own module, matching the scaffold's layout — if the existing project defines `jsxRenderer` inline in its entry file instead, there's no need to split it out; just apply step 5's edit to that file in place and skip this import.
 
 Existing plain Hono JSX components can stay where they are and be moved under `components/` one at a time; only files under a `components` directory are compiled.
 

--- a/docs/core/adapters/hono-adapter.md
+++ b/docs/core/adapters/hono-adapter.md
@@ -215,9 +215,24 @@ export default defineConfig({
 
 ## Adding to an Existing Project
 
-The scaffold (`npm create barefootjs@latest`) is one way to reach the layout described above; this section is the other — retrofitting an existing Hono + Cloudflare Workers app that already renders with `hono/jsx-renderer` and deploys with `wrangler deploy`. The end state is the same as the scaffold's, so a freshly scaffolded project is a valid reference to diff against once you're done.
+`npm create barefootjs@latest` scaffolds the layout above from scratch; this section retrofits it onto an existing Hono + Cloudflare Workers app that already renders with `hono/jsx-renderer` and deploys with `wrangler deploy`. The end state is the same as the scaffold's, so a freshly scaffolded project is a valid reference to diff against when something doesn't line up.
 
-The one structural change worth understanding up front: `barefoot()` compiles **individual components** — each `.tsx` under `components` becomes an SSR template under `templates` plus hydration JS under `build.outDir`. It does not bundle the server app into a single file. If the existing project pre-bundles its SSR entry with a whole-app Vite bundler (e.g. `@hono/vite-build`), that step is not replaced by a BarefootJS equivalent — it goes away, and wrangler's own esbuild bundling of the server entry takes over (step 4).
+### What changes
+
+`barefoot()` compiles **individual components** — each `.tsx` under `components` becomes an SSR template under `templates` plus hydration JS under `build.outDir`. It never bundles the server app into a single file. For a project that currently does that with a whole-app Vite bundler (e.g. `@hono/vite-build`), the consequence is:
+
+| | Before | After |
+|---|---|---|
+| Server build | Bundler plugin emits a single-file SSR bundle | Step removed; nothing replaces it |
+| `wrangler.jsonc` `main` | The pre-bundled output | The uncompiled entry file — wrangler's own esbuild bundles it at dev/deploy time |
+| `vite build` | Produces the server bundle | Produces compiled templates + hydration JS only |
+
+`barefoot()` takes the bundler plugin's place in `vite.config.ts`, and any `package.json` script or CI step that referenced the old bundle path goes with it.
+
+**Paths in this section are the scaffold's** (`components/`, `dist/components`, `public/components`, `server.tsx`, `renderer.tsx`). Substitute your own. Two that are easy to copy literally by mistake:
+
+- `wrangler.jsonc` `main` must be your app's actual Hono entry file (e.g. `src/index.tsx`). Copying `server.tsx` as-is fails immediately with `The entry-point file at "server.tsx" was not found`.
+- `import { renderer } from './renderer'` assumes `jsxRenderer` lives in its own module, as in the scaffold. If yours is defined inline in the entry file, edit it there and skip the import — there's no need to split it out.
 
 ### 1. Install
 
@@ -226,11 +241,11 @@ npm install @barefootjs/client @barefootjs/hono @barefootjs/jsx @barefootjs/shar
 npm install -D @barefootjs/vite
 ```
 
-These packages currently peer-depend on `vite ^6.0.0` and `typescript ^5.0.0`. If the existing project is already on a newer major of either, plain `npm install` fails with an `ERESOLVE` dependency-tree error — install with `--legacy-peer-deps`, or pin `typescript` down to `^5` (the `vite` peer range is the more conservative one in practice; a newer `vite` alone tends to work). A `typescript` major above `^5` is the one that actually matters at runtime: `vite build` can fail at config-load time with `TypeError: ts.createPrinter is not a function` (or similar) rather than a clear version error, because `@barefootjs/vite` calls into the `typescript` package's compiler API directly.
+> **Peer dependencies.** `@barefootjs/hono` peer-depends on `vite ^6.0.0` and `@barefootjs/jsx` on `typescript ^5.0.0`. A project already on a newer major of either (e.g. `vite@8`, `typescript@7`) fails `npm install` with an `ERESOLVE` error. Either install with `--legacy-peer-deps` or pin `typescript` to `^5`. The `typescript` range is the one that matters: a newer `vite` alone works in practice, but a newer `typescript` makes `vite build` crash at config-load time with `TypeError: ts.createPrinter is not a function` — an opaque runtime error, not a version check — because `@barefootjs/vite` calls the `typescript` package's compiler API directly.
 
-### 2. `tsconfig.json` — the `@/components/*` path mapping
+### 2. Config files
 
-Components are imported by the server through a path alias with **two** targets, compiled output first:
+#### `tsconfig.json`
 
 ```json
 {
@@ -246,16 +261,9 @@ Components are imported by the server through a path alias with **two** targets,
 }
 ```
 
-Both entries name the same logical component; TypeScript (and wrangler, which honors `paths`) tries them in order and takes the first that resolves:
+`@/components/*` has two targets, tried in order by both TypeScript and wrangler: the compiled SSR template under `dist/components/` (carrying the hydration markers from Output Format above) whenever it exists, otherwise the raw source under `components/` so editor tooling and type-checking resolve before the first build. Excluding `dist/components` keeps the compiled copy out of type-checking. Everything else already in `compilerOptions` (`types`, `strict`, …) stays as it is.
 
-- `./dist/components/*` — the compiled SSR template written by `barefoot()` (`templates`), carrying the hydration markers and script collection described in Output Format and Script Collection above. Listed first so the server picks it up whenever it exists.
-- `./components/*` — the raw source. Fallback so editor tooling and type-checking resolve imports before the first `vite build` / `vite dev` has produced anything.
-
-`dist/components` is excluded from `include` so the compiled templates aren't type-checked as a second copy of the source. Keep whatever else your existing `compilerOptions` already has (`types`, `strict`, …); only `jsx`, `jsxImportSource`, `baseUrl`, `paths`, and the `exclude` entry are BarefootJS-specific.
-
-### 3. `vite.config.ts` — the `barefoot()` plugin
-
-Three things matter for a retrofit: `components` (where the source lives), `templates` (a build output directory the server imports from through the mapping in step 2), and stock Vite config for the client-asset output. Everything else — bundling, hashing, chunking, minification, the dev server — is unmodified Vite.
+#### `vite.config.ts`
 
 ```ts
 // vite.config.ts
@@ -267,23 +275,20 @@ import { barefoot } from '@barefootjs/hono/vite'
 const HERE = dirname(fileURLToPath(import.meta.url))
 
 export default defineConfig({
-  // Public URL prefix of the client build; must match the path Workers
-  // Assets serves `build.outDir` under (see wrangler.jsonc in step 4).
+  // Public URL prefix of the client build. Must match the path Workers
+  // Assets serves `build.outDir` under (wrangler.jsonc below).
   base: '/components/',
   resolve: {
-    // Mirrors tsconfig's `@/components/*` mapping. Vite's dev-server
-    // dependency pre-scan parses raw source before this plugin's own
-    // `transform` hook runs and knows nothing about tsconfig `paths`,
-    // so the alias is required. Point it at the SOURCE tree, not at
-    // `dist/components`.
+    // Required, not optional: Vite's dev-server dependency pre-scan runs
+    // before this plugin's `transform` hook and ignores tsconfig `paths`.
+    // Points at the SOURCE tree, never at `dist/components`.
     alias: {
       '@/components': resolve(HERE, 'components'),
     },
   },
-  // `build.outDir` lives inside `public/`. With Vite's default
-  // `publicDir` the rest of `public/` (CSS, favicon, …) would be copied
-  // into `public/components` on every build for nothing — Workers
-  // Assets already serves `public/` as-is.
+  // `build.outDir` sits inside `public/`, which Workers Assets already
+  // serves as-is. Vite's default `publicDir` would copy the rest of
+  // `public/` into `public/components` on every build for nothing.
   publicDir: false,
   build: {
     outDir: 'public/components',   // hydration JS → served by Workers Assets
@@ -296,41 +301,29 @@ export default defineConfig({
 })
 ```
 
-`adapterOptions` (see Options above) is available but not needed for a basic setup. The `assets` / `assetsOutputFile` options exist for exposing hand-written non-component scripts' bundled URLs and are unrelated to a retrofit.
+Everything not shown (hashing, chunking, minification, dev server) is stock Vite. `adapterOptions`, `assets`, and `assetsOutputFile` (see Options above) are not needed for a retrofit.
 
-If the project already has a `vite.config.ts` for a whole-app SSR bundler, the `barefoot()` config generally replaces that plugin's entry rather than sitting next to it, since the single-file server build is no longer produced (step 4).
-
-### 4. `wrangler.jsonc` — point `main` at the uncompiled server entry
+#### `wrangler.jsonc`
 
 ```jsonc
 {
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "my-app",
-  // The uncompiled entry, not a pre-bundled SSR output. Wrangler's own
-  // esbuild-based bundler compiles it at dev/deploy time and follows
-  // the tsconfig `paths` mapping into dist/components/. `server.tsx`
-  // here is illustrative — point `main` at wherever your app's Hono
-  // entry file already lives (e.g. `src/index.tsx`); don't create a
-  // new file at this path.
+  // Your existing uncompiled Hono entry (see "Paths" above). Wrangler
+  // bundles it and follows the tsconfig `paths` mapping into dist/components/.
   "main": "server.tsx",
   "compatibility_date": "2025-01-01",
-  // Static assets (CSS, generated client JS, manifest) are served
-  // directly by Workers Assets. The Worker handles everything else.
+  // Must cover `build.outDir` from vite.config.ts and must not include
+  // `templates` — see Deploying to Cloudflare Workers above.
   "assets": {
     "directory": "./public"
   }
 }
 ```
 
-Previously `main` pointed at whatever single-file bundle the SSR build step produced. That step is what this migration removes: `barefoot()` only compiles components, so there is no bundled server artifact to point at anymore. Wrangler bundles the existing entry file natively — resolving `@/components/*` to the compiled templates under `dist/components/` via the tsconfig mapping — so the server entry stays ordinary TypeScript source in the repository, at whatever path it already had.
+### 3. Wire the app
 
-`assets.directory` must cover `build.outDir` from step 3 and must not include `templates` (see above).
-
-When removing the whole-app bundler, also check for any configuration it required elsewhere (its own build script, output paths referenced by `package.json` scripts or CI) so nothing keeps expecting the old bundle to exist.
-
-### 5. Render `<BfScripts />` once in the page shell
-
-`BfScripts` (from `@barefootjs/hono/scripts`) emits the `<script>` tags that load each compiled component's hydration JS exactly once per page, however many instances are rendered (see Script Collection above). It belongs once in the layout your existing `jsxRenderer` already defines, not inside individual components:
+**Render `<BfScripts />` once** (from `@barefootjs/hono/scripts`) in the layout your `jsxRenderer` already defines — not inside individual components. It emits the `<script>` tags loading each compiled component's hydration JS exactly once per page, however many instances are rendered (see Script Collection above). Existing `ContextRenderer` augmentation and stylesheet links stay as they are.
 
 ```tsx
 import { jsxRenderer } from 'hono/jsx-renderer'
@@ -350,11 +343,7 @@ export const renderer = jsxRenderer(({ children, title }) => (
 ))
 ```
 
-Any existing `ContextRenderer` module augmentation and stylesheet links stay as they are.
-
-### 6. Import components through the alias
-
-Server routes import compiled components via `@/components/*` rather than a relative path into the source tree, so the dist-first resolution from step 2 applies:
+**Import components through the alias**, not a relative path into the source tree, so the dist-first resolution from `tsconfig.json` applies:
 
 ```tsx
 // server.tsx
@@ -368,15 +357,13 @@ app.get('/', (c) => c.render(<main><Counter /></main>, { title: 'My app' }))
 export default app
 ```
 
-`import { renderer } from './renderer'` assumes the `jsxRenderer` from step 5 lives in its own module, matching the scaffold's layout — if the existing project defines `jsxRenderer` inline in its entry file instead, there's no need to split it out; just apply step 5's edit to that file in place and skip this import.
+Existing plain Hono JSX components can stay put and move under `components/` one at a time — only files under a configured `components` directory are compiled.
 
-Existing plain Hono JSX components can stay where they are and be moved under `components/` one at a time; only files under a `components` directory are compiled.
-
-### 7. Smoke test
+### 4. Build and verify
 
 ```sh
 npx vite build      # writes dist/components/ (templates) and public/components/ (hydration JS)
 npx wrangler dev    # or: npx wrangler deploy
 ```
 
-Then load a page that renders a converted `"use client"` component and confirm it hydrates — the rendered element carries a `bf` marker attribute (see Output Format above) and the component responds to interaction. During development, run `vite dev` alongside `wrangler dev` so `dist/components/` keeps regenerating on change.
+Load a page that renders a converted `"use client"` component: its element carries a `bf` marker attribute (see Output Format above) and it responds to interaction. During development, run `vite dev` alongside `wrangler dev` so `dist/components/` keeps regenerating on change.


### PR DESCRIPTION
## Summary

Follow-up to #2907, which added the "Adding to an Existing Project" section to `docs/core/adapters/hono-adapter.md`. This PR has two commits:

1. **Fix two gaps found by dry-run.** A subagent built a real plain-Hono-+-Cloudflare-Workers scaffold (using `hono/jsx-renderer` + `@hono/vite-build`, mirroring the scenario #2690 described) and followed the section's steps literally. Two real gaps surfaced:
   - **Install**: `@barefootjs/hono` peer-depends on `vite ^6.0.0` (`packages/adapter-hono/package.json`) and `@barefootjs/jsx` peer-depends on `typescript ^5.0.0` (`packages/jsx/package.json`), undocumented. A project on newer majors (verified with published `vite@8`, `typescript@7`) hits `ERESOLVE` on `npm install`, or a `vite build` config-load crash (`TypeError: ts.createPrinter is not a function`).
   - **`wrangler.jsonc` `main` / `./renderer` import**: the example filenames are the scaffold's own, copy-pasted literally causes wrangler to fail with `The entry-point file at "server.tsx" was not found`.
2. **Redesign for efficiency.** Once the facts above were verified, Fable rewrote the section from scratch rather than leaving the fixes as bolted-on paragraphs (the accretion pattern reviewers flagged as verbose). Same facts, stated once each: a before/after table for the "compiles components, not the whole app" structural change, a single callout collecting both dry-run filename gotchas instead of scattering them across steps, the peer-dependency note as a blockquote at the exact point (`npm install`) a reader would hit it, and 4 task-shaped headings (install → configure 3 files → wire the app → verify) instead of 7 numbered steps. Net: ~23% fewer words in the section (1293 → 990), no fact restated in both a code comment and the prose beneath it.

## Test plan

- [x] `bun test packages/jsx/src/__tests__/doc-examples.test.ts` — 224 pass, 0 fail (all `docs/core/**` `tsx` fences, including this file's — both `tsx` blocks kept byte-identical to the previously-verified ones — still compile).
- [x] Vale `Barefoot.Naming` check — no naming-variant issues.
- [x] Original end-to-end dry run (before the redesign pass): built a plain Hono + `@hono/vite-build` app from scratch, retrofitted it by literally following the (pre-fix) doc section, hit both issues above, confirmed the fixes resolve them, and confirmed the final `vite build` + `wrangler deploy --dry-run` + `wrangler dev` smoke test succeeds with correct hydration markers in the served HTML. The redesign pass changed only prose organization, not the underlying facts or code samples, so this verification still applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELEDYmsRrHZmoDcTk3CENC