### PR TITLE
Fix #2893: Go template adapter bakes a nested static .map() loop

### DIFF
--- a/.changeset/static-nested-loop-bake.md
+++ b/.changeset/static-nested-loop-bake.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/go-template": patch
+---
+
+The Go template adapter's static-array per-item unroll (`analyzeBakeableStaticElementLoop`, #2224) no longer refuses a `.map()` row that contains a nested `.map()` over a per-item array (e.g. `item.children.map(child => ...)`). The analysis now recurses into a nested static loop, accumulating each level's item binding so arbitrarily deep static nesting bakes — previously this shape fell through to a generic BF101 "computed loop array" refusal (#2893).

--- a/packages/adapter-erb/src/render-divergences.ts
+++ b/packages/adapter-erb/src/render-divergences.ts
@@ -15,4 +15,16 @@ import type { RenderDivergences } from '@barefootjs/jsx'
 // at value position and the runtime evaluator's `object-literal` case
 // now merges it, so the seed classifies `derived` and SSRs identically
 // to Hono.
-export const renderDivergences: RenderDivergences = {}
+export const renderDivergences: RenderDivergences = {
+  // #2922: the static-nested-loop bake reuses the SAME Ruby local variable
+  // name (`item`, the JS source's own param name) for both the outer and
+  // inner loop via plain assignment rather than a block parameter — Ruby
+  // assignment to a name already visible in an enclosing scope mutates
+  // that shared variable instead of shadowing it. On the inner loop's
+  // second-plus iteration, `item = item[:children][_i]` reads `item` as
+  // whatever the PREVIOUS inner iteration left it (a leaf child, no
+  // `:children` key), not the stable outer item — `nil[_i]` raises
+  // `NoMethodError`. Compiles clean (no diagnostic); crashes on render.
+  'static-nested-loop-shadowed-param':
+    'https://github.com/piconic-ai/barefootjs/issues/2922',
+}

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -6128,18 +6128,23 @@ export function List() {
     expect(result.errors?.some(e => e.code === 'BF101')).toBe(true)
   })
 
-  test('gate: a nested loop inside the body keeps the BF101 refusal', () => {
+  test('#2893: a nested loop inside the body bakes (recurses per outer item)', () => {
     const result = compileJSX(
       `
 export function List() {
   const items = [{ label: 'Alpha', tags: ['x', 'y'] }]
-  return <ul>{items.map(item => <li key={item.label}>{item.tags.map(t => <span>{t}</span>)}</li>)}</ul>
+  return <ul>{items.map(item => <li key={item.label}>{item.tags.map(t => <span key={t}>{t}</span>)}</li>)}</ul>
 }
 `,
       'test.tsx',
       { adapter: new GoTemplateAdapter() },
     )
-    expect(result.errors?.some(e => e.code === 'BF101')).toBe(true)
+    expect(result.errors ?? []).toEqual([])
+    const template = result.files.find(f => f.type === 'markedTemplate')!.content
+    expect(template).toContain('{{"x"}}')
+    expect(template).toContain('{{"y"}}')
+    // No `{{range}}` anywhere — both levels unroll to literal Go template text.
+    expect(template).not.toContain('{{range')
   })
 
   test('gate: a non-scalar item field (array/object) keeps the BF101 refusal', () => {

--- a/packages/adapter-go-template/src/adapter/analysis/static-element-loop-bake.ts
+++ b/packages/adapter-go-template/src/adapter/analysis/static-element-loop-bake.ts
@@ -38,9 +38,22 @@
  *     conditional (`bodyIsItemConditional`) — those need anchor-marker
  *     machinery this pass doesn't attempt to reproduce per item.
  *   - Every node anywhere in the body's IR tree is an `element`, `text`,
- *     `expression`, or `conditional` — a nested `loop`, `component`, `slot`,
- *     `fragment`, `if-statement`, `provider`, or `async` bails the WHOLE
- *     loop (no partial unroll; a loud refusal beats silently wrong output).
+ *     `expression`, `conditional`, or (#2893) a nested `loop` — a
+ *     `component`, `slot`, `fragment`, `if-statement`, `provider`, or
+ *     `async` bails the WHOLE loop (no partial unroll; a loud refusal beats
+ *     silently wrong output).
+ *   - A nested `loop` node (#2893, e.g. `item.children.map(child => ...)`)
+ *     is foldable only when it independently satisfies every one of THIS
+ *     module's own gates (`isBakeableLoopShape` — no child component, not
+ *     `.flatMap()`, plain non-destructured param, no index param, no
+ *     filter/sort, not multi-root/whole-item-conditional) AND its own body
+ *     is foldable by this same recursive walk. Its array need not be a
+ *     named const — `item.children` (a member read off the OUTER item) also
+ *     resolves, via `evaluateStaticLiteral` against the accumulating
+ *     outer→inner bindings map (`resolveBakedLoopSource`) rather than
+ *     `resolveStaticLoopSource`'s named-const-only path. Arbitrarily deep
+ *     nesting composes for free: each level's per-item pass adds its own
+ *     param to the SAME bindings map before recursing into the next.
  *   - A `conditional` node (#2898) is foldable only when both `whenTrue` and
  *     `whenFalse` are themselves nullish (a `null`/`undefined` expression
  *     branch, matching `renderConditional`'s own empty-branch test) or
@@ -118,41 +131,88 @@ type LoopShape = Pick<
   | 'objectIteration'
   | 'method'
   | 'flatMapCallback'
+  | 'clientOnly'
 >
+
+type BakeOpts = { isNameShadowed?: (name: string) => boolean; bindings?: ReadonlyMap<string, unknown> }
+
+const EMPTY_BINDINGS: ReadonlyMap<string, unknown> = new Map()
+
+/**
+ * The 9 shape gates every bakeable loop (outer or nested, #2893) must pass,
+ * independent of whether its own body/array happen to resolve. Split out
+ * from `analyzeBakeableStaticElementLoop` so a nested `loop` node can be
+ * gated the SAME way as the outer one, by the same code.
+ */
+function isBakeableLoopShape(loop: LoopShape): boolean {
+  if (loop.childComponent) return false // #2208's own path handles this shape.
+  // `.flatMap()`: an item can fold to 0+ elements, and a complex callback
+  // carries its body out-of-band (`flatMapCallback`, `children` left empty)
+  // rather than in `children` — either way this pass's per-item, single-
+  // element-tree model doesn't apply. Out of scope.
+  if (loop.method === 'flatMap' || loop.flatMapCallback) return false
+  if (!loop.param || /^[{[]/.test(loop.param)) return false
+  if (loop.index && loop.index !== '_') return false
+  if (loop.paramBindings && loop.paramBindings.length > 0) return false
+  if (loop.filterPredicate || loop.sortComparator) return false
+  if (loop.iterationShape || loop.objectIteration) return false
+  if (loop.bodyIsMultiRoot || loop.bodyIsItemConditional) return false
+  return true
+}
 
 /**
  * Analyze a `.map()` loop with a plain-element (non-component) body for
  * static unrolling. Returns the resolved item values (ready for the caller
  * to render the body once per item) or `null` when the shape isn't (yet)
  * bakeable this way — see the acceptance criteria in the module docstring.
+ * `opts.bindings` carries an already-baked OUTER item (#2893, recursing
+ * into a nested loop) — absent/empty at the top-level call.
  */
 export function analyzeBakeableStaticElementLoop(
   loop: LoopShape,
   localConstants: ReadonlyArray<ConstantInfo>,
-  opts?: { isNameShadowed?: (name: string) => boolean },
+  opts?: BakeOpts,
 ): BakedStaticElementLoop | null {
-  if (loop.childComponent) return null // #2208's own path handles this shape.
-  // `.flatMap()`: an item can fold to 0+ elements, and a complex callback
-  // carries its body out-of-band (`flatMapCallback`, `children` left empty)
-  // rather than in `children` — either way this pass's per-item, single-
-  // element-tree model doesn't apply. Out of scope.
-  if (loop.method === 'flatMap' || loop.flatMapCallback) return null
-  if (!loop.param || /^[{[]/.test(loop.param)) return null
-  if (loop.index && loop.index !== '_') return null
-  if (loop.paramBindings && loop.paramBindings.length > 0) return null
-  if (loop.filterPredicate || loop.sortComparator) return null
-  if (loop.iterationShape || loop.objectIteration) return null
-  if (loop.bodyIsMultiRoot || loop.bodyIsItemConditional) return null
+  if (!isBakeableLoopShape(loop)) return null
   if (!isFoldableTree(loop.children)) return null
 
-  const items = resolveStaticLoopSource(loop.arrayParsed, localConstants, opts)
+  const outerBindings = opts?.bindings ?? EMPTY_BINDINGS
+  const items = resolveBakedLoopSource(loop.arrayParsed, localConstants, outerBindings, opts)
   if (items === null) return null
 
   for (const item of items) {
-    const bindings = new Map<string, unknown>([[loop.param, item]])
-    if (!allExpressionsFoldFor(loop.children, bindings)) return null
+    const bindings = new Map(outerBindings)
+    bindings.set(loop.param, item)
+    if (!allExpressionsFoldFor(loop.children, bindings, localConstants, opts)) return null
   }
   return { items }
+}
+
+/**
+ * Resolve a loop's array source against the accumulated outer-item
+ * bindings (#2893). A bare identifier NOT already bound to an outer item
+ * (the top-level loop's own array, or an inner loop whose array happens to
+ * be a plain name) goes through `resolveStaticLoopSource`'s named
+ * function/module-scope-const resolution, unchanged from before. Anything
+ * else — a member/index-access read off a bound outer item
+ * (`item.children`), or any other foldable expression shape — resolves via
+ * `evaluateStaticLiteral` against the SAME bindings map the per-item fold
+ * check uses, so the two can never disagree about what an inner loop's
+ * array evaluates to.
+ */
+function resolveBakedLoopSource(
+  arrayParsed: ParsedExpr | undefined,
+  localConstants: ReadonlyArray<ConstantInfo>,
+  bindings: ReadonlyMap<string, unknown>,
+  opts?: { isNameShadowed?: (name: string) => boolean },
+): unknown[] | null {
+  if (!arrayParsed) return null
+  if (!(arrayParsed.kind === 'identifier' && bindings.has(arrayParsed.name))) {
+    const resolved = resolveStaticLoopSource(arrayParsed, localConstants, opts)
+    if (resolved !== null) return resolved
+  }
+  const evaluated = evaluateStaticLiteral(arrayParsed, bindings)
+  return Array.isArray(evaluated?.value) ? evaluated.value : null
 }
 
 /**
@@ -174,9 +234,17 @@ function isFoldableTree(nodes: readonly IRNode[]): boolean {
         if (node.clientOnly) continue // renderClientOnlyConditional: item-independent comment markers.
         if (!isFoldableBranch(node.whenTrue) || !isFoldableBranch(node.whenFalse)) return false
         continue
+      case 'loop':
+        // #2893: a nested loop's per-item resolvability (its array against
+        // the OUTER item, its own body against ITS item) is checked later in
+        // `allExpressionsFoldFor`, where the accumulating bindings map is
+        // available — here just the structural (item-independent) shape.
+        if (node.clientOnly) continue // client-deferred: item-independent, SSR renders nothing for it.
+        if (!isBakeableLoopShape(node) || !isFoldableTree(node.children)) return false
+        continue
       default:
-        // 'loop' | 'component' | 'slot' | 'fragment' | 'if-statement' |
-        // 'provider' | 'async' — none foldable per-item.
+        // 'component' | 'slot' | 'fragment' | 'if-statement' | 'provider' |
+        // 'async' — none foldable per-item.
         return false
     }
   }
@@ -213,7 +281,12 @@ function isFoldableAttrs(element: IRElement): boolean {
 }
 
 /** Per-item pass: every expression actually resolves to a bakeable scalar. */
-function allExpressionsFoldFor(nodes: readonly IRNode[], bindings: ReadonlyMap<string, unknown>): boolean {
+function allExpressionsFoldFor(
+  nodes: readonly IRNode[],
+  bindings: ReadonlyMap<string, unknown>,
+  localConstants: ReadonlyArray<ConstantInfo>,
+  opts?: BakeOpts,
+): boolean {
   for (const node of nodes) {
     if (node.type === 'expression') {
       if (node.clientOnly) continue // renders as an item-independent marker.
@@ -226,15 +299,25 @@ function allExpressionsFoldFor(nodes: readonly IRNode[], bindings: ReadonlyMap<s
         if (attr.value.kind !== 'expression') continue
         if (!attr.value.parsed || !resolvesToScalar(attr.value.parsed, bindings)) return false
       }
-      if (!allExpressionsFoldFor(node.children, bindings)) return false
+      if (!allExpressionsFoldFor(node.children, bindings, localConstants, opts)) return false
       continue
     }
     if (node.type === 'conditional') {
       if (node.clientOnly) continue // renderClientOnlyConditional: item-independent comment markers.
       const parsedCondition = node.parsedCondition ?? parseExpression(node.condition.trim())
       if (classifyBakedCondition(parsedCondition, bindings) === null) return false
-      const branchFolds = (branch: IRNode) => isNullishBranch(branch) || allExpressionsFoldFor([branch], bindings)
+      const branchFolds = (branch: IRNode) => isNullishBranch(branch) || allExpressionsFoldFor([branch], bindings, localConstants, opts)
       if (!branchFolds(node.whenTrue) || !branchFolds(node.whenFalse)) return false
+      continue
+    }
+    if (node.type === 'loop') {
+      // #2893: recurse the WHOLE analysis (shape gates + structural fold +
+      // per-item fold) for the nested loop, seeded with the bindings
+      // accumulated so far — `analyzeBakeableStaticElementLoop` adds its own
+      // param on top before checking ITS body, so a third level nests the
+      // same way a second one does.
+      if (node.clientOnly) continue
+      if (analyzeBakeableStaticElementLoop(node, localConstants, { ...opts, bindings }) === null) return false
       continue
     }
   }

--- a/packages/adapter-go-template/src/adapter/analysis/static-element-loop-bake.ts
+++ b/packages/adapter-go-template/src/adapter/analysis/static-element-loop-bake.ts
@@ -199,6 +199,13 @@ export function analyzeBakeableStaticElementLoop(
  * `evaluateStaticLiteral` against the SAME bindings map the per-item fold
  * check uses, so the two can never disagree about what an inner loop's
  * array evaluates to.
+ *
+ * The bound-name check reads `arrayParsed`'s free identifiers, not just a
+ * bare-identifier `arrayParsed` itself, so a shadowing loop param (an outer
+ * `const item = ...` shadowed by an inner `.map(item => ...)`) always
+ * resolves against the loop binding, never a same-named const — regardless
+ * of whether a future `resolveStaticLoopSource` learns to resolve member
+ * reads off consts.
  */
 function resolveBakedLoopSource(
   arrayParsed: ParsedExpr | undefined,
@@ -207,7 +214,9 @@ function resolveBakedLoopSource(
   opts?: { isNameShadowed?: (name: string) => boolean },
 ): unknown[] | null {
   if (!arrayParsed) return null
-  if (!(arrayParsed.kind === 'identifier' && bindings.has(arrayParsed.name))) {
+  const free = freeIdentifiers(arrayParsed)
+  const referencesBoundName = free !== null && [...free].some((name) => bindings.has(name))
+  if (!referencesBoundName) {
     const resolved = resolveStaticLoopSource(arrayParsed, localConstants, opts)
     if (resolved !== null) return resolved
   }
@@ -239,7 +248,15 @@ function isFoldableTree(nodes: readonly IRNode[]): boolean {
         // the OUTER item, its own body against ITS item) is checked later in
         // `allExpressionsFoldFor`, where the accumulating bindings map is
         // available — here just the structural (item-independent) shape.
-        if (node.clientOnly) continue // client-deferred: item-independent, SSR renders nothing for it.
+        //
+        // A clientOnly nested loop bails here (unlike the clientOnly
+        // conditional case above, whose `cond.slotId` markers are proven
+        // safe to repeat once per unrolled row): `renderLoop`'s clientOnly
+        // branch emits ONE `{{bfComment "loop:<markerId>"}}` pair per call
+        // site, and repeating that same markerId once per unrolled outer
+        // row is untested against the client's per-row insertion targeting
+        // — refuse loudly (#2918) rather than admit an unverified shape.
+        if (node.clientOnly) return false
         if (!isBakeableLoopShape(node) || !isFoldableTree(node.children)) return false
         continue
       default:
@@ -315,8 +332,8 @@ function allExpressionsFoldFor(
       // per-item fold) for the nested loop, seeded with the bindings
       // accumulated so far — `analyzeBakeableStaticElementLoop` adds its own
       // param on top before checking ITS body, so a third level nests the
-      // same way a second one does.
-      if (node.clientOnly) continue
+      // same way a second one does. A clientOnly nested loop never reaches
+      // here — `isFoldableTree`'s structural pass already bailed it.
       if (analyzeBakeableStaticElementLoop(node, localConstants, { ...opts, bindings }) === null) return false
       continue
     }

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -380,6 +380,22 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
   private staticLoopBakeFailed = false
 
   /**
+   * Fold `staticLoopItemStack` (outer→inner) into one bindings map — an
+   * inner row (#2893) needs to resolve BOTH its own item param AND any
+   * outer loop's, not just the innermost entry (`item.id` read from inside
+   * a nested `item.children.map(child => ...)` row). Later entries win on a
+   * name collision, matching normal JS shadowing (`items.map(item =>
+   * item.children.map(item => ...))`, however unlikely). The SAME map shape
+   * `analyzeBakeableStaticElementLoop`'s per-item fold check builds, so the
+   * two can never disagree about what a name resolves to.
+   */
+  private staticLoopBindings(): ReadonlyMap<string, unknown> {
+    const bindings = new Map<string, unknown>()
+    for (const entry of this.staticLoopItemStack) bindings.set(entry.param, entry.item)
+    return bindings
+  }
+
+  /**
    * Cross-component child shapes, keyed by child component name. Populated via
    * `registerChildComponentShape` before the parent's `generateTypes`, so the
    * static-child-init codegen can route an attribute that is NOT a declared
@@ -6528,9 +6544,8 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // passes disagreed and the safest move is a sentinel, not a `.Field`
     // reference with no range context behind it.
     if (this.staticLoopItemStack.length > 0) {
-      const top = this.staticLoopItemStack[this.staticLoopItemStack.length - 1]
       const parsedForBake = preParsed ?? parseExpression(trimmed)
-      const resolved = evaluateStaticLiteral(parsedForBake, new Map([[top.param, top.item]]))
+      const resolved = evaluateStaticLiteral(parsedForBake, this.staticLoopBindings())
       const literal = resolved !== null ? scalarToGoLiteral(resolved.value) : null
       if (literal !== null) {
         // Deliberately leave `out.parsed` unset — a `template-literal`-kind
@@ -7014,8 +7029,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // is the same pre-verified invariant `convertExpressionToGo`'s override
     // guards against, not a real path.
     if (this.staticLoopItemStack.length > 0) {
-      const top = this.staticLoopItemStack[this.staticLoopItemStack.length - 1]
-      const classified = classifyBakedCondition(parsed, new Map([[top.param, top.item]]))
+      const classified = classifyBakedCondition(parsed, this.staticLoopBindings())
       if (classified === null) {
         this.staticLoopBakeFailed = true
         return { condition: 'false', preamble: '' }
@@ -7564,7 +7578,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       : analyzeBakeableStaticElementLoop(
           loop,
           this.state.localConstants,
-          { isNameShadowed: this.scope.asShadowPredicate() },
+          { isNameShadowed: this.scope.asShadowPredicate(), bindings: this.staticLoopBindings() },
         )
     if (bakedElementLoop) {
       return this.renderUnrolledStaticElementLoop(loop, bakedElementLoop.items)

--- a/packages/adapter-go-template/src/conformance-pins.ts
+++ b/packages/adapter-go-template/src/conformance-pins.ts
@@ -101,37 +101,21 @@ export const conformancePins: ConformancePins = {
   // resolves the primitive normally and never reaches this refusal (formerly
   // tracked as #2771, closed) — no open issue tracks further work.
   'namespace-import-primitive': [{ code: 'BF013', severity: 'error' }],
-  // #2893: `analyzeBakeableStaticElementLoop`'s static-array bake (Go's only
-  // path to bind a static/non-signal array as a loop source — `html/template`
-  // has no slice literal syntax) bails the WHOLE loop when the body contains
-  // a nested `loop` node (module docstring, `static-element-loop-bake.ts`).
-  // This fixture's outer static array's row has a nested `.map()` over
-  // `item.children`, so it falls through to the generic "computed loop
-  // array" BF101 refusal. Unrelated to #2798's own fix (a client-JS-only
-  // ref/reactive-binding gap) — this is a pre-existing Go-adapter SSR
-  // static-loop-baking scope boundary the new fixture happened to be the
-  // first to exercise.
+  // #2893's nested-loop STRUCTURAL bail (the whole reason this fixture used
+  // to refuse — see #2893's own minimal `static-nested-loop-plain` fixture,
+  // which now compiles clean) is fixed: `analyzeBakeableStaticElementLoop`
+  // recurses into a nested `loop` node through the same analysis, resolving
+  // its array (`item.children`, a member read off the OUTER item) via
+  // `evaluateStaticLiteral` against the accumulated outer→inner bindings.
+  // This fixture still refuses for a DIFFERENT, narrower reason: its inner
+  // row also reads a signal (`count()`) in TEXT position, which
+  // `allExpressionsFoldFor`'s plain-`expression` case has no
+  // item-independent escape hatch for (unlike a `conditional`'s own
+  // condition, #2898's `classifyBakedCondition`) — tracked separately as
+  // #2909.
   'static-nested-loop-ref': [{
     code: 'BF101',
     severity: 'error',
-    issue: 'https://github.com/piconic-ai/barefootjs/issues/2893',
-  }],
-  // #2893 (successor to #2897): `analyzeBakeableStaticElementLoop`'s
-  // `isFoldableTree` bails the whole bake when the row contains a nested
-  // `loop` node — `static-nested-loop-conditional`'s OUTER row has a nested
-  // `.map()`, the SAME #2893 nested-loop trigger; its own row's conditional
-  // never gets a chance to matter, the nested loop alone already bails.
-  // Falls through to the generic "computed loop array" BF101 refusal.
-  // Unrelated to #2897's own fix (a client-JS-only reactive-wiring gap) —
-  // this is a pre-existing Go-adapter SSR static-loop-baking scope boundary
-  // the new fixture happened to be the first to exercise. (The sibling
-  // `static-loop-conditional` shape — a `conditional` with no nested loop —
-  // graduated in #2898: `isFoldableTree` now allows a `conditional` node
-  // whose branches fold and whose condition classifies as item-literal or
-  // item-independent.)
-  'static-nested-loop-conditional': [{
-    code: 'BF101',
-    severity: 'error',
-    issue: 'https://github.com/piconic-ai/barefootjs/issues/2893',
+    issue: 'https://github.com/piconic-ai/barefootjs/issues/2909',
   }],
 }

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -5515,50 +5515,6 @@
         "text"
       ]
     },
-    "static-loop-item-boolean-attr": {
-      "kinds": [
-        "array-literal",
-        "identifier",
-        "literal",
-        "member",
-        "object-literal"
-      ],
-      "axes": [
-        "literal:boolean",
-        "literal:number",
-        "literal:string"
-      ],
-      "contexts": [
-        "attribute",
-        "loop",
-        "text"
-      ]
-    },
-    "static-loop-item-boolean-attr-client": {
-      "kinds": [
-        "array-literal",
-        "identifier",
-        "member"
-      ],
-      "axes": [],
-      "contexts": [
-        "attribute",
-        "loop",
-        "text"
-      ]
-    },
-    "static-loop-item-boolean-attr-precomputed": {
-      "kinds": [
-        "identifier",
-        "member"
-      ],
-      "axes": [],
-      "contexts": [
-        "attribute",
-        "loop",
-        "text"
-      ]
-    },
     "static-loop-item-conditional": {
       "kinds": [
         "array-literal",
@@ -5666,6 +5622,40 @@
         "attribute",
         "condition",
         "loop"
+      ]
+    },
+    "static-nested-loop-depth2": {
+      "kinds": [
+        "array-literal",
+        "identifier",
+        "literal",
+        "member",
+        "object-literal"
+      ],
+      "axes": [
+        "literal:number"
+      ],
+      "contexts": [
+        "attribute",
+        "loop",
+        "text"
+      ]
+    },
+    "static-nested-loop-plain": {
+      "kinds": [
+        "array-literal",
+        "identifier",
+        "literal",
+        "member",
+        "object-literal"
+      ],
+      "axes": [
+        "literal:number"
+      ],
+      "contexts": [
+        "attribute",
+        "loop",
+        "text"
       ]
     },
     "static-nested-loop-ref": {
@@ -6559,12 +6549,12 @@
     "binary": 104,
     "call": 274,
     "conditional": 31,
-    "identifier": 383,
+    "identifier": 382,
     "index-access": 14,
-    "literal": 306,
+    "literal": 307,
     "logical": 49,
-    "member": 225,
-    "object-literal": 89,
+    "member": 224,
+    "object-literal": 90,
     "template-literal": 31,
     "unary": 29,
     "unsupported": 50
@@ -6605,10 +6595,10 @@
     "binary:===": 54,
     "binary:>": 11,
     "binary:>=": 1,
-    "literal:boolean": 69,
+    "literal:boolean": 68,
     "literal:null": 26,
-    "literal:number": 137,
-    "literal:string": 211,
+    "literal:number": 138,
+    "literal:string": 210,
     "logical:&&": 7,
     "logical:??": 41,
     "logical:||": 16,

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -5756,6 +5756,23 @@
         "text"
       ]
     },
+    "static-nested-loop-shadowed-param": {
+      "kinds": [
+        "array-literal",
+        "identifier",
+        "literal",
+        "member",
+        "object-literal"
+      ],
+      "axes": [
+        "literal:number"
+      ],
+      "contexts": [
+        "attribute",
+        "loop",
+        "text"
+      ]
+    },
     "string-concat-plus": {
       "kinds": [
         "binary",
@@ -6587,18 +6604,18 @@
     }
   },
   "kindCounts": {
-    "array-literal": 112,
+    "array-literal": 113,
     "array-method": 71,
     "arrow": 74,
     "binary": 104,
     "call": 274,
     "conditional": 31,
-    "identifier": 385,
+    "identifier": 386,
     "index-access": 14,
-    "literal": 308,
+    "literal": 309,
     "logical": 49,
-    "member": 227,
-    "object-literal": 91,
+    "member": 228,
+    "object-literal": 92,
     "template-literal": 31,
     "unary": 29,
     "unsupported": 50
@@ -6641,7 +6658,7 @@
     "binary:>=": 1,
     "literal:boolean": 69,
     "literal:null": 26,
-    "literal:number": 139,
+    "literal:number": 140,
     "literal:string": 211,
     "logical:&&": 7,
     "logical:??": 41,

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -5515,6 +5515,50 @@
         "text"
       ]
     },
+    "static-loop-item-boolean-attr": {
+      "kinds": [
+        "array-literal",
+        "identifier",
+        "literal",
+        "member",
+        "object-literal"
+      ],
+      "axes": [
+        "literal:boolean",
+        "literal:number",
+        "literal:string"
+      ],
+      "contexts": [
+        "attribute",
+        "loop",
+        "text"
+      ]
+    },
+    "static-loop-item-boolean-attr-client": {
+      "kinds": [
+        "array-literal",
+        "identifier",
+        "member"
+      ],
+      "axes": [],
+      "contexts": [
+        "attribute",
+        "loop",
+        "text"
+      ]
+    },
+    "static-loop-item-boolean-attr-precomputed": {
+      "kinds": [
+        "identifier",
+        "member"
+      ],
+      "axes": [],
+      "contexts": [
+        "attribute",
+        "loop",
+        "text"
+      ]
+    },
     "static-loop-item-conditional": {
       "kinds": [
         "array-literal",
@@ -6543,18 +6587,18 @@
     }
   },
   "kindCounts": {
-    "array-literal": 110,
+    "array-literal": 112,
     "array-method": 71,
     "arrow": 74,
     "binary": 104,
     "call": 274,
     "conditional": 31,
-    "identifier": 382,
+    "identifier": 385,
     "index-access": 14,
-    "literal": 307,
+    "literal": 308,
     "logical": 49,
-    "member": 224,
-    "object-literal": 90,
+    "member": 227,
+    "object-literal": 91,
     "template-literal": 31,
     "unary": 29,
     "unsupported": 50
@@ -6595,10 +6639,10 @@
     "binary:===": 54,
     "binary:>": 11,
     "binary:>=": 1,
-    "literal:boolean": 68,
+    "literal:boolean": 69,
     "literal:null": 26,
-    "literal:number": 138,
-    "literal:string": 210,
+    "literal:number": 139,
+    "literal:string": 211,
     "logical:&&": 7,
     "logical:??": 41,
     "logical:||": 16,

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -423,6 +423,8 @@ import { fixture as nestedLoopRefConst } from './nested-loop-ref-const'
 import { fixture as staticNestedLoopRef } from './static-nested-loop-ref'
 import { fixture as staticNestedLoopRefClient } from './static-nested-loop-ref-client'
 import { fixture as staticNestedLoopRefPrecomputed } from './static-nested-loop-ref-precomputed'
+import { fixture as staticNestedLoopPlain } from './static-nested-loop-plain'
+import { fixture as staticNestedLoopDepth2 } from './static-nested-loop-depth2'
 import { fixture as staticLoopConditional } from './static-loop-conditional'
 import { fixture as staticLoopConditionalPrecomputed } from './static-loop-conditional-precomputed'
 import { fixture as staticLoopConditionalClient } from './static-loop-conditional-client'
@@ -947,6 +949,8 @@ export const jsxFixtures: JSXFixture[] = [
   staticNestedLoopRef,
   staticNestedLoopRefClient,
   staticNestedLoopRefPrecomputed,
+  staticNestedLoopPlain,
+  staticNestedLoopDepth2,
   staticLoopConditional,
   staticLoopConditionalPrecomputed,
   staticLoopConditionalClient,

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -425,6 +425,7 @@ import { fixture as staticNestedLoopRefClient } from './static-nested-loop-ref-c
 import { fixture as staticNestedLoopRefPrecomputed } from './static-nested-loop-ref-precomputed'
 import { fixture as staticNestedLoopPlain } from './static-nested-loop-plain'
 import { fixture as staticNestedLoopDepth2 } from './static-nested-loop-depth2'
+import { fixture as staticNestedLoopShadowedParam } from './static-nested-loop-shadowed-param'
 import { fixture as staticLoopConditional } from './static-loop-conditional'
 import { fixture as staticLoopConditionalPrecomputed } from './static-loop-conditional-precomputed'
 import { fixture as staticLoopConditionalClient } from './static-loop-conditional-client'
@@ -951,6 +952,7 @@ export const jsxFixtures: JSXFixture[] = [
   staticNestedLoopRefPrecomputed,
   staticNestedLoopPlain,
   staticNestedLoopDepth2,
+  staticNestedLoopShadowedParam,
   staticLoopConditional,
   staticLoopConditionalPrecomputed,
   staticLoopConditionalClient,

--- a/packages/adapter-tests/fixtures/static-nested-loop-conditional-client.ts
+++ b/packages/adapter-tests/fixtures/static-nested-loop-conditional-client.ts
@@ -1,15 +1,16 @@
 import { createFixture } from '../src/types'
 
 /**
- * `/* @client *​/` twin of `static-nested-loop-conditional` (#2897 fix,
- * #2893 Go template refusal).
+ * `/* @client *​/` twin of `static-nested-loop-conditional` (#2897 fix).
  *
  * The marker defers the whole outer loop to client evaluation, so SSR
- * renders the empty `<ul>` on EVERY adapter and no BF101 may fire — same
- * suppression contract as `static-nested-loop-ref-client.ts`. Verifies the
- * Go template adapter's BF101 refusal (pinned in `conformance-pins.ts` for
- * the non-@client fixture, #2893) has a working escape, as its own
- * diagnostic suggestion claims.
+ * renders the empty `<ul>` on EVERY adapter — same suppression contract as
+ * `static-nested-loop-ref-client.ts`. Originally authored to verify the Go
+ * template adapter's BF101 refusal (then pinned to #2893) had a working
+ * escape; #2893 fixed the nested-loop structural bail so the NON-@client
+ * base fixture now compiles clean on Go too (no refusal left to escape) —
+ * kept as its own coverage of the `/* @client *​/` suppression contract on
+ * this nested-loop-plus-conditional shape.
  *
  * `rows` is an EMPTY literal array (unlike the non-@client twin's populated
  * one) — CSR conformance compares `expectedHtml` against the POST-HYDRATION

--- a/packages/adapter-tests/fixtures/static-nested-loop-conditional-precomputed.ts
+++ b/packages/adapter-tests/fixtures/static-nested-loop-conditional-precomputed.ts
@@ -1,26 +1,17 @@
 import { createFixture } from '../src/types'
 
 /**
- * `prop-precompute` twin of `static-nested-loop-conditional` (#2893) — the
- * SECOND escape kind the Go template BF101 diagnostic claims, alongside
- * `static-nested-loop-conditional-client`.
+ * `prop-precompute` twin of `static-nested-loop-conditional`.
  *
- * The base refuses on the Go template adapter because `rows` is a
- * component-scope LOCAL const — `analyzeBakeableStaticElementLoop`'s
- * static-loop bake can't unroll the nested inner `.map()` (the SAME #2893
- * trigger `static-nested-loop-ref` already pins; the inner row's own
- * conditional never even gets a chance to matter — a nested `loop` node
- * alone already bails `isFoldableTree`). That refusal keys specifically on
- * `this.state.localConstants` (`go-template-adapter.ts`), so it never
- * fires for a PROP at all — a prop binds as an ordinary Go struct field.
- * Moving the array to a prop escapes with full SSR.
- *
- * This does NOT fix #2893 — the compiler still cannot bake a nested inner
- * `.map()` inside a LOCAL static array's row on the Go template adapter.
- * What it proves is that the refusal's first-listed escape genuinely
- * works, full SSR included, for this fixture specifically (mirroring
- * `static-nested-loop-ref-precomputed`'s already-proven twin for the
- * ref/text/attr sibling shape).
+ * Originally authored (#2893, before its nested-loop structural bail was
+ * fixed) to prove that moving `rows` from a component-scope LOCAL const to
+ * a PROP escaped the then-refusal — `analyzeBakeableStaticElementLoop`'s
+ * refusal keyed specifically on `this.state.localConstants`
+ * (`go-template-adapter.ts`), so it never fired for a prop at all. #2893's
+ * fix means the NON-@client base fixture now compiles clean on Go too (no
+ * refusal left to escape) — kept as its own coverage of a prop-derived
+ * nested-loop-plus-conditional shape, mirroring
+ * `static-nested-loop-ref-precomputed`'s sibling twin.
  */
 export const fixture = createFixture({
   id: 'static-nested-loop-conditional-precomputed',

--- a/packages/adapter-tests/fixtures/static-nested-loop-conditional.ts
+++ b/packages/adapter-tests/fixtures/static-nested-loop-conditional.ts
@@ -42,15 +42,4 @@ export const spec: SharedFixtureSpec = {
   ],
 }
 
-export const fixture: JSXFixture = {
-  ...defineSharedFixture(spec),
-  // Go template adapter refuses this shape with BF101 (#2893 — the SAME
-  // nested-loop-present bail `static-nested-loop-ref` already pins; the
-  // inner row's own conditional never gets a chance to matter). The
-  // diagnostic's own suggestion names a prop-precompute/@client escape,
-  // verified by the twins below.
-  escapes: [
-    { kind: 'prop-precompute', fixture: 'static-nested-loop-conditional-precomputed' },
-    { kind: 'client-directive', fixture: 'static-nested-loop-conditional-client' },
-  ],
-}
+export const fixture: JSXFixture = defineSharedFixture(spec)

--- a/packages/adapter-tests/fixtures/static-nested-loop-depth2.ts
+++ b/packages/adapter-tests/fixtures/static-nested-loop-depth2.ts
@@ -1,0 +1,51 @@
+import { createFixture } from '../src/types'
+
+/**
+ * #2893's recursive design covers arbitrarily deep static nesting, not just
+ * one level — `analyzeBakeableStaticElementLoop` recurses into a nested
+ * `loop` node through the SAME function, accumulating each level's item
+ * binding into one map. This fixture exercises THREE static levels (the
+ * two-level `static-nested-loop-plain` fixture only proves depth 1), with
+ * the innermost row reading BOTH its own item AND the two outer items'
+ * fields — proving the merged-bindings change (`staticLoopBindings()` on
+ * the render side folding the whole `staticLoopItemStack`, not just its
+ * innermost entry).
+ */
+export const fixture = createFixture({
+  id: 'static-nested-loop-depth2',
+  description: 'three levels of static nested .map() bake on the Go template adapter, inner rows reading every enclosing item (#2893)',
+  source: `
+type Grandchild = { id: number }
+type Child = { id: number; grandchildren: Grandchild[] }
+type Item = { id: number; children: Child[] }
+
+export function StaticNestedLoopDepth2() {
+  const items: Item[] = [
+    {
+      id: 1,
+      children: [
+        { id: 11, grandchildren: [{ id: 111 }, { id: 112 }] },
+      ],
+    },
+  ]
+  return (
+    <ul>
+      {items.map(item => (
+        <li key={item.id}>
+          {item.children.map(child => (
+            <ul key={child.id}>
+              {child.grandchildren.map(gc => (
+                <li key={gc.id}>{item.id}-{child.id}-{gc.id}</li>
+              ))}
+            </ul>
+          ))}
+        </li>
+      ))}
+    </ul>
+  )
+}
+`,
+  expectedHtml: `
+    <ul bf-s="test" bf="s5"><li bf="s4" data-key="1"><ul bf="s3" data-key-1="11"><li data-key-2="111"><!--bf:s0-->1<!--/-->-<!--bf:s1-->11<!--/-->-<!--bf:s2-->111<!--/--></li><li data-key-2="112"><!--bf:s0-->1<!--/-->-<!--bf:s1-->11<!--/-->-<!--bf:s2-->112<!--/--></li></ul></li></ul>
+  `,
+})

--- a/packages/adapter-tests/fixtures/static-nested-loop-plain.ts
+++ b/packages/adapter-tests/fixtures/static-nested-loop-plain.ts
@@ -1,0 +1,53 @@
+import { createFixture } from '../src/types'
+
+/**
+ * #2893's own minimal repro: a static (non-signal) OUTER array whose row
+ * contains a nested `.map()` over a per-item array (`item.children`), with
+ * no other dynamic content in either row. `analyzeBakeableStaticElementLoop`
+ * used to bail the WHOLE outer loop the moment it saw a nested `loop` node
+ * anywhere in the body (module docstring's original acceptance criteria),
+ * falling through to the generic "computed loop array" BF101 refusal.
+ *
+ * Distinct from `static-nested-loop-ref` (#2798, this repo's other
+ * nested-static-loop fixture): that one ALSO reads a signal
+ * (`count()`) inside the inner row's text, which stays unresolvable by this
+ * bake (a signal/memo call in TEXT position has no item-independent escape
+ * hatch — unlike a `conditional`'s own condition, #2898 — so it still bails
+ * for a narrower, separate reason). This fixture isolates the nested-loop
+ * structural gate #2893 is actually about.
+ */
+export const fixture = createFixture({
+  id: 'static-nested-loop-plain',
+  description: 'a nested .map() over a per-item array inside a static outer loop bakes on the Go template adapter (#2893)',
+  source: `
+type Child = { id: number }
+type Item = { id: number; children: Child[] }
+
+export function StaticNestedLoopPlain() {
+  const items: Item[] = [
+    { id: 1, children: [{ id: 11 }, { id: 12 }] },
+    { id: 2, children: [{ id: 21 }] },
+  ]
+  return (
+    <ul>
+      {items.map(item => (
+        <li key={item.id}>
+          {item.children.map(child => (
+            <span key={child.id}>{child.id}</span>
+          ))}
+        </li>
+      ))}
+    </ul>
+  )
+}
+`,
+  expectedHtml: `
+    <ul bf-s="test" bf="s2">
+      <li bf="s1" data-key="1">
+        <span data-key-1="11"><!--bf:s0-->11<!--/--></span>
+        <span data-key-1="12"><!--bf:s0-->12<!--/--></span>
+      </li>
+      <li bf="s1" data-key="2"><span data-key-1="21"><!--bf:s0-->21<!--/--></span></li>
+    </ul>
+  `,
+})

--- a/packages/adapter-tests/fixtures/static-nested-loop-ref-client.ts
+++ b/packages/adapter-tests/fixtures/static-nested-loop-ref-client.ts
@@ -1,14 +1,16 @@
 import { createFixture } from '../src/types'
 
 /**
- * `/* @client *​/` twin of `static-nested-loop-ref` (#2798 fix, #2893 Go
- * template refusal).
+ * `/* @client *​/` twin of `static-nested-loop-ref` (#2798 fix, #2909 Go
+ * template refusal — originally pinned to #2893, whose nested-loop
+ * structural bail is now fixed; this fixture's OWN refusal cause is the
+ * narrower one #2909 tracks, a signal call in the inner row's text).
  *
  * The marker defers the whole outer loop to client evaluation, so SSR
  * renders the empty `<ul>` on EVERY adapter and no BF101 may fire — same
  * suppression contract as `filter-nested-callback-predicate-client.ts`.
  * Verifies the Go template adapter's BF101 refusal (pinned in
- * `conformance-pins.ts` for the non-@client fixture, #2893) has a working
+ * `conformance-pins.ts` for the non-@client fixture, #2909) has a working
  * escape, as its own diagnostic suggestion claims.
  *
  * `items` is an EMPTY literal array (unlike the non-@client twin's
@@ -22,7 +24,7 @@ import { createFixture } from '../src/types'
  */
 export const fixture = createFixture({
   id: 'static-nested-loop-ref-client',
-  description: 'static outer array + nested inner .map() + /* @client */ suppresses the Go template BF101 refusal (#2893)',
+  description: 'static outer array + nested inner .map() + /* @client */ suppresses the Go template BF101 refusal (#2909)',
   source: `
 'use client'
 import { createSignal } from '@barefootjs/client'

--- a/packages/adapter-tests/fixtures/static-nested-loop-ref-precomputed.ts
+++ b/packages/adapter-tests/fixtures/static-nested-loop-ref-precomputed.ts
@@ -1,28 +1,33 @@
 import { createFixture } from '../src/types'
 
 /**
- * `prop-precompute` twin of `static-nested-loop-ref` (#2893) — the SECOND
- * escape kind the Go template BF101 diagnostic claims, alongside
- * `static-nested-loop-ref-client`.
+ * `prop-precompute` twin of `static-nested-loop-ref` (#2909 — originally
+ * pinned to #2893, whose nested-loop structural bail is now fixed; the
+ * base fixture's OWN remaining refusal is the narrower #2909, a signal
+ * call in the inner row's text) — the SECOND escape kind the Go template
+ * BF101 diagnostic claims, alongside `static-nested-loop-ref-client`.
  *
- * The base refuses on the Go template adapter because `items` is a
- * component-scope LOCAL const — `analyzeBakeableStaticElementLoop`'s
- * static-loop bake can't unroll the nested inner `.map()`, and the
- * generic "local computed value" BF101 fallback fires. That refusal keys
- * specifically on `this.state.localConstants` (`go-template-adapter.ts`),
- * so it never fires for a PROP at all — a prop binds as an ordinary Go
- * struct field, same as `static-array-from-props-precomputed`'s twin.
+ * The base refuses on the Go template adapter because `count()` (a signal
+ * read in the inner row's text) has no item-independent bake path
+ * (`allExpressionsFoldFor`'s plain-`expression` case, unlike a
+ * `conditional`'s own condition — #2898's `classifyBakedCondition`). A prop
+ * doesn't change that — but this twin's array IS the loop source, and
+ * `analyzeBakeableStaticElementLoop`'s bake gate never even considers a
+ * prop-derived array (it keys off `this.state.localConstants`,
+ * `go-template-adapter.ts`) — a prop binds as an ordinary Go struct field
+ * and the loop renders via the adapter's normal `{{range}}` path instead,
+ * where `count()` resolves fine (real dot-context, no bake involved).
  * Moving the array to a prop escapes with full SSR (contrast with the
  * `-client` twin, which renders the loop host empty until hydration).
  *
- * This does NOT fix #2893 — the compiler still cannot bake a nested
- * inner `.map()` inside a LOCAL static array's row on the Go template
- * adapter. What it proves is that the refusal's first-listed escape
- * genuinely works, full SSR included.
+ * This does NOT fix #2909 — the compiler still cannot bake a signal read
+ * inside a nested LOCAL static array's row on the Go template adapter.
+ * What it proves is that the refusal's first-listed escape genuinely
+ * works, full SSR included.
  */
 export const fixture = createFixture({
   id: 'static-nested-loop-ref-precomputed',
-  description: 'prop-precompute twin of static-nested-loop-ref — items moved to a prop, full SSR (#2893)',
+  description: 'prop-precompute twin of static-nested-loop-ref — items moved to a prop, full SSR (#2909)',
   source: `
 'use client'
 import { createSignal } from '@barefootjs/client'

--- a/packages/adapter-tests/fixtures/static-nested-loop-ref.ts
+++ b/packages/adapter-tests/fixtures/static-nested-loop-ref.ts
@@ -53,9 +53,12 @@ export function StaticNestedLoopRef() {
   expectedHtml: `
     <ul bf-s="test" bf="s4"><li bf="s3" data-key="1"><span bf="s2" data-key-1="11"><!--bf:s0-->11<!--/-->:<!--bf:s1-->0<!--/--></span><span bf="s2" data-key-1="12"><!--bf:s0-->12<!--/-->:<!--bf:s1-->0<!--/--></span></li></ul>
   `,
-  // Go template adapter refuses this shape with BF101 (#2893 — its own
-  // static-loop-baking can't unroll a nested inner .map()); the diagnostic's
-  // own suggestion names a /* @client */ escape, verified by the twin below.
+  // Go template adapter refuses this shape with BF101 (#2909 — the inner
+  // row's `count()` signal read in TEXT position has no item-independent
+  // bake path; #2893's own nested-loop structural gate this fixture
+  // originally exercised is fixed — see `static-nested-loop-plain`). The
+  // diagnostic's own suggestion names a /* @client */ escape, verified by
+  // the twin below.
   escapes: [
     { kind: 'prop-precompute', fixture: 'static-nested-loop-ref-precomputed' },
     { kind: 'client-directive', fixture: 'static-nested-loop-ref-client' },

--- a/packages/adapter-tests/fixtures/static-nested-loop-shadowed-param.ts
+++ b/packages/adapter-tests/fixtures/static-nested-loop-shadowed-param.ts
@@ -1,0 +1,48 @@
+import { createFixture } from '../src/types'
+
+/**
+ * A nested `.map()` whose param NAME SHADOWS the outer loop's param
+ * (`items.map(item => item.children.map(item => ...))`) — the exact example
+ * `staticLoopBindings()`'s own docstring (`go-template-adapter.ts`) uses to
+ * justify "later entries win on a name collision", called out during #2893
+ * review as a documented claim with no fixture proving it. `id` is present
+ * on both the outer item and the inner item with DIFFERENT values, so a
+ * wrong-precedence bug (outer wins instead of inner) would still bake —
+ * just to the wrong, outer, id repeated across every child — rather than
+ * refuse loudly.
+ */
+export const fixture = createFixture({
+  id: 'static-nested-loop-shadowed-param',
+  description: 'a nested .map() whose param name shadows the outer loop param resolves to the INNER item, not the outer one (#2893)',
+  source: `
+type Child = { id: number }
+type Item = { id: number; children: Child[] }
+
+export function StaticNestedLoopShadowedParam() {
+  const items: Item[] = [
+    { id: 1, children: [{ id: 11 }, { id: 12 }] },
+    { id: 2, children: [{ id: 21 }] },
+  ]
+  return (
+    <ul>
+      {items.map(item => (
+        <li key={item.id}>
+          {item.children.map(item => (
+            <span key={item.id}>{item.id}</span>
+          ))}
+        </li>
+      ))}
+    </ul>
+  )
+}
+`,
+  expectedHtml: `
+    <ul bf-s="test" bf="s2">
+      <li bf="s1" data-key="1">
+        <span data-key-1="11"><!--bf:s0-->11<!--/--></span>
+        <span data-key-1="12"><!--bf:s0-->12<!--/--></span>
+      </li>
+      <li bf="s1" data-key="2"><span data-key-1="21"><!--bf:s0-->21<!--/--></span></li>
+    </ul>
+  `,
+})

--- a/packages/compat/src/__tests__/compat-engine.test.ts
+++ b/packages/compat/src/__tests__/compat-engine.test.ts
@@ -50,20 +50,21 @@ describe('compileForCompat', () => {
     // source), #2700 (a `derived` object-literal signal/memo the
     // constructor-time baker can't reproduce, `signal-object-spread-init`),
     // #2805 (a named jsx-children prop routed into a child's rest bag,
-    // `jsx-element-prop-rest-bag-dynamic`), and #2893 (a nested `.map()`
-    // inside a static outer array's row, `static-nested-loop-ref` AND
-    // `static-nested-loop-conditional` — the latter `unescapable`-pinned
-    // to the same issue rather than re-proving the identical escape)
+    // `jsx-element-prop-rest-bag-dynamic`), and #2909 (a signal/memo call
+    // read inside a nested static loop's row, `static-nested-loop-ref`)
     // surface here even though this test only exercises the
-    // nested-filter-callback shape. Four pins are no longer among them,
+    // nested-filter-callback shape. Five pins are no longer among them,
     // each because the shape got a real lowering rather than a narrower
     // refusal: #2319 (dangerous-inner-html-dynamic → a faithful raw-output
     // lowering), #2208 (static-array-children → the loop-source gate bakes
     // a fully-static array-of-objects const), #2448 (loop-row child prop
     // override feeding a derived field → the child rebuilds itself per row
-    // through `bf_reprops`), and #2898 (a conditional inside a static
-    // array's row with no nested loop → `isFoldableTree` now bakes it).
-    // See `go-template`'s `conformance-pins.ts`.
+    // through `bf_reprops`), #2898 (a conditional inside a static array's
+    // row with no nested loop → `isFoldableTree` now bakes it), and #2893
+    // (a nested `.map()`'s own structural bail → the bake now recurses into
+    // a nested loop; `static-nested-loop-conditional` graduated outright,
+    // `static-nested-loop-ref` still refuses but for the narrower #2909
+    // reason). See `go-template`'s `conformance-pins.ts`.
     expect(cell.diagnostics).toEqual([
       {
         code: 'BF101',
@@ -73,7 +74,7 @@ describe('compileForCompat', () => {
           'https://github.com/piconic-ai/barefootjs/issues/2321',
           'https://github.com/piconic-ai/barefootjs/issues/2700',
           'https://github.com/piconic-ai/barefootjs/issues/2805',
-          'https://github.com/piconic-ai/barefootjs/issues/2893',
+          'https://github.com/piconic-ai/barefootjs/issues/2909',
         ],
       },
     ])

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-conformance section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. This answers, per fixture and per adapter, whether the construct WORKS — not just whether it compiles. A construct works either as written (✓) or with a documented `/* @client */` comment (✓†, a verified, supported escape — most refusals have one). Fixtures absent from the table below work on every adapter — most as written, some via that documented escape; the headline says how many of each. Listed fixtures need attention somewhere: a bare diagnostic code is still-open debt with no escape yet, a code led by ✗ owes no escape at all (by design), and ≠ means the fixture compiles clean but its rendered output diverges from the reference.",
-    "totalFixtures": 407,
+    "totalFixtures": 408,
     "fixtures": {
       "date-method-uncatalogued": {
         "blade": {

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-conformance section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. This answers, per fixture and per adapter, whether the construct WORKS — not just whether it compiles. A construct works either as written (✓) or with a documented `/* @client */` comment (✓†, a verified, supported escape — most refusals have one). Fixtures absent from the table below work on every adapter — most as written, some via that documented escape; the headline says how many of each. Listed fixtures need attention somewhere: a bare diagnostic code is still-open debt with no escape yet, a code led by ✗ owes no escape at all (by design), and ≠ means the fixture compiles clean but its rendered output diverges from the reference.",
-    "totalFixtures": 405,
+    "totalFixtures": 404,
     "fixtures": {
       "date-method-uncatalogued": {
         "blade": {
@@ -3479,34 +3479,6 @@
           }
         }
       },
-      "static-loop-item-boolean-attr": {
-        "mojolicious": {
-          "kind": "refusal",
-          "codes": [
-            "BF101"
-          ],
-          "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2911"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "static-loop-item-boolean-attr-precomputed"
-          }
-        },
-        "xslate": {
-          "kind": "refusal",
-          "codes": [
-            "BF101"
-          ],
-          "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2911"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "static-loop-item-boolean-attr-precomputed"
-          }
-        }
-      },
       "static-loop-item-conditional": {
         "mojolicious": {
           "kind": "refusal",
@@ -3535,21 +3507,6 @@
           }
         }
       },
-      "static-nested-loop-conditional": {
-        "go-template": {
-          "kind": "refusal",
-          "codes": [
-            "BF101"
-          ],
-          "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2893"
-          ],
-          "escape": {
-            "state": "escapable",
-            "twin": "static-nested-loop-conditional-precomputed"
-          }
-        }
-      },
       "static-nested-loop-ref": {
         "go-template": {
           "kind": "refusal",
@@ -3557,7 +3514,7 @@
             "BF101"
           ],
           "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2893"
+            "https://github.com/piconic-ai/barefootjs/issues/2909"
           ],
           "escape": {
             "state": "escapable",
@@ -3737,17 +3694,9 @@
         "description": "Static-array loop with childComponent body materialises rendered children on CSR (#1268)",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-array-from-props-with-component.ts"
       },
-      "static-loop-item-boolean-attr": {
-        "description": "static array's .map() row boolean attribute keyed off the item itself renders per item (#2898)",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-loop-item-boolean-attr.ts"
-      },
       "static-loop-item-conditional": {
         "description": "static array's .map() row conditional keyed off the item itself bakes to a per-item Go literal…",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-loop-item-conditional.ts"
-      },
-      "static-nested-loop-conditional": {
-        "description": "a static outer array + depth-1 inner loop row conditional swaps live, not frozen at its SSR-time…",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-nested-loop-conditional.ts"
       },
       "static-nested-loop-ref": {
         "description": "a ref callback and a signal-derived text inside a nested .map() under a static (non-signal) outer…",
@@ -3813,20 +3762,12 @@
         "description": "prop-precompute twin of static-array-from-props-with-component — child components render at SSR…",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-array-from-props-with-component-precomputed.ts"
       },
-      "static-loop-item-boolean-attr-precomputed": {
-        "description": "prop-precompute twin of static-loop-item-boolean-attr — items moved to a prop, full SSR (#2898,…",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-loop-item-boolean-attr-precomputed.ts"
-      },
       "static-loop-item-conditional-precomputed": {
         "description": "prop-precompute twin of static-loop-item-conditional — items moved to a prop, full SSR (#2898,…",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-loop-item-conditional-precomputed.ts"
       },
-      "static-nested-loop-conditional-precomputed": {
-        "description": "prop-precompute twin of static-nested-loop-conditional — rows moved to a prop, full SSR (#2893)",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-nested-loop-conditional-precomputed.ts"
-      },
       "static-nested-loop-ref-precomputed": {
-        "description": "prop-precompute twin of static-nested-loop-ref — items moved to a prop, full SSR (#2893)",
+        "description": "prop-precompute twin of static-nested-loop-ref — items moved to a prop, full SSR (#2909)",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-nested-loop-ref-precomputed.ts"
       }
     }

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-conformance section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. This answers, per fixture and per adapter, whether the construct WORKS — not just whether it compiles. A construct works either as written (✓) or with a documented `/* @client */` comment (✓†, a verified, supported escape — most refusals have one). Fixtures absent from the table below work on every adapter — most as written, some via that documented escape; the headline says how many of each. Listed fixtures need attention somewhere: a bare diagnostic code is still-open debt with no escape yet, a code led by ✗ owes no escape at all (by design), and ≠ means the fixture compiles clean but its rendered output diverges from the reference.",
-    "totalFixtures": 404,
+    "totalFixtures": 407,
     "fixtures": {
       "date-method-uncatalogued": {
         "blade": {
@@ -3479,6 +3479,34 @@
           }
         }
       },
+      "static-loop-item-boolean-attr": {
+        "mojolicious": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2911"
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "static-loop-item-boolean-attr-precomputed"
+          }
+        },
+        "xslate": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2911"
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "static-loop-item-boolean-attr-precomputed"
+          }
+        }
+      },
       "static-loop-item-conditional": {
         "mojolicious": {
           "kind": "refusal",
@@ -3694,6 +3722,10 @@
         "description": "Static-array loop with childComponent body materialises rendered children on CSR (#1268)",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-array-from-props-with-component.ts"
       },
+      "static-loop-item-boolean-attr": {
+        "description": "static array's .map() row boolean attribute keyed off the item itself renders per item (#2898)",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-loop-item-boolean-attr.ts"
+      },
       "static-loop-item-conditional": {
         "description": "static array's .map() row conditional keyed off the item itself bakes to a per-item Go literal…",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-loop-item-conditional.ts"
@@ -3761,6 +3793,10 @@
       "static-array-from-props-with-component-precomputed": {
         "description": "prop-precompute twin of static-array-from-props-with-component — child components render at SSR…",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-array-from-props-with-component-precomputed.ts"
+      },
+      "static-loop-item-boolean-attr-precomputed": {
+        "description": "prop-precompute twin of static-loop-item-boolean-attr — items moved to a prop, full SSR (#2898,…",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-loop-item-boolean-attr-precomputed.ts"
       },
       "static-loop-item-conditional-precomputed": {
         "description": "prop-precompute twin of static-loop-item-conditional — items moved to a prop, full SSR (#2898,…",

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -3550,6 +3550,12 @@
           }
         }
       },
+      "static-nested-loop-shadowed-param": {
+        "erb": {
+          "kind": "render",
+          "reason": "https://github.com/piconic-ai/barefootjs/issues/2922"
+        }
+      },
       "tag-cloud": {
         "blade": {
           "kind": "refusal",
@@ -3733,6 +3739,10 @@
       "static-nested-loop-ref": {
         "description": "a ref callback and a signal-derived text inside a nested .map() under a static (non-signal) outer…",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-nested-loop-ref.ts"
+      },
+      "static-nested-loop-shadowed-param": {
+        "description": "a nested .map() whose param name shadows the outer loop param resolves to the INNER item, not the…",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-nested-loop-shadowed-param.ts"
       },
       "tag-cloud": {
         "description": "flatMap block-body tag list — hydration adoption, in-place leaf patch, add, and remove",

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -79,7 +79,7 @@
           ]
         },
         "erb": {
-          "pass": 102,
+          "pass": 101,
           "total": 113,
           "gaps": [
             {
@@ -122,6 +122,10 @@
             },
             {
               "fixture": "some-typeof-predicate",
+              "issues": []
+            },
+            {
+              "fixture": "static-nested-loop-shadowed-param",
               "issues": []
             },
             {
@@ -2375,7 +2379,7 @@
           ]
         },
         "erb": {
-          "pass": 367,
+          "pass": 366,
           "total": 386,
           "gaps": [
             {
@@ -2457,6 +2461,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
+            },
+            {
+              "fixture": "static-nested-loop-shadowed-param",
+              "issues": []
             },
             {
               "fixture": "tag-cloud",
@@ -3211,7 +3219,7 @@
           ]
         },
         "erb": {
-          "pass": 297,
+          "pass": 296,
           "total": 309,
           "gaps": [
             {
@@ -3259,6 +3267,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
+            },
+            {
+              "fixture": "static-nested-loop-shadowed-param",
+              "issues": []
             },
             {
               "fixture": "tag-cloud",
@@ -3921,7 +3933,7 @@
           ]
         },
         "erb": {
-          "pass": 210,
+          "pass": 209,
           "total": 228,
           "gaps": [
             {
@@ -3999,6 +4011,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
+            },
+            {
+              "fixture": "static-nested-loop-shadowed-param",
+              "issues": []
             },
             {
               "fixture": "tag-cloud",
@@ -4635,7 +4651,7 @@
           ]
         },
         "erb": {
-          "pass": 89,
+          "pass": 88,
           "total": 92,
           "gaps": [
             {
@@ -4647,6 +4663,10 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
+            },
+            {
+              "fixture": "static-nested-loop-shadowed-param",
+              "issues": []
             },
             {
               "fixture": "tag-cloud",
@@ -8158,7 +8178,7 @@
           ]
         },
         "erb": {
-          "pass": 135,
+          "pass": 134,
           "total": 140,
           "gaps": [
             {
@@ -8175,6 +8195,10 @@
             },
             {
               "fixture": "reduce-typeof-body",
+              "issues": []
+            },
+            {
+              "fixture": "static-nested-loop-shadowed-param",
               "issues": []
             },
             {

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -14,15 +14,15 @@
   ],
   "kinds": {
     "array-literal": {
-      "total": 112,
+      "total": 113,
       "cells": {
         "hono": {
-          "pass": 112,
-          "total": 112
+          "pass": 113,
+          "total": 113
         },
         "blade": {
-          "pass": 100,
-          "total": 112,
+          "pass": 101,
+          "total": 113,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -79,8 +79,8 @@
           ]
         },
         "erb": {
-          "pass": 101,
-          "total": 112,
+          "pass": 102,
+          "total": 113,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -131,8 +131,8 @@
           ]
         },
         "go-template": {
-          "pass": 99,
-          "total": 112,
+          "pass": 100,
+          "total": 113,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -195,8 +195,8 @@
           ]
         },
         "jinja": {
-          "pass": 100,
-          "total": 112,
+          "pass": 101,
+          "total": 113,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -253,8 +253,8 @@
           ]
         },
         "minijinja": {
-          "pass": 100,
-          "total": 112,
+          "pass": 101,
+          "total": 113,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -311,8 +311,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 99,
-          "total": 112,
+          "pass": 100,
+          "total": 113,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -375,8 +375,8 @@
           ]
         },
         "twig": {
-          "pass": 100,
-          "total": 112,
+          "pass": 101,
+          "total": 113,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -433,8 +433,8 @@
           ]
         },
         "xslate": {
-          "pass": 98,
-          "total": 112,
+          "pass": 99,
+          "total": 113,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -2252,11 +2252,11 @@
       }
     },
     "identifier": {
-      "total": 385,
+      "total": 386,
       "cells": {
         "hono": {
-          "pass": 381,
-          "total": 385,
+          "pass": 382,
+          "total": 386,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2279,8 +2279,8 @@
           ]
         },
         "blade": {
-          "pass": 365,
-          "total": 385,
+          "pass": 366,
+          "total": 386,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2375,8 +2375,8 @@
           ]
         },
         "erb": {
-          "pass": 366,
-          "total": 385,
+          "pass": 367,
+          "total": 386,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2465,8 +2465,8 @@
           ]
         },
         "go-template": {
-          "pass": 362,
-          "total": 385,
+          "pass": 363,
+          "total": 386,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2579,8 +2579,8 @@
           ]
         },
         "jinja": {
-          "pass": 365,
-          "total": 385,
+          "pass": 366,
+          "total": 386,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2675,8 +2675,8 @@
           ]
         },
         "minijinja": {
-          "pass": 365,
-          "total": 385,
+          "pass": 366,
+          "total": 386,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2771,8 +2771,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 364,
-          "total": 385,
+          "pass": 365,
+          "total": 386,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2873,8 +2873,8 @@
           ]
         },
         "twig": {
-          "pass": 365,
-          "total": 385,
+          "pass": 366,
+          "total": 386,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2969,8 +2969,8 @@
           ]
         },
         "xslate": {
-          "pass": 363,
-          "total": 385,
+          "pass": 364,
+          "total": 386,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3142,11 +3142,11 @@
       }
     },
     "literal": {
-      "total": 308,
+      "total": 309,
       "cells": {
         "hono": {
-          "pass": 307,
-          "total": 308,
+          "pass": 308,
+          "total": 309,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -3155,8 +3155,8 @@
           ]
         },
         "blade": {
-          "pass": 296,
-          "total": 308,
+          "pass": 297,
+          "total": 309,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3211,8 +3211,8 @@
           ]
         },
         "erb": {
-          "pass": 296,
-          "total": 308,
+          "pass": 297,
+          "total": 309,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3267,8 +3267,8 @@
           ]
         },
         "go-template": {
-          "pass": 293,
-          "total": 308,
+          "pass": 294,
+          "total": 309,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3341,8 +3341,8 @@
           ]
         },
         "jinja": {
-          "pass": 296,
-          "total": 308,
+          "pass": 297,
+          "total": 309,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3397,8 +3397,8 @@
           ]
         },
         "minijinja": {
-          "pass": 296,
-          "total": 308,
+          "pass": 297,
+          "total": 309,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3453,8 +3453,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 294,
-          "total": 308,
+          "pass": 295,
+          "total": 309,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3521,8 +3521,8 @@
           ]
         },
         "twig": {
-          "pass": 296,
-          "total": 308,
+          "pass": 297,
+          "total": 309,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3577,8 +3577,8 @@
           ]
         },
         "xslate": {
-          "pass": 294,
-          "total": 308,
+          "pass": 295,
+          "total": 309,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3806,11 +3806,11 @@
       }
     },
     "member": {
-      "total": 227,
+      "total": 228,
       "cells": {
         "hono": {
-          "pass": 224,
-          "total": 227,
+          "pass": 225,
+          "total": 228,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3829,8 +3829,8 @@
           ]
         },
         "blade": {
-          "pass": 208,
-          "total": 227,
+          "pass": 209,
+          "total": 228,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3921,8 +3921,8 @@
           ]
         },
         "erb": {
-          "pass": 209,
-          "total": 227,
+          "pass": 210,
+          "total": 228,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4007,8 +4007,8 @@
           ]
         },
         "go-template": {
-          "pass": 205,
-          "total": 227,
+          "pass": 206,
+          "total": 228,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4117,8 +4117,8 @@
           ]
         },
         "jinja": {
-          "pass": 208,
-          "total": 227,
+          "pass": 209,
+          "total": 228,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4209,8 +4209,8 @@
           ]
         },
         "minijinja": {
-          "pass": 208,
-          "total": 227,
+          "pass": 209,
+          "total": 228,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4301,8 +4301,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 207,
-          "total": 227,
+          "pass": 208,
+          "total": 228,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4399,8 +4399,8 @@
           ]
         },
         "twig": {
-          "pass": 208,
-          "total": 227,
+          "pass": 209,
+          "total": 228,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4491,8 +4491,8 @@
           ]
         },
         "xslate": {
-          "pass": 206,
-          "total": 227,
+          "pass": 207,
+          "total": 228,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4608,15 +4608,15 @@
       }
     },
     "object-literal": {
-      "total": 91,
+      "total": 92,
       "cells": {
         "hono": {
-          "pass": 91,
-          "total": 91
+          "pass": 92,
+          "total": 92
         },
         "blade": {
-          "pass": 88,
-          "total": 91,
+          "pass": 89,
+          "total": 92,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4635,8 +4635,8 @@
           ]
         },
         "erb": {
-          "pass": 88,
-          "total": 91,
+          "pass": 89,
+          "total": 92,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4655,8 +4655,8 @@
           ]
         },
         "go-template": {
-          "pass": 86,
-          "total": 91,
+          "pass": 87,
+          "total": 92,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4687,8 +4687,8 @@
           ]
         },
         "jinja": {
-          "pass": 88,
-          "total": 91,
+          "pass": 89,
+          "total": 92,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4707,8 +4707,8 @@
           ]
         },
         "minijinja": {
-          "pass": 88,
-          "total": 91,
+          "pass": 89,
+          "total": 92,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4727,8 +4727,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 86,
-          "total": 91,
+          "pass": 87,
+          "total": 92,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4759,8 +4759,8 @@
           ]
         },
         "twig": {
-          "pass": 88,
-          "total": 91,
+          "pass": 89,
+          "total": 92,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4779,8 +4779,8 @@
           ]
         },
         "xslate": {
-          "pass": 86,
-          "total": 91,
+          "pass": 87,
+          "total": 92,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -8125,15 +8125,15 @@
       }
     },
     "literal:number": {
-      "total": 139,
+      "total": 140,
       "cells": {
         "hono": {
-          "pass": 139,
-          "total": 139
+          "pass": 140,
+          "total": 140
         },
         "blade": {
-          "pass": 134,
-          "total": 139,
+          "pass": 135,
+          "total": 140,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8158,8 +8158,8 @@
           ]
         },
         "erb": {
-          "pass": 134,
-          "total": 139,
+          "pass": 135,
+          "total": 140,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8184,8 +8184,8 @@
           ]
         },
         "go-template": {
-          "pass": 133,
-          "total": 139,
+          "pass": 134,
+          "total": 140,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8216,8 +8216,8 @@
           ]
         },
         "jinja": {
-          "pass": 134,
-          "total": 139,
+          "pass": 135,
+          "total": 140,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8242,8 +8242,8 @@
           ]
         },
         "minijinja": {
-          "pass": 134,
-          "total": 139,
+          "pass": 135,
+          "total": 140,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8268,8 +8268,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 132,
-          "total": 139,
+          "pass": 133,
+          "total": 140,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8306,8 +8306,8 @@
           ]
         },
         "twig": {
-          "pass": 134,
-          "total": 139,
+          "pass": 135,
+          "total": 140,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8332,8 +8332,8 @@
           ]
         },
         "xslate": {
-          "pass": 132,
-          "total": 139,
+          "pass": 133,
+          "total": 140,
           "gaps": [
             {
               "fixture": "fill-unsupported",

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -14,15 +14,15 @@
   ],
   "kinds": {
     "array-literal": {
-      "total": 110,
+      "total": 112,
       "cells": {
         "hono": {
-          "pass": 110,
-          "total": 110
+          "pass": 112,
+          "total": 112
         },
         "blade": {
-          "pass": 98,
-          "total": 110,
+          "pass": 100,
+          "total": 112,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -79,8 +79,8 @@
           ]
         },
         "erb": {
-          "pass": 99,
-          "total": 110,
+          "pass": 101,
+          "total": 112,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -131,8 +131,8 @@
           ]
         },
         "go-template": {
-          "pass": 97,
-          "total": 110,
+          "pass": 99,
+          "total": 112,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -195,8 +195,8 @@
           ]
         },
         "jinja": {
-          "pass": 98,
-          "total": 110,
+          "pass": 100,
+          "total": 112,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -253,8 +253,8 @@
           ]
         },
         "minijinja": {
-          "pass": 98,
-          "total": 110,
+          "pass": 100,
+          "total": 112,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -311,8 +311,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 98,
-          "total": 110,
+          "pass": 99,
+          "total": 112,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -357,6 +357,12 @@
               "issues": []
             },
             {
+              "fixture": "static-loop-item-boolean-attr",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2911"
+              ]
+            },
+            {
               "fixture": "static-loop-item-conditional",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2911"
@@ -369,8 +375,8 @@
           ]
         },
         "twig": {
-          "pass": 98,
-          "total": 110,
+          "pass": 100,
+          "total": 112,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -427,8 +433,8 @@
           ]
         },
         "xslate": {
-          "pass": 97,
-          "total": 110,
+          "pass": 98,
+          "total": 112,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -477,6 +483,12 @@
             {
               "fixture": "some-typeof-predicate",
               "issues": []
+            },
+            {
+              "fixture": "static-loop-item-boolean-attr",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2911"
+              ]
             },
             {
               "fixture": "static-loop-item-conditional",
@@ -2240,11 +2252,11 @@
       }
     },
     "identifier": {
-      "total": 382,
+      "total": 385,
       "cells": {
         "hono": {
-          "pass": 378,
-          "total": 382,
+          "pass": 381,
+          "total": 385,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2267,8 +2279,8 @@
           ]
         },
         "blade": {
-          "pass": 362,
-          "total": 382,
+          "pass": 365,
+          "total": 385,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2363,8 +2375,8 @@
           ]
         },
         "erb": {
-          "pass": 363,
-          "total": 382,
+          "pass": 366,
+          "total": 385,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2453,8 +2465,8 @@
           ]
         },
         "go-template": {
-          "pass": 359,
-          "total": 382,
+          "pass": 362,
+          "total": 385,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2567,8 +2579,8 @@
           ]
         },
         "jinja": {
-          "pass": 362,
-          "total": 382,
+          "pass": 365,
+          "total": 385,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2663,8 +2675,8 @@
           ]
         },
         "minijinja": {
-          "pass": 362,
-          "total": 382,
+          "pass": 365,
+          "total": 385,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2759,8 +2771,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 362,
-          "total": 382,
+          "pass": 364,
+          "total": 385,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2843,6 +2855,12 @@
               ]
             },
             {
+              "fixture": "static-loop-item-boolean-attr",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2911"
+              ]
+            },
+            {
               "fixture": "static-loop-item-conditional",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2911"
@@ -2855,8 +2873,8 @@
           ]
         },
         "twig": {
-          "pass": 362,
-          "total": 382,
+          "pass": 365,
+          "total": 385,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2951,8 +2969,8 @@
           ]
         },
         "xslate": {
-          "pass": 361,
-          "total": 382,
+          "pass": 363,
+          "total": 385,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3038,6 +3056,12 @@
               "fixture": "static-array-from-props-with-component",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
+            },
+            {
+              "fixture": "static-loop-item-boolean-attr",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2911"
               ]
             },
             {
@@ -3118,11 +3142,11 @@
       }
     },
     "literal": {
-      "total": 307,
+      "total": 308,
       "cells": {
         "hono": {
-          "pass": 306,
-          "total": 307,
+          "pass": 307,
+          "total": 308,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -3131,8 +3155,8 @@
           ]
         },
         "blade": {
-          "pass": 295,
-          "total": 307,
+          "pass": 296,
+          "total": 308,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3187,8 +3211,8 @@
           ]
         },
         "erb": {
-          "pass": 295,
-          "total": 307,
+          "pass": 296,
+          "total": 308,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3243,8 +3267,8 @@
           ]
         },
         "go-template": {
-          "pass": 292,
-          "total": 307,
+          "pass": 293,
+          "total": 308,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3317,8 +3341,8 @@
           ]
         },
         "jinja": {
-          "pass": 295,
-          "total": 307,
+          "pass": 296,
+          "total": 308,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3373,8 +3397,8 @@
           ]
         },
         "minijinja": {
-          "pass": 295,
-          "total": 307,
+          "pass": 296,
+          "total": 308,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3430,7 +3454,7 @@
         },
         "mojolicious": {
           "pass": 294,
-          "total": 307,
+          "total": 308,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3479,6 +3503,12 @@
               ]
             },
             {
+              "fixture": "static-loop-item-boolean-attr",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2911"
+              ]
+            },
+            {
               "fixture": "static-loop-item-conditional",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2911"
@@ -3491,8 +3521,8 @@
           ]
         },
         "twig": {
-          "pass": 295,
-          "total": 307,
+          "pass": 296,
+          "total": 308,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3548,7 +3578,7 @@
         },
         "xslate": {
           "pass": 294,
-          "total": 307,
+          "total": 308,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3594,6 +3624,12 @@
               "fixture": "static-array-from-props-with-component",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
+            },
+            {
+              "fixture": "static-loop-item-boolean-attr",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2911"
               ]
             },
             {
@@ -3770,11 +3806,11 @@
       }
     },
     "member": {
-      "total": 224,
+      "total": 227,
       "cells": {
         "hono": {
-          "pass": 221,
-          "total": 224,
+          "pass": 224,
+          "total": 227,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3793,8 +3829,8 @@
           ]
         },
         "blade": {
-          "pass": 205,
-          "total": 224,
+          "pass": 208,
+          "total": 227,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3885,8 +3921,8 @@
           ]
         },
         "erb": {
-          "pass": 206,
-          "total": 224,
+          "pass": 209,
+          "total": 227,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3971,8 +4007,8 @@
           ]
         },
         "go-template": {
-          "pass": 202,
-          "total": 224,
+          "pass": 205,
+          "total": 227,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4081,8 +4117,8 @@
           ]
         },
         "jinja": {
-          "pass": 205,
-          "total": 224,
+          "pass": 208,
+          "total": 227,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4173,8 +4209,8 @@
           ]
         },
         "minijinja": {
-          "pass": 205,
-          "total": 224,
+          "pass": 208,
+          "total": 227,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4265,8 +4301,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 205,
-          "total": 224,
+          "pass": 207,
+          "total": 227,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4345,6 +4381,12 @@
               ]
             },
             {
+              "fixture": "static-loop-item-boolean-attr",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2911"
+              ]
+            },
+            {
               "fixture": "static-loop-item-conditional",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2911"
@@ -4357,8 +4399,8 @@
           ]
         },
         "twig": {
-          "pass": 205,
-          "total": 224,
+          "pass": 208,
+          "total": 227,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4449,8 +4491,8 @@
           ]
         },
         "xslate": {
-          "pass": 204,
-          "total": 224,
+          "pass": 206,
+          "total": 227,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4535,6 +4577,12 @@
               ]
             },
             {
+              "fixture": "static-loop-item-boolean-attr",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2911"
+              ]
+            },
+            {
               "fixture": "static-loop-item-conditional",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2911"
@@ -4560,15 +4608,15 @@
       }
     },
     "object-literal": {
-      "total": 90,
+      "total": 91,
       "cells": {
         "hono": {
-          "pass": 90,
-          "total": 90
+          "pass": 91,
+          "total": 91
         },
         "blade": {
-          "pass": 87,
-          "total": 90,
+          "pass": 88,
+          "total": 91,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4587,8 +4635,8 @@
           ]
         },
         "erb": {
-          "pass": 87,
-          "total": 90,
+          "pass": 88,
+          "total": 91,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4607,8 +4655,8 @@
           ]
         },
         "go-template": {
-          "pass": 85,
-          "total": 90,
+          "pass": 86,
+          "total": 91,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4639,8 +4687,8 @@
           ]
         },
         "jinja": {
-          "pass": 87,
-          "total": 90,
+          "pass": 88,
+          "total": 91,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4659,8 +4707,8 @@
           ]
         },
         "minijinja": {
-          "pass": 87,
-          "total": 90,
+          "pass": 88,
+          "total": 91,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4680,7 +4728,7 @@
         },
         "mojolicious": {
           "pass": 86,
-          "total": 90,
+          "total": 91,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4690,6 +4738,12 @@
               "fixture": "static-array-from-props",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
+            },
+            {
+              "fixture": "static-loop-item-boolean-attr",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2911"
               ]
             },
             {
@@ -4705,8 +4759,8 @@
           ]
         },
         "twig": {
-          "pass": 87,
-          "total": 90,
+          "pass": 88,
+          "total": 91,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4726,7 +4780,7 @@
         },
         "xslate": {
           "pass": 86,
-          "total": 90,
+          "total": 91,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4736,6 +4790,12 @@
               "fixture": "static-array-from-props",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
+            },
+            {
+              "fixture": "static-loop-item-boolean-attr",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2911"
               ]
             },
             {
@@ -7824,11 +7884,11 @@
       }
     },
     "literal:boolean": {
-      "total": 68,
+      "total": 69,
       "cells": {
         "hono": {
-          "pass": 67,
-          "total": 68,
+          "pass": 68,
+          "total": 69,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -7837,8 +7897,8 @@
           ]
         },
         "blade": {
-          "pass": 66,
-          "total": 68,
+          "pass": 67,
+          "total": 69,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -7851,8 +7911,8 @@
           ]
         },
         "erb": {
-          "pass": 66,
-          "total": 68,
+          "pass": 67,
+          "total": 69,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -7865,8 +7925,8 @@
           ]
         },
         "go-template": {
-          "pass": 64,
-          "total": 68,
+          "pass": 65,
+          "total": 69,
           "gaps": [
             {
               "fixture": "jsx-element-prop-rest-bag-dynamic",
@@ -7891,8 +7951,8 @@
           ]
         },
         "jinja": {
-          "pass": 66,
-          "total": 68,
+          "pass": 67,
+          "total": 69,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -7905,8 +7965,8 @@
           ]
         },
         "minijinja": {
-          "pass": 66,
-          "total": 68,
+          "pass": 67,
+          "total": 69,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -7920,7 +7980,7 @@
         },
         "mojolicious": {
           "pass": 65,
-          "total": 68,
+          "total": 69,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -7931,6 +7991,12 @@
               "issues": []
             },
             {
+              "fixture": "static-loop-item-boolean-attr",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2911"
+              ]
+            },
+            {
               "fixture": "static-loop-item-conditional",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2911"
@@ -7939,8 +8005,8 @@
           ]
         },
         "twig": {
-          "pass": 66,
-          "total": 68,
+          "pass": 67,
+          "total": 69,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -7954,7 +8020,7 @@
         },
         "xslate": {
           "pass": 65,
-          "total": 68,
+          "total": 69,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -7963,6 +8029,12 @@
             {
               "fixture": "preamble-cells",
               "issues": []
+            },
+            {
+              "fixture": "static-loop-item-boolean-attr",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2911"
+              ]
             },
             {
               "fixture": "static-loop-item-conditional",
@@ -8053,15 +8125,15 @@
       }
     },
     "literal:number": {
-      "total": 138,
+      "total": 139,
       "cells": {
         "hono": {
-          "pass": 138,
-          "total": 138
+          "pass": 139,
+          "total": 139
         },
         "blade": {
-          "pass": 133,
-          "total": 138,
+          "pass": 134,
+          "total": 139,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8086,8 +8158,8 @@
           ]
         },
         "erb": {
-          "pass": 133,
-          "total": 138,
+          "pass": 134,
+          "total": 139,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8112,8 +8184,8 @@
           ]
         },
         "go-template": {
-          "pass": 132,
-          "total": 138,
+          "pass": 133,
+          "total": 139,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8144,8 +8216,8 @@
           ]
         },
         "jinja": {
-          "pass": 133,
-          "total": 138,
+          "pass": 134,
+          "total": 139,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8170,8 +8242,8 @@
           ]
         },
         "minijinja": {
-          "pass": 133,
-          "total": 138,
+          "pass": 134,
+          "total": 139,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8197,7 +8269,7 @@
         },
         "mojolicious": {
           "pass": 132,
-          "total": 138,
+          "total": 139,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8216,6 +8288,12 @@
               "issues": []
             },
             {
+              "fixture": "static-loop-item-boolean-attr",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2911"
+              ]
+            },
+            {
               "fixture": "static-loop-item-conditional",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2911"
@@ -8228,8 +8306,8 @@
           ]
         },
         "twig": {
-          "pass": 133,
-          "total": 138,
+          "pass": 134,
+          "total": 139,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8255,7 +8333,7 @@
         },
         "xslate": {
           "pass": 132,
-          "total": 138,
+          "total": 139,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8272,6 +8350,12 @@
             {
               "fixture": "reduce-typeof-body",
               "issues": []
+            },
+            {
+              "fixture": "static-loop-item-boolean-attr",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2911"
+              ]
             },
             {
               "fixture": "static-loop-item-conditional",
@@ -8299,15 +8383,15 @@
       }
     },
     "literal:string": {
-      "total": 210,
+      "total": 211,
       "cells": {
         "hono": {
-          "pass": 210,
-          "total": 210
+          "pass": 211,
+          "total": 211
         },
         "blade": {
-          "pass": 202,
-          "total": 210,
+          "pass": 203,
+          "total": 211,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8346,8 +8430,8 @@
           ]
         },
         "erb": {
-          "pass": 202,
-          "total": 210,
+          "pass": 203,
+          "total": 211,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8386,8 +8470,8 @@
           ]
         },
         "go-template": {
-          "pass": 201,
-          "total": 210,
+          "pass": 202,
+          "total": 211,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8432,8 +8516,8 @@
           ]
         },
         "jinja": {
-          "pass": 202,
-          "total": 210,
+          "pass": 203,
+          "total": 211,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8472,8 +8556,8 @@
           ]
         },
         "minijinja": {
-          "pass": 202,
-          "total": 210,
+          "pass": 203,
+          "total": 211,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8513,7 +8597,7 @@
         },
         "mojolicious": {
           "pass": 201,
-          "total": 210,
+          "total": 211,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8550,6 +8634,12 @@
               ]
             },
             {
+              "fixture": "static-loop-item-boolean-attr",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2911"
+              ]
+            },
+            {
               "fixture": "static-loop-item-conditional",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2911"
@@ -8558,8 +8648,8 @@
           ]
         },
         "twig": {
-          "pass": 202,
-          "total": 210,
+          "pass": 203,
+          "total": 211,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8599,7 +8689,7 @@
         },
         "xslate": {
           "pass": 201,
-          "total": 210,
+          "total": 211,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8633,6 +8723,12 @@
               "fixture": "static-array-from-props-with-component",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2321"
+              ]
+            },
+            {
+              "fixture": "static-loop-item-boolean-attr",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2911"
               ]
             },
             {

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -131,7 +131,7 @@
           ]
         },
         "go-template": {
-          "pass": 96,
+          "pass": 97,
           "total": 110,
           "gaps": [
             {
@@ -183,15 +183,9 @@
               "issues": []
             },
             {
-              "fixture": "static-nested-loop-conditional",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2893"
-              ]
-            },
-            {
               "fixture": "static-nested-loop-ref",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2893"
+                "https://github.com/piconic-ai/barefootjs/issues/2909"
               ]
             },
             {
@@ -317,7 +311,7 @@
           ]
         },
         "mojolicious": {
-          "pass": 97,
+          "pass": 98,
           "total": 110,
           "gaps": [
             {
@@ -361,12 +355,6 @@
             {
               "fixture": "some-typeof-predicate",
               "issues": []
-            },
-            {
-              "fixture": "static-loop-item-boolean-attr",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2911"
-              ]
             },
             {
               "fixture": "static-loop-item-conditional",
@@ -439,7 +427,7 @@
           ]
         },
         "xslate": {
-          "pass": 96,
+          "pass": 97,
           "total": 110,
           "gaps": [
             {
@@ -489,12 +477,6 @@
             {
               "fixture": "some-typeof-predicate",
               "issues": []
-            },
-            {
-              "fixture": "static-loop-item-boolean-attr",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2911"
-              ]
             },
             {
               "fixture": "static-loop-item-conditional",
@@ -779,7 +761,7 @@
           ]
         },
         "go-template": {
-          "pass": 64,
+          "pass": 65,
           "total": 74,
           "gaps": [
             {
@@ -817,12 +799,6 @@
             {
               "fixture": "some-typeof-predicate",
               "issues": []
-            },
-            {
-              "fixture": "static-nested-loop-conditional",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2893"
-              ]
             },
             {
               "fixture": "tag-cloud",
@@ -1633,7 +1609,7 @@
           ]
         },
         "go-template": {
-          "pass": 255,
+          "pass": 256,
           "total": 274,
           "gaps": [
             {
@@ -1713,15 +1689,9 @@
               ]
             },
             {
-              "fixture": "static-nested-loop-conditional",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2893"
-              ]
-            },
-            {
               "fixture": "static-nested-loop-ref",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2893"
+                "https://github.com/piconic-ai/barefootjs/issues/2909"
               ]
             },
             {
@@ -2270,11 +2240,11 @@
       }
     },
     "identifier": {
-      "total": 383,
+      "total": 382,
       "cells": {
         "hono": {
-          "pass": 379,
-          "total": 383,
+          "pass": 378,
+          "total": 382,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2297,8 +2267,8 @@
           ]
         },
         "blade": {
-          "pass": 363,
-          "total": 383,
+          "pass": 362,
+          "total": 382,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2393,8 +2363,8 @@
           ]
         },
         "erb": {
-          "pass": 364,
-          "total": 383,
+          "pass": 363,
+          "total": 382,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2484,7 +2454,7 @@
         },
         "go-template": {
           "pass": 359,
-          "total": 383,
+          "total": 382,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2585,15 +2555,9 @@
               ]
             },
             {
-              "fixture": "static-nested-loop-conditional",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2893"
-              ]
-            },
-            {
               "fixture": "static-nested-loop-ref",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2893"
+                "https://github.com/piconic-ai/barefootjs/issues/2909"
               ]
             },
             {
@@ -2603,8 +2567,8 @@
           ]
         },
         "jinja": {
-          "pass": 363,
-          "total": 383,
+          "pass": 362,
+          "total": 382,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2699,8 +2663,8 @@
           ]
         },
         "minijinja": {
-          "pass": 363,
-          "total": 383,
+          "pass": 362,
+          "total": 382,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2796,7 +2760,7 @@
         },
         "mojolicious": {
           "pass": 362,
-          "total": 383,
+          "total": 382,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2879,12 +2843,6 @@
               ]
             },
             {
-              "fixture": "static-loop-item-boolean-attr",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2911"
-              ]
-            },
-            {
               "fixture": "static-loop-item-conditional",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2911"
@@ -2897,8 +2855,8 @@
           ]
         },
         "twig": {
-          "pass": 363,
-          "total": 383,
+          "pass": 362,
+          "total": 382,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2994,7 +2952,7 @@
         },
         "xslate": {
           "pass": 361,
-          "total": 383,
+          "total": 382,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3083,12 +3041,6 @@
               ]
             },
             {
-              "fixture": "static-loop-item-boolean-attr",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2911"
-              ]
-            },
-            {
               "fixture": "static-loop-item-conditional",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2911"
@@ -3166,11 +3118,11 @@
       }
     },
     "literal": {
-      "total": 306,
+      "total": 307,
       "cells": {
         "hono": {
-          "pass": 305,
-          "total": 306,
+          "pass": 306,
+          "total": 307,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -3179,8 +3131,8 @@
           ]
         },
         "blade": {
-          "pass": 294,
-          "total": 306,
+          "pass": 295,
+          "total": 307,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3235,8 +3187,8 @@
           ]
         },
         "erb": {
-          "pass": 294,
-          "total": 306,
+          "pass": 295,
+          "total": 307,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3291,8 +3243,8 @@
           ]
         },
         "go-template": {
-          "pass": 290,
-          "total": 306,
+          "pass": 292,
+          "total": 307,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3353,15 +3305,9 @@
               ]
             },
             {
-              "fixture": "static-nested-loop-conditional",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2893"
-              ]
-            },
-            {
               "fixture": "static-nested-loop-ref",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2893"
+                "https://github.com/piconic-ai/barefootjs/issues/2909"
               ]
             },
             {
@@ -3371,8 +3317,8 @@
           ]
         },
         "jinja": {
-          "pass": 294,
-          "total": 306,
+          "pass": 295,
+          "total": 307,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3427,8 +3373,8 @@
           ]
         },
         "minijinja": {
-          "pass": 294,
-          "total": 306,
+          "pass": 295,
+          "total": 307,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3483,8 +3429,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 292,
-          "total": 306,
+          "pass": 294,
+          "total": 307,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3533,12 +3479,6 @@
               ]
             },
             {
-              "fixture": "static-loop-item-boolean-attr",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2911"
-              ]
-            },
-            {
               "fixture": "static-loop-item-conditional",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2911"
@@ -3551,8 +3491,8 @@
           ]
         },
         "twig": {
-          "pass": 294,
-          "total": 306,
+          "pass": 295,
+          "total": 307,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3607,8 +3547,8 @@
           ]
         },
         "xslate": {
-          "pass": 292,
-          "total": 306,
+          "pass": 294,
+          "total": 307,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3654,12 +3594,6 @@
               "fixture": "static-array-from-props-with-component",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2321"
-              ]
-            },
-            {
-              "fixture": "static-loop-item-boolean-attr",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2911"
               ]
             },
             {
@@ -3836,11 +3770,11 @@
       }
     },
     "member": {
-      "total": 225,
+      "total": 224,
       "cells": {
         "hono": {
-          "pass": 222,
-          "total": 225,
+          "pass": 221,
+          "total": 224,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3859,8 +3793,8 @@
           ]
         },
         "blade": {
-          "pass": 206,
-          "total": 225,
+          "pass": 205,
+          "total": 224,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3951,8 +3885,8 @@
           ]
         },
         "erb": {
-          "pass": 207,
-          "total": 225,
+          "pass": 206,
+          "total": 224,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4038,7 +3972,7 @@
         },
         "go-template": {
           "pass": 202,
-          "total": 225,
+          "total": 224,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4135,15 +4069,9 @@
               ]
             },
             {
-              "fixture": "static-nested-loop-conditional",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2893"
-              ]
-            },
-            {
               "fixture": "static-nested-loop-ref",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2893"
+                "https://github.com/piconic-ai/barefootjs/issues/2909"
               ]
             },
             {
@@ -4153,8 +4081,8 @@
           ]
         },
         "jinja": {
-          "pass": 206,
-          "total": 225,
+          "pass": 205,
+          "total": 224,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4245,8 +4173,8 @@
           ]
         },
         "minijinja": {
-          "pass": 206,
-          "total": 225,
+          "pass": 205,
+          "total": 224,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4338,7 +4266,7 @@
         },
         "mojolicious": {
           "pass": 205,
-          "total": 225,
+          "total": 224,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4417,12 +4345,6 @@
               ]
             },
             {
-              "fixture": "static-loop-item-boolean-attr",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2911"
-              ]
-            },
-            {
               "fixture": "static-loop-item-conditional",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2911"
@@ -4435,8 +4357,8 @@
           ]
         },
         "twig": {
-          "pass": 206,
-          "total": 225,
+          "pass": 205,
+          "total": 224,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4528,7 +4450,7 @@
         },
         "xslate": {
           "pass": 204,
-          "total": 225,
+          "total": 224,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4613,12 +4535,6 @@
               ]
             },
             {
-              "fixture": "static-loop-item-boolean-attr",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2911"
-              ]
-            },
-            {
               "fixture": "static-loop-item-conditional",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2911"
@@ -4644,15 +4560,15 @@
       }
     },
     "object-literal": {
-      "total": 89,
+      "total": 90,
       "cells": {
         "hono": {
-          "pass": 89,
-          "total": 89
+          "pass": 90,
+          "total": 90
         },
         "blade": {
-          "pass": 86,
-          "total": 89,
+          "pass": 87,
+          "total": 90,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4671,8 +4587,8 @@
           ]
         },
         "erb": {
-          "pass": 86,
-          "total": 89,
+          "pass": 87,
+          "total": 90,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4691,8 +4607,8 @@
           ]
         },
         "go-template": {
-          "pass": 83,
-          "total": 89,
+          "pass": 85,
+          "total": 90,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4711,15 +4627,9 @@
               ]
             },
             {
-              "fixture": "static-nested-loop-conditional",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2893"
-              ]
-            },
-            {
               "fixture": "static-nested-loop-ref",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2893"
+                "https://github.com/piconic-ai/barefootjs/issues/2909"
               ]
             },
             {
@@ -4729,8 +4639,8 @@
           ]
         },
         "jinja": {
-          "pass": 86,
-          "total": 89,
+          "pass": 87,
+          "total": 90,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4749,8 +4659,8 @@
           ]
         },
         "minijinja": {
-          "pass": 86,
-          "total": 89,
+          "pass": 87,
+          "total": 90,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4769,8 +4679,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 84,
-          "total": 89,
+          "pass": 86,
+          "total": 90,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4780,12 +4690,6 @@
               "fixture": "static-array-from-props",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2321"
-              ]
-            },
-            {
-              "fixture": "static-loop-item-boolean-attr",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2911"
               ]
             },
             {
@@ -4801,8 +4705,8 @@
           ]
         },
         "twig": {
-          "pass": 86,
-          "total": 89,
+          "pass": 87,
+          "total": 90,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4821,8 +4725,8 @@
           ]
         },
         "xslate": {
-          "pass": 84,
-          "total": 89,
+          "pass": 86,
+          "total": 90,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4832,12 +4736,6 @@
               "fixture": "static-array-from-props",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2321"
-              ]
-            },
-            {
-              "fixture": "static-loop-item-boolean-attr",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2911"
               ]
             },
             {
@@ -5045,7 +4943,7 @@
           ]
         },
         "go-template": {
-          "pass": 26,
+          "pass": 27,
           "total": 29,
           "gaps": [
             {
@@ -5057,12 +4955,6 @@
             {
               "fixture": "preamble-cells",
               "issues": []
-            },
-            {
-              "fixture": "static-nested-loop-conditional",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2893"
-              ]
             }
           ]
         },
@@ -5307,7 +5199,7 @@
             {
               "fixture": "static-nested-loop-ref",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2893"
+                "https://github.com/piconic-ai/barefootjs/issues/2909"
               ]
             },
             {
@@ -7932,11 +7824,11 @@
       }
     },
     "literal:boolean": {
-      "total": 69,
+      "total": 68,
       "cells": {
         "hono": {
-          "pass": 68,
-          "total": 69,
+          "pass": 67,
+          "total": 68,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -7945,8 +7837,8 @@
           ]
         },
         "blade": {
-          "pass": 67,
-          "total": 69,
+          "pass": 66,
+          "total": 68,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -7959,8 +7851,8 @@
           ]
         },
         "erb": {
-          "pass": 67,
-          "total": 69,
+          "pass": 66,
+          "total": 68,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -7974,7 +7866,7 @@
         },
         "go-template": {
           "pass": 64,
-          "total": 69,
+          "total": 68,
           "gaps": [
             {
               "fixture": "jsx-element-prop-rest-bag-dynamic",
@@ -7995,18 +7887,12 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2700"
               ]
-            },
-            {
-              "fixture": "static-nested-loop-conditional",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2893"
-              ]
             }
           ]
         },
         "jinja": {
-          "pass": 67,
-          "total": 69,
+          "pass": 66,
+          "total": 68,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -8019,8 +7905,8 @@
           ]
         },
         "minijinja": {
-          "pass": 67,
-          "total": 69,
+          "pass": 66,
+          "total": 68,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -8034,7 +7920,7 @@
         },
         "mojolicious": {
           "pass": 65,
-          "total": 69,
+          "total": 68,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -8045,12 +7931,6 @@
               "issues": []
             },
             {
-              "fixture": "static-loop-item-boolean-attr",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2911"
-              ]
-            },
-            {
               "fixture": "static-loop-item-conditional",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2911"
@@ -8059,8 +7939,8 @@
           ]
         },
         "twig": {
-          "pass": 67,
-          "total": 69,
+          "pass": 66,
+          "total": 68,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -8074,7 +7954,7 @@
         },
         "xslate": {
           "pass": 65,
-          "total": 69,
+          "total": 68,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -8083,12 +7963,6 @@
             {
               "fixture": "preamble-cells",
               "issues": []
-            },
-            {
-              "fixture": "static-loop-item-boolean-attr",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2911"
-              ]
             },
             {
               "fixture": "static-loop-item-conditional",
@@ -8179,15 +8053,15 @@
       }
     },
     "literal:number": {
-      "total": 137,
+      "total": 138,
       "cells": {
         "hono": {
-          "pass": 137,
-          "total": 137
+          "pass": 138,
+          "total": 138
         },
         "blade": {
-          "pass": 132,
-          "total": 137,
+          "pass": 133,
+          "total": 138,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8212,8 +8086,8 @@
           ]
         },
         "erb": {
-          "pass": 132,
-          "total": 137,
+          "pass": 133,
+          "total": 138,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8238,8 +8112,8 @@
           ]
         },
         "go-template": {
-          "pass": 130,
-          "total": 137,
+          "pass": 132,
+          "total": 138,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8258,15 +8132,9 @@
               "issues": []
             },
             {
-              "fixture": "static-nested-loop-conditional",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2893"
-              ]
-            },
-            {
               "fixture": "static-nested-loop-ref",
               "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2893"
+                "https://github.com/piconic-ai/barefootjs/issues/2909"
               ]
             },
             {
@@ -8276,8 +8144,8 @@
           ]
         },
         "jinja": {
-          "pass": 132,
-          "total": 137,
+          "pass": 133,
+          "total": 138,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8302,8 +8170,8 @@
           ]
         },
         "minijinja": {
-          "pass": 132,
-          "total": 137,
+          "pass": 133,
+          "total": 138,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8328,8 +8196,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 130,
-          "total": 137,
+          "pass": 132,
+          "total": 138,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8348,12 +8216,6 @@
               "issues": []
             },
             {
-              "fixture": "static-loop-item-boolean-attr",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2911"
-              ]
-            },
-            {
               "fixture": "static-loop-item-conditional",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2911"
@@ -8366,8 +8228,8 @@
           ]
         },
         "twig": {
-          "pass": 132,
-          "total": 137,
+          "pass": 133,
+          "total": 138,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8392,8 +8254,8 @@
           ]
         },
         "xslate": {
-          "pass": 130,
-          "total": 137,
+          "pass": 132,
+          "total": 138,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8410,12 +8272,6 @@
             {
               "fixture": "reduce-typeof-body",
               "issues": []
-            },
-            {
-              "fixture": "static-loop-item-boolean-attr",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2911"
-              ]
             },
             {
               "fixture": "static-loop-item-conditional",
@@ -8443,15 +8299,15 @@
       }
     },
     "literal:string": {
-      "total": 211,
+      "total": 210,
       "cells": {
         "hono": {
-          "pass": 211,
-          "total": 211
+          "pass": 210,
+          "total": 210
         },
         "blade": {
-          "pass": 203,
-          "total": 211,
+          "pass": 202,
+          "total": 210,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8490,8 +8346,8 @@
           ]
         },
         "erb": {
-          "pass": 203,
-          "total": 211,
+          "pass": 202,
+          "total": 210,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8530,8 +8386,8 @@
           ]
         },
         "go-template": {
-          "pass": 202,
-          "total": 211,
+          "pass": 201,
+          "total": 210,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8576,8 +8432,8 @@
           ]
         },
         "jinja": {
-          "pass": 203,
-          "total": 211,
+          "pass": 202,
+          "total": 210,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8616,8 +8472,8 @@
           ]
         },
         "minijinja": {
-          "pass": 203,
-          "total": 211,
+          "pass": 202,
+          "total": 210,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8657,7 +8513,7 @@
         },
         "mojolicious": {
           "pass": 201,
-          "total": 211,
+          "total": 210,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8694,12 +8550,6 @@
               ]
             },
             {
-              "fixture": "static-loop-item-boolean-attr",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2911"
-              ]
-            },
-            {
               "fixture": "static-loop-item-conditional",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2911"
@@ -8708,8 +8558,8 @@
           ]
         },
         "twig": {
-          "pass": 203,
-          "total": 211,
+          "pass": 202,
+          "total": 210,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8749,7 +8599,7 @@
         },
         "xslate": {
           "pass": 201,
-          "total": 211,
+          "total": 210,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8783,12 +8633,6 @@
               "fixture": "static-array-from-props-with-component",
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2321"
-              ]
-            },
-            {
-              "fixture": "static-loop-item-boolean-attr",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2911"
               ]
             },
             {
@@ -9814,7 +9658,7 @@
           ]
         },
         "go-template": {
-          "pass": 18,
+          "pass": 19,
           "total": 21,
           "gaps": [
             {
@@ -9826,12 +9670,6 @@
             {
               "fixture": "preamble-cells",
               "issues": []
-            },
-            {
-              "fixture": "static-nested-loop-conditional",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2893"
-              ]
             }
           ]
         },


### PR DESCRIPTION
## Summary

Originally stacked on #2908 (#2898); #2908 has since merged, so this now targets `main` directly (GitHub retargeted the base and this branch has been rebased onto the new `main` accordingly).

- `analyzeBakeableStaticElementLoop`'s per-item unroll used to bail the WHOLE outer loop the moment its row contained a nested `loop` node (e.g. `item.children.map(child => ...)`), falling through to the generic BF101 "computed loop array" refusal.
- The analysis now recurses: a nested loop is gated by the same 9 shape checks as the outer one (`isBakeableLoopShape`, extracted from the outer-only checks), and its array resolves via `evaluateStaticLiteral` against the accumulated outer-item bindings (`resolveBakedLoopSource`) rather than requiring a named const the way the outer loop's own array does. Arbitrarily deep nesting composes for free through one recursive bindings map — verified by a new 3-level `static-nested-loop-depth2` fixture.
- On the render side, `renderUnrolledStaticElementLoop`'s existing `staticLoopItemStack`/`scope.enterLoopRow` stacks already nest for a second level unmodified; the real gap was `convertExpressionToGo`'s and `convertConditionToGo`'s override each only consulting the INNERMOST stack entry. Both now fold the whole stack via a new `staticLoopBindings()`.
- Graduates `static-nested-loop-conditional` off its BF101 pin outright (composes for free with #2898's conditional fix) and re-attributes `static-nested-loop-ref`'s still-refusing pin to a new, narrower issue (#2909) — that fixture's inner row also reads a signal in text position, an unrelated gap.

Fixes #2893.

### Folded in from #2898 (base branch history, merged via #2908)

These landed on the `claude/issue-2898-static-loop-conditional` branch while this PR was stacked on top, and are now part of `main` history via #2908 — noted here since they were previously undescribed by either PR body:

- A fixture-design bugfix to #2898's own `static-loop-item-conditional` fixture, found while verifying it against every adapter: its dead conditional branch read the same nullable field driving the condition itself — reworked to keep null-condition-value coverage while keeping the dead branch's own content static.
- That same fixture surfaced a genuinely separate, pre-existing limitation on two Perl-backed adapters (#2911): Mojolicious and Xslate's own static-array bake deliberately refuses a `boolean` value anywhere in the item shape (Perl has no boolean literal) — pinned on both, with prop-precompute/@client escape twins proving the diagnostic's own suggested escapes work.

### Review follow-up (this PR, post-Opus-review)

- `isFoldableTree`'s `case 'loop'` now refuses (loud BF101) a `clientOnly` nested loop instead of silently admitting it — `renderLoop`'s clientOnly branch emits a single `{{bfComment "loop:<markerId>"}}` marker pair per call site, and repeating that same markerId once per unrolled outer row was untested against the client's per-row insertion targeting. Filed #2918 to track faithfully lowering this shape once verified/covered.
- `resolveBakedLoopSource` now checks the array expression's free identifiers against the bindings map (not just whether the expression itself is a bare bound identifier), so a nested loop's array read off ANY bound outer-item field always resolves against the loop binding rather than risking a same-named module/component-scope const, regardless of the expression's shape (latent shadowing footgun, not currently reachable but closed defensively).
- Adds `static-nested-loop-shadowed-param`, covering the exact `items.map(item => item.children.map(item => ...))` shadowing example `staticLoopBindings()`'s own docstring uses to justify its "later wins" binding-fold order — previously undocumented by any fixture.

## Test plan

- [x] `bun run packages/adapter-tests/scripts/generate-expected-html.ts` — regenerated expected HTML for all new/changed fixtures from the Hono reference adapter; clean beyond intended fixture changes.
- [x] `bun packages/adapter-tests/scripts/coverage-map.ts` / `bun run support-matrix:lock` / `bun run compat:lock` — regenerated all derived lock artifacts; no drift after the post-merge rebase.
- [x] `tsgo --noEmit` on `packages/adapter-go-template` — clean.
- [x] `bun test packages/adapter-go-template/src` — 2105 pass, 0 fail.
- [x] `bun test packages/adapter-mojolicious/src/__tests__ packages/adapter-xslate/src/__tests__` — 3663 pass, 0 fail.
- [x] `bun test packages/compat/__tests__/support-matrix.test.ts packages/compat/src/__tests__/escape-coverage.test.ts packages/compat/src/__tests__/compat-engine.test.ts` — 305 pass, 0 fail.
- [ ] CI

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JoiEowwf1mVvYywj5AesY