### PR TITLE
Fix loop-mutated ChartConfig and .map()-produced Line children in charts

### DIFF
--- a/.changeset/chart-loop-mutated-config.md
+++ b/.changeset/chart-loop-mutated-config.md
@@ -1,0 +1,9 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/client": patch
+---
+
+Fixed two silent rendering failures (#2910) that combine in `@barefootjs/chart`'s `LineChart`/`Line` whenever their series/config are built dynamically instead of as static JSX/object literals:
+
+- A `.map()`-produced child component nested two component-levels below a comment-scoped wrapper (e.g. `<ChartContainer><LineChart>{series.map(s => <Line .../>)}</LineChart></ChartContainer>`) never initialised on hydration — its parent's own `__scopeId` resolved against the wrong scope, so every `[bf-h="…"]` child lookup matched nothing. Fixed by a new `ownScopeId` runtime helper that reads the comment-scope registry instead of the proxy element's own `bf-s` attribute.
+- A `const` mutated in place after its declaration (`const config = {}; for (const s of series) config[s.key] = {...}`) was re-inlined by its stale pre-mutation initializer text wherever referenced as a component prop, silently dropping the mutation. The analyzer now flags such bindings so every inlining consumer falls back to a live reference instead.

--- a/packages/adapter-tests/fixtures/__snapshots__/accordion.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/accordion.client.js
@@ -1,4 +1,4 @@
-import { $, $c, __bfSlot, applyRestAttrs, createComponent, createContext, createEffect, createMemo, createSignal, escapeAttr, escapeText, forwardProps, hydrate, initChild, insert, markupOrEmpty, provideContext, renderChild, spreadAttrs, useContext } from '@barefootjs/client/runtime'
+import { $, $c, __bfSlot, applyRestAttrs, createComponent, createContext, createEffect, createMemo, createSignal, escapeAttr, escapeText, forwardProps, hydrate, initChild, insert, markupOrEmpty, ownScopeId, provideContext, renderChild, spreadAttrs, useContext } from '@barefootjs/client/runtime'
 
 export function initCheckIcon(__scope, _p = {}) {
   if (!__scope) return
@@ -3185,7 +3185,7 @@ hydrate('AccordionContent', { init: initAccordionContent, template: (_p) => `<di
 export function AccordionContent(_p, __bfKey) { return createComponent('AccordionContent', _p, __bfKey) }
 export function initAccordionSingleOpenDemo(__scope, _p = {}) {
   if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
+  const __scopeId = ownScopeId(__scope)
 
   const [openItem, setOpenItem] = createSignal('item-1')
 
@@ -3291,7 +3291,7 @@ hydrate('AccordionAsChildDemo', { init: initAccordionAsChildDemo, template: (_p)
 export function AccordionAsChildDemo(_p, __bfKey) { return createComponent('AccordionAsChildDemo', _p, __bfKey) }
 export function initAccordionMultipleOpenDemo(__scope, _p = {}) {
   if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
+  const __scopeId = ownScopeId(__scope)
 
   const [item1Open, setItem1Open] = createSignal(true)
   const [item2Open, setItem2Open] = createSignal(false)

--- a/packages/adapter-tests/fixtures/__snapshots__/command.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/command.client.js
@@ -1,4 +1,4 @@
-import { $, $c, __bfSlot, applyRestAttrs, createComponent, createContext, createDisposableEffect, createEffect, createMemo, createPortal, createSignal, escapeAttr, escapeText, escapeTextOrNode, forwardProps, hydrate, initChild, insert, isSSRPortal, lazySlots, markupOrEmpty, onCleanup, provideContext, renderChild, spreadAttrs, upsertChild, useContext } from '@barefootjs/client/runtime'
+import { $, $c, __bfSlot, applyRestAttrs, createComponent, createContext, createDisposableEffect, createEffect, createMemo, createPortal, createSignal, escapeAttr, escapeText, escapeTextOrNode, forwardProps, hydrate, initChild, insert, isSSRPortal, lazySlots, markupOrEmpty, onCleanup, ownScopeId, provideContext, renderChild, spreadAttrs, upsertChild, useContext } from '@barefootjs/client/runtime'
 
 export function initCheckIcon(__scope, _p = {}) {
   if (!__scope) return
@@ -3849,7 +3849,7 @@ var documentOrder = documentOrder ?? function(a, b) {
 
 export function initCommandDialog(__scope, _p = {}) {
   if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
+  const __scopeId = ownScopeId(__scope)
 
   const commandDialogContentClasses = 'overflow-hidden p-0'
 
@@ -4075,7 +4075,7 @@ hydrate('Button', { init: initButton, template: (_p) => `${_p.asChild ? `${rende
 export function Button(_p, __bfKey) { return createComponent('Button', _p, __bfKey) }
 export function initCommandPreviewDemo(__scope, _p = {}) {
   if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
+  const __scopeId = ownScopeId(__scope)
 
   const [_s0, _s14, _s1, _s5, _s2, _s3, _s4, _s6, _s13, _s8, _s7, _s10, _s9, _s12, _s11] = $c(__scope, 's0', 's14', 's1', 's5', 's2', 's3', 's4', 's6', 's13', 's8', 's7', 's10', 's9', 's12', 's11')
 
@@ -4167,7 +4167,7 @@ hydrate('CommandDialogDemo', { init: initCommandDialogDemo, template: (_p) => `<
 export function CommandDialogDemo(_p, __bfKey) { return createComponent('CommandDialogDemo', _p, __bfKey) }
 export function initCommandFilterDemo(__scope, _p = {}) {
   if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
+  const __scopeId = ownScopeId(__scope)
 
   const prefixFilter = (value, search) => {
     if (!search) return true

--- a/packages/adapter-tests/fixtures/__snapshots__/dropdown-menu.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/dropdown-menu.client.js
@@ -1,4 +1,4 @@
-import { $, $c, applyRestAttrs, createComponent, createContext, createEffect, createMemo, createPortal, createSignal, escapeAttr, findSiblingSlot, forwardProps, hydrate, initChild, insert, isSSRPortal, markupOrEmpty, provideContext, renderChild, spreadAttrs, trackPosition, useContext } from '@barefootjs/client/runtime'
+import { $, $c, applyRestAttrs, createComponent, createContext, createEffect, createMemo, createPortal, createSignal, escapeAttr, findSiblingSlot, forwardProps, hydrate, initChild, insert, isSSRPortal, markupOrEmpty, ownScopeId, provideContext, renderChild, spreadAttrs, trackPosition, useContext } from '@barefootjs/client/runtime'
 
 export function initCheckIcon(__scope, _p = {}) {
   if (!__scope) return
@@ -3713,7 +3713,7 @@ hydrate('DropdownMenuGroup', { init: initDropdownMenuGroup, template: (_p) => `<
 export function DropdownMenuGroup(_p, __bfKey) { return createComponent('DropdownMenuGroup', _p, __bfKey) }
 export function initDropdownMenuBasicDemo(__scope, _p = {}) {
   if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
+  const __scopeId = ownScopeId(__scope)
 
   const [open, setOpen] = createSignal(false)
 
@@ -3755,7 +3755,7 @@ hydrate('DropdownMenuBasicDemo', { init: initDropdownMenuBasicDemo, template: (_
 export function DropdownMenuBasicDemo(_p, __bfKey) { return createComponent('DropdownMenuBasicDemo', _p, __bfKey) }
 export function initDropdownMenuCheckboxDemo(__scope, _p = {}) {
   if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
+  const __scopeId = ownScopeId(__scope)
 
   const [open, setOpen] = createSignal(false)
   const [showStatus, setShowStatus] = createSignal(true)
@@ -3819,7 +3819,7 @@ hydrate('DropdownMenuCheckboxDemo', { init: initDropdownMenuCheckboxDemo, templa
 export function DropdownMenuCheckboxDemo(_p, __bfKey) { return createComponent('DropdownMenuCheckboxDemo', _p, __bfKey) }
 export function initDropdownMenuProfileDemo(__scope, _p = {}) {
   if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
+  const __scopeId = ownScopeId(__scope)
 
   const [open, setOpen] = createSignal(false)
   const [showBookmarks, setShowBookmarks] = createSignal(true)

--- a/packages/adapter-tests/fixtures/__snapshots__/multi-root-fragment.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/multi-root-fragment.client.js
@@ -1,9 +1,9 @@
-import { $, createComponent, createEffect, createSignal, escapeTextOrMarkup, escapeTextOrNode, hydrate, lazySlots } from '@barefootjs/client/runtime'
+import { $, createComponent, createEffect, createSignal, escapeTextOrMarkup, escapeTextOrNode, hydrate, lazySlots, ownScopeId } from '@barefootjs/client/runtime'
 
 
 export function initMultiRootFragment(__scope, _p = {}) {
   if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
+  const __scopeId = ownScopeId(__scope)
 
   const [count, setCount] = createSignal(0)
 

--- a/packages/adapter-tests/fixtures/__snapshots__/pagination.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/pagination.client.js
@@ -1,4 +1,4 @@
-import { $, $c, applyRestAttrs, createComponent, createEffect, createMemo, createSignal, escapeAttr, escapeText, escapeTextOrMarkup, escapeTextOrNode, forwardProps, hydrate, initChild, lazySlots, markupOrEmpty, renderChild, spreadAttrs } from '@barefootjs/client/runtime'
+import { $, $c, applyRestAttrs, createComponent, createEffect, createMemo, createSignal, escapeAttr, escapeText, escapeTextOrMarkup, escapeTextOrNode, forwardProps, hydrate, initChild, lazySlots, markupOrEmpty, ownScopeId, renderChild, spreadAttrs } from '@barefootjs/client/runtime'
 
 export function initCheckIcon(__scope, _p = {}) {
   if (!__scope) return
@@ -3207,7 +3207,7 @@ hydrate('PaginationEllipsis', { init: initPaginationEllipsis, template: (_p) => 
 export function PaginationEllipsis(_p, __bfKey) { return createComponent('PaginationEllipsis', _p, __bfKey) }
 export function initPaginationBasicDemo(__scope, _p = {}) {
   if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
+  const __scopeId = ownScopeId(__scope)
 
   const [_s12, _s1, _s0, _s3, _s2, _s5, _s4, _s7, _s6, _s9, _s8, _s11, _s10] = $c(__scope, 's12', 's1', 's0', 's3', 's2', 's5', 's4', 's7', 's6', 's9', 's8', 's11', 's10')
 

--- a/packages/adapter-tests/fixtures/__snapshots__/popover.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/popover.client.js
@@ -1,4 +1,4 @@
-import { $, $c, __bfSlot, createComponent, createContext, createEffect, createPortal, createSignal, escapeAttr, escapeText, findSiblingSlot, hydrate, initChild, insert, isSSRPortal, markupOrEmpty, provideContext, renderChild, trackPosition, useContext } from '@barefootjs/client/runtime'
+import { $, $c, __bfSlot, createComponent, createContext, createEffect, createPortal, createSignal, escapeAttr, escapeText, findSiblingSlot, hydrate, initChild, insert, isSSRPortal, markupOrEmpty, ownScopeId, provideContext, renderChild, trackPosition, useContext } from '@barefootjs/client/runtime'
 
 var PopoverContext = PopoverContext ?? createContext()
 
@@ -242,7 +242,7 @@ hydrate('PopoverClose', { init: initPopoverClose, template: (_p) => `<button dat
 export function PopoverClose(_p, __bfKey) { return createComponent('PopoverClose', _p, __bfKey) }
 export function initPopoverPreviewDemo(__scope, _p = {}) {
   if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
+  const __scopeId = ownScopeId(__scope)
 
   const [open, setOpen] = createSignal(false)
 
@@ -278,7 +278,7 @@ hydrate('PopoverPreviewDemo', { init: initPopoverPreviewDemo, template: (_p) => 
 export function PopoverPreviewDemo(_p, __bfKey) { return createComponent('PopoverPreviewDemo', _p, __bfKey) }
 export function initPopoverBasicDemo(__scope, _p = {}) {
   if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
+  const __scopeId = ownScopeId(__scope)
 
   const [open, setOpen] = createSignal(false)
 
@@ -314,7 +314,7 @@ hydrate('PopoverBasicDemo', { init: initPopoverBasicDemo, template: (_p) => `${r
 export function PopoverBasicDemo(_p, __bfKey) { return createComponent('PopoverBasicDemo', _p, __bfKey) }
 export function initPopoverFormDemo(__scope, _p = {}) {
   if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
+  const __scopeId = ownScopeId(__scope)
 
   const [open, setOpen] = createSignal(false)
   const [saved, setSaved] = createSignal(false)

--- a/packages/adapter-tests/fixtures/__snapshots__/tabs.client.js
+++ b/packages/adapter-tests/fixtures/__snapshots__/tabs.client.js
@@ -1,4 +1,4 @@
-import { $, $c, applyRestAttrs, createComponent, createEffect, createMemo, createSignal, escapeAttr, hydrate, initChild, markupOrEmpty, renderChild } from '@barefootjs/client/runtime'
+import { $, $c, applyRestAttrs, createComponent, createEffect, createMemo, createSignal, escapeAttr, hydrate, initChild, markupOrEmpty, ownScopeId, renderChild } from '@barefootjs/client/runtime'
 
 export function initTabs(__scope, _p = {}) {
   if (!__scope) return
@@ -185,7 +185,7 @@ hydrate('TabsContent', { init: initTabsContent, template: (_p) => `<div data-slo
 export function TabsContent(_p, __bfKey) { return createComponent('TabsContent', _p, __bfKey) }
 export function initTabsBasicDemo(__scope, _p = {}) {
   if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
+  const __scopeId = ownScopeId(__scope)
 
   const [activeTab, setActiveTab] = createSignal('account')
   const isAccountSelected = createMemo(() => activeTab() === 'account')
@@ -280,7 +280,7 @@ hydrate('TabsBasicDemo', { init: initTabsBasicDemo, template: (_p) => `${renderC
 export function TabsBasicDemo(_p, __bfKey) { return createComponent('TabsBasicDemo', _p, __bfKey) }
 export function initTabsMultipleDemo(__scope, _p = {}) {
   if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
+  const __scopeId = ownScopeId(__scope)
 
   const [activeTab, setActiveTab] = createSignal('overview')
   const isOverviewSelected = createMemo(() => activeTab() === 'overview')
@@ -439,7 +439,7 @@ hydrate('TabsMultipleDemo', { init: initTabsMultipleDemo, template: (_p) => `${r
 export function TabsMultipleDemo(_p, __bfKey) { return createComponent('TabsMultipleDemo', _p, __bfKey) }
 export function initTabsDisabledDemo(__scope, _p = {}) {
   if (!__scope) return
-  const __scopeId = __scope.getAttribute('bf-s')
+  const __scopeId = ownScopeId(__scope)
 
   const [activeTab, setActiveTab] = createSignal('active')
   const isActiveSelected = createMemo(() => activeTab() === 'active')

--- a/packages/client/__tests__/runtime/issue-2910-comment-wrapper-loop-child-scope.test.ts
+++ b/packages/client/__tests__/runtime/issue-2910-comment-wrapper-loop-child-scope.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Regression test for #2910 (bug 1): a `.map()`-produced child component,
+ * nested two component-levels below a comment-scoped wrapper (root is a
+ * single child-component call, #2649 — the exact shape of
+ * `<ChartContainer><LineChart>{series.map(s => <Line .../>)}</LineChart></ChartContainer>`),
+ * never initialised on hydration. `series` is a MODULE-LEVEL const array
+ * (not a prop) so the compiler takes the "static array child-init" plan
+ * (`build-static-array-child-init.ts`) rather than the dynamic `mapArray`
+ * plan — the plan the actual chart issue hits.
+ *
+ * Root cause: the wrapper's own `initHost` read `__scopeId` from
+ * `__scope.getAttribute('bf-s')`. For a comment-scoped root, `__scope` is
+ * the PROXY element rendered by the wrapper's single child (here,
+ * `Container`'s own `<div>`), whose `bf-s` names ITS OWN scope — not the
+ * wrapper's. So `[bf-h="${__scopeId}"]` searched for the wrong id and
+ * found none of the `.map()`-produced `Row` children, leaving them
+ * un-initialised (in the chart's case: `useContext` never resolves,
+ * `registerBar` never runs, every line's `d` stays empty).
+ *
+ * Fixed by `ownScopeId(__scope)` (`packages/client/src/runtime/scope.ts`),
+ * which reads the id the comment-scope registry recorded during hydration
+ * instead of the proxy's own attribute.
+ */
+import { describe, test, expect, beforeAll, beforeEach } from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+import { compileJSX } from '../../../jsx/src/compiler'
+import { TestAdapter } from '../../../jsx/src/adapters/test-adapter'
+import { renderHonoComponent } from '../../../adapter-hono/src/test-render'
+import { HonoAdapter } from '../../../adapter-hono/src/adapter/hono-adapter'
+import { writeFileSync, mkdtempSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+beforeAll(() => {
+  if (typeof window === 'undefined') GlobalRegistrator.register()
+})
+
+const adapter = new TestAdapter()
+const runtimePath = join(__dirname, '../../src/runtime/index.ts')
+
+const SOURCE = `'use client'
+import { createContext, useContext } from '@barefootjs/client'
+
+type RowInfo = { key: string; label: string }
+const RowContext = createContext<{ register: (k: string) => void }>({ register: () => {} })
+const items: RowInfo[] = [{ key: 'a', label: 'A' }, { key: 'b', label: 'B' }]
+
+function Container(props: { children?: unknown }) {
+  return (
+    <RowContext.Provider value={{ register: (k) => document.body.setAttribute('data-registered-' + k, '1') }}>
+      <div className="host">{props.children}</div>
+    </RowContext.Provider>
+  )
+}
+
+function Inner(props: { children?: unknown }) {
+  return <div className="inner">{props.children}</div>
+}
+
+function Row(props: { item: RowInfo }) {
+  const ctx = useContext(RowContext)
+  const handleMount = (el: HTMLElement) => { ctx.register(props.item.key) }
+  return <span ref={handleMount} data-key={props.item.key}>{props.item.label}</span>
+}
+
+export function Host() {
+  return (
+    <Container>
+      <Inner>
+        {items.map((item) => <Row key={item.key} item={item} />)}
+      </Inner>
+    </Container>
+  )
+}
+`
+
+function clientJsFor(source: string, filename: string): string {
+  const result = compileJSX(source, filename, { adapter })
+  const errors = result.errors.filter(e => e.severity === 'error')
+  if (errors.length > 0) {
+    throw new Error(`Compile errors in ${filename}:\n${errors.map(e => `${e.code}: ${e.message}`).join('\n')}`)
+  }
+  const clientJs = result.files.find(f => f.type === 'clientJs')?.content
+  if (!clientJs) throw new Error(`No client JS for ${filename}`)
+  return clientJs
+    .replace(/from\s+['"]@barefootjs\/client\/runtime['"]/g, `from '${runtimePath}'`)
+    .replace(/^import '\/\* @bf-child:\w+ \*\/'\n/gm, '')
+}
+
+describe('#2910 — .map()-produced child under a nested comment-scoped wrapper registers on hydration', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    document.body.removeAttribute('data-registered-a')
+    document.body.removeAttribute('data-registered-b')
+  })
+
+  test('every mapped Row calls its context-provided callback after hydration', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'bf-2910-'))
+    const file = join(dir, 'Host.mjs')
+    writeFileSync(file, clientJsFor(SOURCE, 'Host.tsx'))
+    await import(file)
+
+    const ssrHtml = await renderHonoComponent({
+      adapter: new HonoAdapter(),
+      source: SOURCE,
+      props: { __instanceId: 'Host_test' },
+    })
+    // Comment-scoped root (the shape under test): the wrapper carries no
+    // element of its own, only the anchoring comment pair.
+    expect(ssrHtml).toContain('<!--bf-scope:Host_test')
+    // Both rows rendered with the WRAPPER's real scope id as their `bf-h`
+    // ancestor stamp, not `Container`'s derived sub-scope.
+    expect(ssrHtml).toContain('bf-h="Host_test"')
+
+    document.body.innerHTML = ssrHtml
+
+    const { rehydrateAll, flushHydration } = await import(runtimePath)
+    rehydrateAll()
+    flushHydration()
+
+    expect(document.body.getAttribute('data-registered-a')).toBe('1')
+    expect(document.body.getAttribute('data-registered-b')).toBe('1')
+  }, 30000)
+})

--- a/packages/client/__tests__/runtime/issue-2910-comment-wrapper-nested-csr-mount-scope.test.ts
+++ b/packages/client/__tests__/runtime/issue-2910-comment-wrapper-nested-csr-mount-scope.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Regression test for a gap pullfrog's review of #2915 (issue #2910) found
+ * in the `ownScopeId` fix: `materializeComponent` (`component.ts`) only
+ * captured `wrapperScopeId` — the id `commentScopeRegistry` needs to
+ * resolve a comment-wrapper's OWN scope later via `ownScopeId()` — for two
+ * of its three mount shapes (a genuine fragment root, and a wrapper
+ * mounted BARE at the top level, #2728). The third shape, a comment
+ * wrapper (`comment: true`, no `fragmentRoot` — "root is a single
+ * child-component call", #2649) CSR-materialized as a NESTED/slotted
+ * child — i.e. through `upsertChild`'s CSR-create branch with a real
+ * `slotId`, the ordinary way a named child component gets created — hit
+ * the `slot?.parent` branch, which set `_parentScopeId` but left
+ * `wrapperScopeId` null. `commentScopeId` then resolved to null and the
+ * proxy never got a `commentScopeRegistry` entry, so `ownScopeId()` fell
+ * through to the proxy's own (wrong) `bf-s` attribute — the exact failure
+ * this PR fixes for hydration, reached instead via pure CSR.
+ *
+ * `#2910-comment-wrapper-loop-child-scope.test.ts` and
+ * `#2910-mutated-const-child-prop.test.ts` are both SSR+hydrate, so
+ * neither exercised this CSR-only materialize path — this test fills
+ * that gap directly against the runtime primitives (`upsertChild` /
+ * `createComponent`), mirroring `issue-2728-comment-wrapper-csr-mount-
+ * child-slots.test.ts`'s bare-top-level case but with a real `slotId`.
+ */
+import { describe, test, expect, beforeAll, beforeEach } from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+import { compileJSX } from '../../../jsx/src/compiler'
+import { TestAdapter } from '../../../jsx/src/adapters/test-adapter'
+import { writeFileSync, mkdtempSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+beforeAll(() => {
+  if (typeof window === 'undefined') GlobalRegistrator.register()
+})
+
+const adapter = new TestAdapter()
+const runtimePath = join(__dirname, '../../src/runtime/index.ts')
+
+function clientJsFor(source: string, filename: string): string {
+  const result = compileJSX(source, filename, { adapter })
+  const errors = result.errors.filter(e => e.severity === 'error')
+  if (errors.length > 0) {
+    throw new Error(`Compile errors in ${filename}:\n${errors.map(e => `${e.code}: ${e.message}`).join('\n')}`)
+  }
+  const clientJs = result.files.find(f => f.type === 'clientJs')?.content
+  if (!clientJs) throw new Error(`No client JS for ${filename}`)
+  return clientJs
+    .replace(/from\s+['"]@barefootjs\/client\/runtime['"]/g, `from '${runtimePath}'`)
+    .replace(/^import '\/\* @bf-child:\w+ \*\/'\n/gm, '')
+}
+
+async function loadComponent(source: string, filename: string): Promise<void> {
+  const dir = mkdtempSync(join(tmpdir(), 'bf-2910-nested-csr-'))
+  const file = join(dir, `${filename.replace(/\W/g, '_')}_${Math.random().toString(36).slice(2)}.mjs`)
+  writeFileSync(file, clientJsFor(source, filename))
+  await import(file)
+}
+
+const BOX_SRC = `'use client'
+export function Box2910Nested(props: { children?: unknown }) {
+  return <div data-box="true">{props.children}</div>
+}
+`
+
+const LEAF_SRC = `'use client'
+export function Leaf2910Nested(props: { a: number }) {
+  return <span data-leaf="true">{props.a}</span>
+}
+`
+
+// A comment-wrapper component: its own root is a single child-component
+// call (`<Box2910Nested>`), so it registers with `comment: true` and no
+// `fragmentRoot` — the exact shape under test.
+const MIDDLE_SRC = `'use client'
+import { Box2910Nested } from './Box2910Nested'
+import { Leaf2910Nested } from './Leaf2910Nested'
+export function Middle2910Nested(props: { value: number }) {
+  return (
+    <Box2910Nested>
+      <Leaf2910Nested a={props.value} />
+    </Box2910Nested>
+  )
+}
+`
+
+describe('#2910 follow-up — a comment wrapper CSR-materialized as a NESTED (slotted) child registers its own comment scope', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  test('upsertChild with a real slotId registers commentScopeRegistry so ownScopeId resolves correctly', async () => {
+    await loadComponent(BOX_SRC, 'Box2910Nested.tsx')
+    await loadComponent(LEAF_SRC, 'Leaf2910Nested.tsx')
+    await loadComponent(MIDDLE_SRC, 'Middle2910Nested.tsx')
+
+    const { upsertChild } = await import(runtimePath)
+    const { commentScopeRegistry, ownScopeId } = await import('../../src/runtime/scope')
+
+    // Stand in for a parent scope that mounts `Middle2910Nested` as an
+    // ordinary named child at slot 's0' via a CSR placeholder — the shape
+    // `upsertChild`'s CSR-create branch handles for any deferred/dynamic
+    // child, not just this PR's `.map()` case.
+    const host = document.createElement('div')
+    host.setAttribute('bf-s', 'Host2910Nested_x1')
+    const placeholder = document.createElement('div')
+    placeholder.setAttribute('data-bf-ph', 's0')
+    host.appendChild(placeholder)
+    document.body.appendChild(host)
+
+    const proxy = upsertChild(host, 'Middle2910Nested', 's0', { value: 7 })
+    expect(proxy).not.toBeNull()
+    expect(proxy!.getAttribute('data-box')).toBe('true')
+
+    // The proxy IS `Box2910Nested`'s own rendered element (Middle has no
+    // DOM footprint of its own) — its `bf-s` names Box's scope, not
+    // Middle's. `ownScopeId` must resolve Middle's real derived scope
+    // (`${slot.parent}_${slot.mount}`) via the registry, not that attribute.
+    expect(commentScopeRegistry.has(proxy!)).toBe(true)
+    expect(ownScopeId(proxy!)).toBe('Host2910Nested_x1_s0')
+    expect(ownScopeId(proxy!)).not.toBe(proxy!.getAttribute('bf-s'))
+
+    // And the actual bug this covers: Leaf (Middle's `.map()`-analogue
+    // child in the real chart shape) rendered with its prop applied.
+    const leaf = proxy!.querySelector('[data-leaf]')
+    expect(leaf?.textContent).toBe('7')
+  })
+})

--- a/packages/client/__tests__/runtime/issue-2910-mutated-const-child-prop.test.ts
+++ b/packages/client/__tests__/runtime/issue-2910-mutated-const-child-prop.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Regression test for #2910 (bug 2): a `const` built via a same-scope
+ * loop mutation (`const config = {}; for (...) config[k] = ...`, the exact
+ * shape `chart-container.ts`'s `applyChartCSSVariables` consumer hits) and
+ * passed as a component prop must reach the child with its POST-mutation
+ * value, not the stale pre-mutation literal its declaration captured.
+ *
+ * Root cause: `expandDynamicPropValue` (`ir-to-client-js/prop-handling.ts`)
+ * inlined `ConstantInfo.value` — the declaration's initializer TEXT
+ * (`"{}"`)  — wherever the bare `config` identifier was referenced as a
+ * prop value, re-embedding a snapshot from BEFORE the mutating `for` loop
+ * ran instead of a live reference to the binding. Fixed by flagging such
+ * bindings `mutatedAfterDeclaration` (`analyzer.ts`'s `markMutatedConstants`)
+ * and having every inlining consumer fall back to a live reference.
+ */
+import { describe, test, expect, beforeAll, beforeEach } from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+import { compileJSX } from '../../../jsx/src/compiler'
+import { TestAdapter } from '../../../jsx/src/adapters/test-adapter'
+import { renderHonoComponent } from '../../../adapter-hono/src/test-render'
+import { HonoAdapter } from '../../../adapter-hono/src/adapter/hono-adapter'
+import { writeFileSync, mkdtempSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+beforeAll(() => {
+  if (typeof window === 'undefined') GlobalRegistrator.register()
+})
+
+const adapter = new TestAdapter()
+const runtimePath = join(__dirname, '../../src/runtime/index.ts')
+
+const SOURCE = `'use client'
+type SeriesConfig = Record<string, { color: string }>
+
+function Swatch(props: { config: SeriesConfig }) {
+  const handleMount = (el: HTMLElement) => {
+    for (const [key, value] of Object.entries(props.config)) {
+      el.style.setProperty('--color-' + key, value.color)
+    }
+  }
+  return <div ref={handleMount} />
+}
+
+export function Host() {
+  const config: SeriesConfig = {}
+  const series = [{ key: 'a', color: 'red' }, { key: 'b', color: 'blue' }]
+  for (const s of series) config[s.key] = { color: s.color }
+  return <Swatch config={config} />
+}
+`
+
+function clientJsFor(source: string, filename: string): string {
+  const result = compileJSX(source, filename, { adapter })
+  const errors = result.errors.filter(e => e.severity === 'error')
+  if (errors.length > 0) {
+    throw new Error(`Compile errors in ${filename}:\n${errors.map(e => `${e.code}: ${e.message}`).join('\n')}`)
+  }
+  const clientJs = result.files.find(f => f.type === 'clientJs')?.content
+  if (!clientJs) throw new Error(`No client JS for ${filename}`)
+  return clientJs
+    .replace(/from\s+['"]@barefootjs\/client\/runtime['"]/g, `from '${runtimePath}'`)
+    .replace(/^import '\/\* @bf-child:\w+ \*\/'\n/gm, '')
+}
+
+describe('#2910 — loop-mutated const reaches a child prop with its post-mutation value', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  test('the child applies BOTH CSS custom properties the loop populated', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'bf-2910-config-'))
+    const file = join(dir, 'Host.mjs')
+    writeFileSync(file, clientJsFor(SOURCE, 'Host.tsx'))
+    await import(file)
+
+    const ssrHtml = await renderHonoComponent({
+      adapter: new HonoAdapter(),
+      source: SOURCE,
+      props: { __instanceId: 'Host_test' },
+    })
+
+    document.body.innerHTML = ssrHtml
+
+    const { rehydrateAll, flushHydration } = await import(runtimePath)
+    rehydrateAll()
+    flushHydration()
+
+    const div = document.querySelector('div')!
+    expect(div.style.getPropertyValue('--color-a')).toBe('red')
+    expect(div.style.getPropertyValue('--color-b')).toBe('blue')
+  }, 30000)
+})

--- a/packages/client/src/runtime/component.ts
+++ b/packages/client/src/runtime/component.ts
@@ -383,6 +383,32 @@ function materializeComponent(
     _parentScopeId = scopeId
   } else if (slot?.parent) {
     _parentScopeId = slot.parent
+    // A comment wrapper materialized here with a real DESTINATION
+    // (`mountAt`/`rowMount` — the shape `upsertChild`'s CSR-create branch
+    // always produces, e.g. a comment-wrapper component used as an
+    // ordinary named child) is a NESTED/slotted mount, not the top-level
+    // bare mount the `!_parentScopeId` branch below covers (#2910
+    // follow-up — pullfrog review on this PR). Without this,
+    // `wrapperScopeId` stays null, `commentScopeId` below resolves to
+    // null, and this wrapper's proxy never gets a `commentScopeRegistry`
+    // entry — so `ownScopeId()` falls through to the proxy's own `bf-s`
+    // (the wrapped child's scope, not this wrapper's), the exact failure
+    // this PR fixes for hydration, now reached via pure CSR instead.
+    // `derivedScopeId` is this wrapper's own scope identity per the SSR
+    // convention (`${hostScope}_${slotId}`) — it's already computed above
+    // but withheld from `scopeId` for comment wrappers (line 342) because
+    // there's no element of the wrapper's own to stamp it onto; here it
+    // still needs to be registered under, since the wrapped child (this
+    // mount's proxy) doesn't carry it as its own `bf-s`.
+    //
+    // Gated on `mountAt || rowMount` (a real place for the boundary
+    // comments this derivation triggers to land) so a bare mount with a
+    // slot and no destination — #1320's "hoisted-children placeholder
+    // resolves against `slot.parent`" contract, `issue-2757-top-level-
+    // comment-wrapper-scope.test.ts`'s explicitly-pinned "unchanged" case —
+    // keeps returning the bare element instead of a newly-wrapped
+    // DocumentFragment.
+    if (isCommentWrapper && (mountAt || rowMount)) wrapperScopeId = derivedScopeId
   } else if (!_parentScopeId) {
     wrapperScopeId = `${def?.name ?? name}_${generateId()}`
     _parentScopeId = wrapperScopeId

--- a/packages/client/src/runtime/index.ts
+++ b/packages/client/src/runtime/index.ts
@@ -128,6 +128,7 @@ export { styleToCss } from './style.ts'
 
 // Runtime helpers
 export { findScope, find, $, $c, $t, qsa, qsaChildScope, qsaChildScopes, cssEscape, tAfter } from './query.ts'
+export { ownScopeId } from './scope.ts'
 export { date } from './date.ts'
 export { hydrate, rehydrateAll, rehydrateScope, disposeScope, flushHydration, getRegisteredDef } from './hydrate.ts'
 export { registerComponent, getComponentInit, initChild, upsertChild } from './registry.ts'

--- a/packages/client/src/runtime/registry.ts
+++ b/packages/client/src/runtime/registry.ts
@@ -139,7 +139,15 @@ export function upsertChild(
   // Without slotId: name-prefix bf-s scan for top-level component lookup.
   let ssr: HTMLElement | null = null
   if (slotId) {
-    ssr = findSsrScopeBySlotIn(parent, slotId, anchorScope, /* selfMatch */ false)
+    // selfMatch: true — mirrors the CSR/placeholder branch below (`parent`
+    // itself may carry `data-bf-ph`), because the SSR shape has the same
+    // degenerate case: a comment-scoped wrapper whose root IS the deferred
+    // child renders NO wrapper element of its own, so `parent` (the
+    // wrapper's proxy) IS the child's own (bf-h, bf-m)-stamped root, not an
+    // ancestor of it (#2910). Without this, `parent.querySelector(...)`
+    // only searches DESCENDANTS and never matches `parent` itself, so the
+    // deferred child's init never runs.
+    ssr = findSsrScopeBySlotIn(parent, slotId, anchorScope, /* selfMatch */ true)
   } else {
     ssr = parent.querySelector(`[${BF_SCOPE}^="${name}_"]`) as HTMLElement | null
   }

--- a/packages/client/src/runtime/scope.ts
+++ b/packages/client/src/runtime/scope.ts
@@ -43,12 +43,13 @@ export function getPortalScopeId(element: Element): string | null {
  * never the proxy's `bf-s`), so none of them match and the component's
  * `.map()`-produced children silently never initialise.
  *
- * `hydrateCommentScope`, `findCommentChildScope`, and `createComponent`'s
- * top-level CSR mount all register the proxy in `commentScopeRegistry`
- * before running this component's init, so preferring that registration
- * over the raw attribute gives the component its own id in both cases;
- * an element-scoped component (never registered here) falls through to
- * the attribute unchanged.
+ * `hydrateCommentScope`, `findCommentChildScope`, and every CSR-materialize
+ * path through `createComponent` (a bare top-level mount, AND a nested/
+ * slotted mount via `upsertChild`/`upsertChildItem`) register the proxy in
+ * `commentScopeRegistry` before running this component's init, so
+ * preferring that registration over the raw attribute gives the component
+ * its own id in every case; an element-scoped component (never registered
+ * here) falls through to the attribute unchanged.
  */
 export function ownScopeId(element: Element): string | null {
   return commentScopeRegistry.get(element)?.scopeId ?? element.getAttribute(BF_SCOPE)

--- a/packages/client/src/runtime/scope.ts
+++ b/packages/client/src/runtime/scope.ts
@@ -5,7 +5,7 @@
  * Maps an element to its comment node and the sibling range boundary.
  */
 
-import { BF_SCOPE_COMMENT_PREFIX, BF_SCOPE_COMMENT_END_PREFIX, BF_LOOP_ITEM, BF_LOOP_END } from '@barefootjs/shared'
+import { BF_SCOPE, BF_SCOPE_COMMENT_PREFIX, BF_SCOPE_COMMENT_END_PREFIX, BF_LOOP_ITEM, BF_LOOP_END } from '@barefootjs/shared'
 
 /**
  * Information about a comment-based scope.
@@ -27,6 +27,31 @@ export const commentScopeRegistry = new WeakMap<Element, CommentScopeInfo>()
 export function getPortalScopeId(element: Element): string | null {
   const info = commentScopeRegistry.get(element)
   return info?.scopeId ?? null
+}
+
+/**
+ * Resolve the scope id a component's OWN init body should use for
+ * `[bf-h="<id>"]`/`[bf-s$="_<slot>"]` child lookups (#2910).
+ *
+ * A comment-scoped component (a fragment root wrapped in
+ * `<!--bf-scope:-->`, or a root that is itself a single child-component
+ * call, #2649) is mounted on a PROXY element that also carries its own
+ * `bf-s` attribute — but that attribute names the proxy's host/parent
+ * scope, not this component's. Reading it as `__scopeId` makes every
+ * child selector this component builds search for children stamped with
+ * the WRONG id (the compiled child rows carry `bf-h="<comment scope id>"`,
+ * never the proxy's `bf-s`), so none of them match and the component's
+ * `.map()`-produced children silently never initialise.
+ *
+ * `hydrateCommentScope`, `findCommentChildScope`, and `createComponent`'s
+ * top-level CSR mount all register the proxy in `commentScopeRegistry`
+ * before running this component's init, so preferring that registration
+ * over the raw attribute gives the component its own id in both cases;
+ * an element-scoped component (never registered here) falls through to
+ * the attribute unchanged.
+ */
+export function ownScopeId(element: Element): string | null {
+  return commentScopeRegistry.get(element)?.scopeId ?? element.getAttribute(BF_SCOPE)
 }
 
 /**

--- a/packages/jsx/src/__tests__/issue-2910-mutated-const-not-inlined.test.ts
+++ b/packages/jsx/src/__tests__/issue-2910-mutated-const-not-inlined.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Regression tests for #2910 (bug 2): a `const`/`let` binding mutated by a
+ * same-scope statement AFTER its declaration must never be inlined by its
+ * (now stale) declaration-time initializer text wherever the bare
+ * identifier is referenced as a component prop value.
+ *
+ * `const config = {}; for (const s of series) config[s.key] = {...}` is the
+ * `@barefootjs/chart` shape the issue reports: `expandDynamicPropValue`
+ * (`ir-to-client-js/prop-handling.ts`) used to look up `config` in
+ * `ctx.localConstants` and re-embed its initializer text (`"{}"`)
+ * verbatim — a snapshot from BEFORE the mutating `for` loop ran — instead
+ * of a live reference to the `config` binding. `markMutatedConstants`
+ * (analyzer.ts) now flags such bindings `mutatedAfterDeclaration`, and
+ * every inlining consumer checks that flag first.
+ */
+import { describe, expect, test } from 'bun:test'
+import { compileJSX } from '../index.ts'
+import { TestAdapter } from '../adapters/test-adapter.ts'
+
+function clientJsOf(source: string, path: string): string {
+  const result = compileJSX(source, path, { adapter: new TestAdapter() })
+  const errors = result.errors.filter(e => e.severity === 'error')
+  expect(errors).toEqual([])
+  const js = result.files.find(f => f.path.endsWith('.client.js'))?.content
+  if (!js) throw new Error(`no client JS emitted for ${path}`)
+  return js
+}
+
+describe('#2910 — a mutated-after-declaration const is never re-inlined', () => {
+  test('a for-of-loop-mutated object literal reaches the child prop as a live reference', () => {
+    const js = clientJsOf(
+      `'use client'
+function Child(props: { config: Record<string, { color: string }> }) {
+  const handleMount = (el: HTMLElement) => {
+    for (const [k, v] of Object.entries(props.config)) el.style.setProperty('--color-' + k, v.color)
+  }
+  return <div ref={handleMount} />
+}
+
+export function Host() {
+  const config: Record<string, { color: string }> = {}
+  const series = [{ key: 'a', color: 'red' }, { key: 'b', color: 'blue' }]
+  for (const s of series) config[s.key] = { color: s.color }
+  return <Child config={config} />
+}
+`,
+      'host.tsx',
+    )
+
+    expect(js).toContain('get config() { return config }')
+    expect(js).not.toContain('return {}')
+    // The prop can no longer be known statically at template time — the
+    // child render must defer to init (`upsertChild`), not an inline
+    // `initChild(..., { config: {} })` call.
+    expect(js).toContain("upsertChild(__scope, 'Child")
+    expect(js).not.toContain('config: ')
+  })
+
+  test('a reassigned let binding is treated the same as an in-place mutation', () => {
+    const js = clientJsOf(
+      `'use client'
+function Child(props: { label: string }) {
+  return <span>{props.label}</span>
+}
+
+export function Host() {
+  let label = 'initial'
+  if (Math.random() > 0.5) label = 'changed'
+  return <Child label={label} />
+}
+`,
+      'host-let.tsx',
+    )
+
+    expect(js).toContain('get label() { return label }')
+    expect(js).not.toContain("get label() { return 'initial' }")
+  })
+
+  test('a .push()-mutated array reaches the child prop as a live reference', () => {
+    const js = clientJsOf(
+      `'use client'
+function List(props: { items: string[] }) {
+  return <span>{props.items.join(',')}</span>
+}
+
+export function Host() {
+  const items: string[] = []
+  items.push('a')
+  items.push('b')
+  return <List items={items} />
+}
+`,
+      'host-push.tsx',
+    )
+
+    expect(js).toContain('get items() { return items }')
+    expect(js).not.toContain('items: []')
+  })
+
+  test('an untouched object-literal const is still inlined (no regression)', () => {
+    const js = clientJsOf(
+      `'use client'
+function Child(props: { config: Record<string, { color: string }> }) {
+  return <span>{Object.keys(props.config).length}</span>
+}
+
+export function Host() {
+  const config: Record<string, { color: string }> = { a: { color: 'red' }, b: { color: 'blue' } }
+  return <Child config={config} />
+}
+`,
+      'host-literal.tsx',
+    )
+
+    // Never mutated — the existing inlining behaviour is unaffected.
+    expect(js).toContain("config: ({ a: { color: 'red' }, b: { color: 'blue' } })")
+  })
+})

--- a/packages/jsx/src/__tests__/issue-2910-own-scope-id-emission.test.ts
+++ b/packages/jsx/src/__tests__/issue-2910-own-scope-id-emission.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Regression test for #2910 (bug 1): `generateInitFunction` must emit
+ * `const __scopeId = ownScopeId(__scope)` for a comment-scoped root (a
+ * fragment root, or a root that is itself a single child-component call,
+ * #2649) and keep the plain `__scope.getAttribute('bf-s')` read for an
+ * ordinary element-scoped root. See `packages/client/src/runtime/scope.ts`'s
+ * `ownScopeId` for why the two differ: a comment-scoped component is
+ * mounted on a PROXY element whose own `bf-s` names its host/parent scope,
+ * not its own — reading it directly resolves every `.map()`-produced
+ * child lookup (`[bf-h="${__scopeId}"]`) against the wrong id.
+ */
+import { describe, expect, test } from 'bun:test'
+import { compileJSX } from '../index.ts'
+import { TestAdapter } from '../adapters/test-adapter.ts'
+
+function clientJsOf(source: string, path: string): string {
+  const result = compileJSX(source, path, { adapter: new TestAdapter() })
+  const errors = result.errors.filter(e => e.severity === 'error')
+  expect(errors).toEqual([])
+  const js = result.files.find(f => f.path.endsWith('.client.js'))?.content
+  if (!js) throw new Error(`no client JS emitted for ${path}`)
+  return js
+}
+
+describe('#2910 — __scopeId reads the comment-scope registry for a comment-scoped root', () => {
+  test('root is a single child-component call (#2649 shape) uses ownScopeId', () => {
+    const js = clientJsOf(
+      `'use client'
+function Panel(props: { children?: unknown }) {
+  return <div className="panel">{props.children}</div>
+}
+
+export function Host() {
+  return <Panel><span>hi</span></Panel>
+}
+`,
+      'host.tsx',
+    )
+
+    expect(js).toContain('function initHost')
+    const initHost = js.slice(js.indexOf('function initHost'))
+    expect(initHost).toContain('const __scopeId = ownScopeId(__scope)')
+    expect(initHost).not.toContain("__scope.getAttribute('bf-s')")
+  })
+
+  test('an ordinary element-scoped root keeps reading the bf-s attribute directly', () => {
+    const js = clientJsOf(
+      `'use client'
+function Leaf(props: { label: string }) {
+  return <span>{props.label}</span>
+}
+
+export function Host() {
+  return <div className="panel"><Leaf label="hi" /></div>
+}
+`,
+      'host-plain.tsx',
+    )
+
+    const initHost = js.slice(js.indexOf('function initHost'))
+    expect(initHost).toContain("const __scopeId = __scope.getAttribute('bf-s')")
+    expect(initHost).not.toContain('ownScopeId')
+  })
+})

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -1806,6 +1806,7 @@ function collectInitStatement(node: ts.Statement, ctx: AnalyzerContext): void {
     loc: getSourceLocation(node, ctx.sourceFile, ctx.filePath),
     freeIdentifiers: extractFreeIdentifiersFromNode(node),
     assignedIdentifiers: extractAssignedIdentifiersFromNode(node),
+    mutatedIdentifiers: extractMutatedIdentifiersFromNode(node),
     // Init statements run inside the component's init function, so they
     // belong to `init` scope. Phase is conservatively `hydrate` (run-once
     // at hydration). relocate() can refine this when consuming the field.
@@ -1896,28 +1897,8 @@ function extractAssignedIdentifiersFromNode(node: ts.Node): Set<string> {
     ) {
       return
     }
-    if (ts.isBinaryExpression(n)) {
-      const op = n.operatorToken.kind
-      if (
-        op === ts.SyntaxKind.EqualsToken ||
-        op === ts.SyntaxKind.PlusEqualsToken ||
-        op === ts.SyntaxKind.MinusEqualsToken ||
-        op === ts.SyntaxKind.AsteriskEqualsToken ||
-        op === ts.SyntaxKind.SlashEqualsToken ||
-        op === ts.SyntaxKind.PercentEqualsToken ||
-        op === ts.SyntaxKind.AsteriskAsteriskEqualsToken ||
-        op === ts.SyntaxKind.AmpersandEqualsToken ||
-        op === ts.SyntaxKind.BarEqualsToken ||
-        op === ts.SyntaxKind.CaretEqualsToken ||
-        op === ts.SyntaxKind.LessThanLessThanEqualsToken ||
-        op === ts.SyntaxKind.GreaterThanGreaterThanEqualsToken ||
-        op === ts.SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken ||
-        op === ts.SyntaxKind.AmpersandAmpersandEqualsToken ||
-        op === ts.SyntaxKind.BarBarEqualsToken ||
-        op === ts.SyntaxKind.QuestionQuestionEqualsToken
-      ) {
-        addFromTarget(n.left)
-      }
+    if (ts.isBinaryExpression(n) && isAssignmentOperator(n.operatorToken.kind)) {
+      addFromTarget(n.left)
     }
     if (ts.isPrefixUnaryExpression(n) || ts.isPostfixUnaryExpression(n)) {
       if (
@@ -1938,6 +1919,126 @@ function extractAssignedIdentifiersFromNode(node: ts.Node): Set<string> {
   for (const name of localDecls) ids.delete(name)
 
   return ids
+}
+
+/**
+ * Method names that mutate their receiver in place. Used only to recognise
+ * `<root>.<method>(...)` calls as mutating the root identifier (#2910) —
+ * NOT to model array/collection semantics generally, so this stays a small,
+ * explicit catalogue rather than a heuristic over every possible method.
+ */
+const MUTATING_METHOD_NAMES: ReadonlySet<string> = new Set([
+  'push', 'pop', 'shift', 'unshift', 'splice', 'sort', 'reverse', 'fill', 'copyWithin',
+  'set', 'add', 'delete', 'clear',
+])
+
+/**
+ * Collect identifiers mutated IN PLACE by a statement — a property/element
+ * write (`config[k] = …`, `config.a.b += 1`), an `Object.assign(config, …)`
+ * call, or a call to a known mutating method on the receiver
+ * (`items.push(...)`) — as opposed to `extractAssignedIdentifiersFromNode`,
+ * which only tracks reassignment of the BINDING itself (#2910).
+ *
+ * This distinction matters because `expandDynamicPropValue` /
+ * `expandConstantForReactivity` (`ir-to-client-js/prop-handling.ts`) inline
+ * a `localConstants` entry's DECLARATION-TIME initializer text wherever the
+ * bare identifier is referenced. A `const config = {}` later populated by
+ * `for (const s of series) config[s.key] = {...}` never reassigns `config`
+ * itself — `extractAssignedIdentifiersFromNode` (correctly) reports no
+ * assigned identifiers, since `config[s.key] = …` doesn't create an
+ * implicit global — but the compiler must still know `config`'s value is
+ * no longer just `{}` by the time this statement has run, so a consumer
+ * that inlines the stale literal (instead of referencing the live `config`
+ * binding) silently drops everything the mutation was supposed to do. See
+ * `ConstantInfo.mutatedAfterDeclaration` for where this is consumed.
+ */
+function extractMutatedIdentifiersFromNode(node: ts.Node): Set<string> {
+  const ids = new Set<string>()
+
+  function rootIdentifierOf(expr: ts.Expression): string | null {
+    let current: ts.Expression = expr
+    while (true) {
+      if (ts.isIdentifier(current)) return current.text
+      if (ts.isParenthesizedExpression(current)) { current = current.expression; continue }
+      if (ts.isNonNullExpression(current)) { current = current.expression; continue }
+      if (ts.isPropertyAccessExpression(current)) { current = current.expression; continue }
+      if (ts.isElementAccessExpression(current)) { current = current.expression; continue }
+      return null
+    }
+  }
+
+  function visit(n: ts.Node): void {
+    // Same init/sub-init boundary as `extractAssignedIdentifiersFromNode`:
+    // a mutation inside a nested function literal doesn't run at init time.
+    if (
+      ts.isArrowFunction(n) ||
+      ts.isFunctionExpression(n) ||
+      ts.isFunctionDeclaration(n) ||
+      ts.isMethodDeclaration(n) ||
+      ts.isGetAccessorDeclaration(n) ||
+      ts.isSetAccessorDeclaration(n) ||
+      ts.isConstructorDeclaration(n)
+    ) {
+      return
+    }
+
+    if (ts.isBinaryExpression(n) && isAssignmentOperator(n.operatorToken.kind)) {
+      if (ts.isPropertyAccessExpression(n.left) || ts.isElementAccessExpression(n.left)) {
+        const root = rootIdentifierOf(n.left)
+        if (root) ids.add(root)
+      }
+    } else if (ts.isPrefixUnaryExpression(n) || ts.isPostfixUnaryExpression(n)) {
+      const isIncDec = n.operator === ts.SyntaxKind.PlusPlusToken || n.operator === ts.SyntaxKind.MinusMinusToken
+      if (isIncDec && (ts.isPropertyAccessExpression(n.operand) || ts.isElementAccessExpression(n.operand))) {
+        const root = rootIdentifierOf(n.operand)
+        if (root) ids.add(root)
+      }
+    } else if (ts.isCallExpression(n)) {
+      const callee = n.expression
+      if (ts.isPropertyAccessExpression(callee)) {
+        const methodName = callee.name.text
+        if (MUTATING_METHOD_NAMES.has(methodName)) {
+          const root = rootIdentifierOf(callee.expression)
+          if (root) ids.add(root)
+        } else if (
+          methodName === 'assign' &&
+          ts.isIdentifier(callee.expression) &&
+          callee.expression.text === 'Object' &&
+          n.arguments.length > 0
+        ) {
+          // `Object.assign(target, ...)` mutates `target` in place.
+          const root = rootIdentifierOf(n.arguments[0])
+          if (root) ids.add(root)
+        }
+      }
+    }
+
+    ts.forEachChild(n, visit)
+  }
+
+  visit(node)
+  return ids
+}
+
+function isAssignmentOperator(kind: ts.SyntaxKind): boolean {
+  return (
+    kind === ts.SyntaxKind.EqualsToken ||
+    kind === ts.SyntaxKind.PlusEqualsToken ||
+    kind === ts.SyntaxKind.MinusEqualsToken ||
+    kind === ts.SyntaxKind.AsteriskEqualsToken ||
+    kind === ts.SyntaxKind.SlashEqualsToken ||
+    kind === ts.SyntaxKind.PercentEqualsToken ||
+    kind === ts.SyntaxKind.AsteriskAsteriskEqualsToken ||
+    kind === ts.SyntaxKind.AmpersandEqualsToken ||
+    kind === ts.SyntaxKind.BarEqualsToken ||
+    kind === ts.SyntaxKind.CaretEqualsToken ||
+    kind === ts.SyntaxKind.LessThanLessThanEqualsToken ||
+    kind === ts.SyntaxKind.GreaterThanGreaterThanEqualsToken ||
+    kind === ts.SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken ||
+    kind === ts.SyntaxKind.AmpersandAmpersandEqualsToken ||
+    kind === ts.SyntaxKind.BarBarEqualsToken ||
+    kind === ts.SyntaxKind.QuestionQuestionEqualsToken
+  )
 }
 
 /**
@@ -3899,6 +4000,11 @@ function validateContext(ctx: AnalyzerContext): void {
     }
   }
 
+  // A same-scope statement (typically a `for`/`while` loop) may mutate a
+  // `localConstants` binding after its declaration — flag those bindings so
+  // downstream inlining never re-embeds their stale initializer text (#2910).
+  markMutatedConstants(ctx)
+
   // BF052: init statements that write to an identifier with no visible
   // declaration cause a ReferenceError in ESM strict mode. Flag them
   // at compile time instead of shipping broken client JS. (#933)
@@ -4160,6 +4266,35 @@ function fileHasUseClientDirective(filePath: string): boolean {
   }
   visit(sf)
   return found
+}
+
+/**
+ * Flag every `localConstants` entry a same-scope init statement mutates
+ * after its declaration (#2910) — see `ConstantInfo.mutatedAfterDeclaration`
+ * for why this matters and who reads it. Runs once, after the whole
+ * component (and module-level) body has been walked, since the mutating
+ * statement is a SEPARATE statement from the declaration and may follow it
+ * by any number of lines.
+ *
+ * Deliberately keyed off BOTH `mutatedIdentifiers` (in-place writes) and
+ * `assignedIdentifiers` (whole-binding reassignment, e.g. a `let` later
+ * written to): both leave `ConstantInfo.value` stale, and
+ * `expandDynamicPropValue` inlines `value` for `let` bindings exactly the
+ * same way it does for `const`.
+ */
+function markMutatedConstants(ctx: AnalyzerContext): void {
+  if (ctx.initStatements.length === 0 || ctx.localConstants.length === 0) return
+
+  const mutatedNames = new Set<string>()
+  for (const stmt of ctx.initStatements) {
+    if (stmt.mutatedIdentifiers) for (const name of stmt.mutatedIdentifiers) mutatedNames.add(name)
+    if (stmt.assignedIdentifiers) for (const name of stmt.assignedIdentifiers) mutatedNames.add(name)
+  }
+  if (mutatedNames.size === 0) return
+
+  for (const constant of ctx.localConstants) {
+    if (mutatedNames.has(constant.name)) constant.mutatedAfterDeclaration = true
+  }
 }
 
 function validateInitStatementReferences(ctx: AnalyzerContext): void {

--- a/packages/jsx/src/ir-to-client-js/compute-inlinability.ts
+++ b/packages/jsx/src/ir-to-client-js/compute-inlinability.ts
@@ -113,6 +113,12 @@ export type ConstantInlinability =
   /** After chained-ref resolution, the inlined value still mentions
    *  a name classified unsafe above. Transitive demotion. */
   | { kind: 'depends-on-unsafe' }
+  /** A same-scope statement mutates this binding's value after its
+   *  declaration (`ConstantInfo.mutatedAfterDeclaration`, #2910) — e.g.
+   *  `const config = {}; for (...) config[k] = ...`. `value` is a
+   *  pre-mutation snapshot; inlining it anywhere would silently drop
+   *  the mutation, so this is unsafe exactly like an init-local. */
+  | { kind: 'mutated-after-declaration' }
 
 export type FunctionInlinability =
   /** Module-scope function that does NOT touch component internals —
@@ -339,7 +345,7 @@ function populateCsrInlinable(ctx: ClientJsContext, relocateEnv: RelocateEnv, ge
   // call-kind entry (`buildEnvWithConsts`'s Map spread puts `constSubs`
   // last) — the literal `(undefined)()` this issue is about (#2778).
   for (const c of ctx.localConstants) {
-    if (c.isJsx || !c.value || c.containsArrow || c.systemConstructKind || getterAliases.has(c.name)) {
+    if (c.isJsx || !c.value || c.containsArrow || c.systemConstructKind || c.mutatedAfterDeclaration || getterAliases.has(c.name)) {
       ctx.csrInlinable.set(c.name, null)
       finalised.add(c.name)
     }
@@ -626,6 +632,7 @@ function classifyConstantInitial(
 ): { status: ConstantInlinability; decisions: RelocateDecision[] } {
   if (c.isJsx) return { status: { kind: 'jsx-inline' }, decisions: [] }
   if (!c.value) return { status: { kind: 'placeholder-let' }, decisions: [] }
+  if (c.mutatedAfterDeclaration) return { status: { kind: 'mutated-after-declaration' }, decisions: [] }
   if (c.containsArrow) return { status: { kind: 'arrow-literal' }, decisions: [] }
   if (c.systemConstructKind) return { status: { kind: 'system-construct' }, decisions: [] }
   // A multi-hop alias chain to a getter (`const a = items; const b = a`)

--- a/packages/jsx/src/ir-to-client-js/emit-registration.ts
+++ b/packages/jsx/src/ir-to-client-js/emit-registration.ts
@@ -6,7 +6,7 @@
 
 import type { ComponentIR, IRFragment, IRNode, ReferencesGraph, SignalInfo } from '../types.ts'
 import type { ClientJsContext } from './types.ts'
-import { PROPS_PARAM } from './utils.ts'
+import { PROPS_PARAM, isCommentScopedRoot } from './utils.ts'
 import { computeInlinability, toLegacyInlinability } from './compute-inlinability.ts'
 import { canGenerateStaticTemplate, irToComponentTemplate, generateCsrTemplate, createStringProtector } from './html-template.ts'
 import { markupSlotIdsOf } from './markup-slots.ts'
@@ -215,7 +215,7 @@ export function emitRegistrationAndHydration(
   //     DOM presence of its own, and `materializeComponent` must leave
   //     `scopeId` null so it doesn't stamp over (or duplicate) the child's.
   const isFragmentRoot = _ir.root.type === 'fragment' && !!(_ir.root as IRFragment).needsScopeComment
-  const isCommentScope = isFragmentRoot || _ir.root.type === 'component'
+  const isCommentScope = isCommentScopedRoot(_ir.root)
 
   // Build ComponentDef object for hydrate()
   const defParts: string[] = [`init: init${name}`]

--- a/packages/jsx/src/ir-to-client-js/generate-init.ts
+++ b/packages/jsx/src/ir-to-client-js/generate-init.ts
@@ -10,7 +10,7 @@
 
 import type { ComponentIR } from '../types.ts'
 import type { ClientJsContext } from './types.ts'
-import { PROPS_PARAM } from './utils.ts'
+import { PROPS_PARAM, isCommentScopedRoot } from './utils.ts'
 import { buildReferencesGraph } from './build-references.ts'
 import { computePropUsage } from './compute-prop-usage.ts'
 import { IMPORT_PLACEHOLDER, MODULE_CONSTANTS_PLACEHOLDER } from './imports.ts'
@@ -44,7 +44,21 @@ export function generateInitFunction(
   // Host scope id for (bf-h, bf-m) child lookups inside this init body
   // (#1249). Compile-time selectors emit
   // `[bf-h="${__scopeId}"][bf-m="<slotId>"]` against this value.
-  lines.push(`  const __scopeId = __scope.getAttribute('${BF_SCOPE}')`)
+  //
+  // A comment-scoped root (`comment: true` — a `needsScopeComment` fragment
+  // root, or a root that is itself a single child-component call, #2649) is
+  // mounted on a PROXY element whose OWN `bf-s` attribute names its
+  // host/parent scope, not this component's — this component's real id
+  // lives in the comment-scope registry the proxy was registered under
+  // (`ownScopeId`, #2910). Reading the raw attribute there resolves to the
+  // wrong id, so every `.map()`-produced child this component's init tries
+  // to find via `[bf-h="${__scopeId}"]` silently matches nothing. An
+  // element-scoped root keeps reading the attribute directly.
+  lines.push(
+    isCommentScopedRoot(ir.root)
+      ? `  const __scopeId = ownScopeId(__scope)`
+      : `  const __scopeId = __scope.getAttribute('${BF_SCOPE}')`,
+  )
   lines.push('')
 
   // --- Analysis: one graph, many queries; scope routing as data ---

--- a/packages/jsx/src/ir-to-client-js/imports.ts
+++ b/packages/jsx/src/ir-to-client-js/imports.ts
@@ -61,6 +61,12 @@ export const RUNTIME_IMPORT_CANDIDATES = [
   // rewrite targets `formatDate(recv, pattern, tz)`, so the emitted code
   // needs the runtime export when the component didn't import it itself.
   'formatDate',
+  // A comment-scoped component's own scope id (#2910) — reads the
+  // `commentScopeRegistry` entry the proxy element was registered under
+  // (falling back to its `bf-s` attribute for an element-scoped root), so
+  // `[bf-h="${__scopeId}"]` child lookups target THIS component's children
+  // rather than the proxy's host/parent scope. See `generate-init.ts`.
+  'ownScopeId',
 ] as const
 
 /** @deprecated Use RUNTIME_IMPORT_CANDIDATES */

--- a/packages/jsx/src/ir-to-client-js/index.ts
+++ b/packages/jsx/src/ir-to-client-js/index.ts
@@ -256,6 +256,12 @@ function hasInitScopeOnlyConstant(ctx: ClientJsContext): boolean {
   for (const c of ctx.localConstants) {
     if (c.isModule || c.isJsx || c.containsArrow || c.systemConstructKind) continue
     if (!c.value) continue
+    // A mutated binding's value is a pre-mutation snapshot (#2910) —
+    // `isInlinableInTemplate` would happily pass a value like `{}` that
+    // looks safe on its own, but the mutating statement that gives it its
+    // real value only runs in init scope, so the const needs init scope
+    // exactly as if the value itself had failed the check.
+    if (c.mutatedAfterDeclaration) return true
     if (!isInlinableInTemplate(c.value, env).ok) return true
   }
   return false

--- a/packages/jsx/src/ir-to-client-js/prop-handling.ts
+++ b/packages/jsx/src/ir-to-client-js/prop-handling.ts
@@ -113,6 +113,11 @@ export function expandDynamicPropValue(value: string, ctx: ClientJsContext, scop
   if (scope?.isBound(trimmedValue)) return value
 
   const constant = ctx.localConstants.find((c) => c.name === trimmedValue)
+  // A binding mutated after its declaration (#2910) has no compile-time
+  // value — `constant.value` is a snapshot from BEFORE the mutation ran.
+  // Re-embedding it here would silently drop the mutation; keep the bare
+  // reference instead so the emitted getter reads the LIVE binding.
+  if (constant?.mutatedAfterDeclaration) return value
   if (constant && constant.value) {
     return constant.value
   }
@@ -156,6 +161,10 @@ export function expandConstantForReactivity(
   if (scope?.isBound(trimmedValue)) return { expr, freeIds: originalFreeIds }
 
   const constant = ctx.localConstants.find((c) => c.name === trimmedValue)
+  // See `expandDynamicPropValue`'s matching guard (#2910): a mutated
+  // binding's `value` is a stale pre-mutation snapshot, so it must not be
+  // substituted in place of a live reference.
+  if (constant?.mutatedAfterDeclaration) return { expr, freeIds: originalFreeIds }
   if (constant && constant.value) {
     return { expr: constant.value, freeIds: constant.freeIdentifiers }
   }

--- a/packages/jsx/src/ir-to-client-js/utils.ts
+++ b/packages/jsx/src/ir-to-client-js/utils.ts
@@ -4,7 +4,7 @@
  */
 
 import ts from 'typescript'
-import type { AttrValue, IRTemplatePart, LoopParamBinding, FreeReference, IRNode } from '../types.ts'
+import type { AttrValue, IRTemplatePart, LoopParamBinding, FreeReference, IRNode, IRFragment, ComponentIR } from '../types.ts'
 import type { TopLevelLoop, BranchLoop, LoopOffset } from './types.ts'
 import { buildLoopChainExpr } from '../loop-chain.ts'
 import { templatePartsToJsExpr } from '../template-parts.ts'
@@ -35,6 +35,20 @@ export { DATA_KEY, DATA_KEY_PREFIX, DATA_BF_PH, BF_LOOP_START, BF_LOOP_END, loop
  * Short name to minimize client JS bundle size.
  */
 export const PROPS_PARAM = '_p'
+
+/**
+ * True when the component's rendered root is a comment-scoped proxy rather
+ * than an element carrying its own `bf-s`/`bf-h` scope id directly — the
+ * `comment: true` def flag's condition (`emit-registration.ts`), computed
+ * here so `generate-init.ts` can decide the SAME thing before that phase
+ * runs (#2910). Two shapes share this: a genuine `needsScopeComment`
+ * fragment root (SSR wraps it in `<!--bf-scope:-->`) and a root that is
+ * itself a single child-component call (`root.type === 'component'`, #2649)
+ * — the wrapping comment marks a scope with no DOM presence of its own.
+ */
+export function isCommentScopedRoot(root: ComponentIR['root']): boolean {
+  return (root.type === 'fragment' && !!(root as IRFragment).needsScopeComment) || root.type === 'component'
+}
 
 /**
  * Get the data-key attribute name for a given loop depth.

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -6816,6 +6816,9 @@ function tryResolveTemplateSpanFromConst(
     if (ctx.scope.isBound(expr.text)) return null
     const constInfo = findLocalConst(expr.text, ctx.analyzer)
     if (!constInfo) return null
+    // #2910: see `tryResolveIdentifierAsTemplateLiteral`'s matching guard —
+    // a binding mutated after its declaration has no compile-time value.
+    if (constInfo.mutatedAfterDeclaration) return null
     const ast = parseConstInitializer(constInfo)
     if (!ast) return null
     if (ts.isStringLiteral(ast) || ts.isNoSubstitutionTemplateLiteral(ast)) {
@@ -6833,6 +6836,8 @@ function tryResolveTemplateSpanFromConst(
     if (ctx.scope.isBound(expr.expression.text)) return null
     const constInfo = findLocalConst(expr.expression.text, ctx.analyzer)
     if (!constInfo) return null
+    // #2910: see `tryResolveIdentifierAsTemplateLiteral`'s matching guard.
+    if (constInfo.mutatedAfterDeclaration) return null
     const ast = parseConstInitializer(constInfo)
     if (!ast || !ts.isObjectLiteralExpression(ast)) return null
     const cases: Record<string, string> = {}
@@ -7011,6 +7016,15 @@ function tryResolveIdentifierAsTemplateLiteral(
   if (ctx.scope.isBound(ident.text)) return null
   const constInfo = findLocalConst(ident.text, ctx.analyzer)
   if (!constInfo) return null
+  // #2910: a binding mutated after its declaration has no compile-time
+  // value — baking its DECLARATION-TIME literal into the IR here would
+  // freeze the attribute at a pre-mutation snapshot, permanently invisible
+  // to `ir-to-client-js`'s own `mutatedAfterDeclaration` guard (which only
+  // sees this attribute AFTER it has already been resolved to a literal
+  // `template` AttrValue, too late to intervene). Falling through to
+  // `null` here keeps the attribute a plain `expression`, so the runtime
+  // reference stays live.
+  if (constInfo.mutatedAfterDeclaration) return null
   const ast = parseConstInitializer(constInfo)
   if (!ast) return null
 

--- a/packages/jsx/src/types.ts
+++ b/packages/jsx/src/types.ts
@@ -1737,6 +1737,17 @@ export interface InitStatementInfo {
    */
   assignedIdentifiers?: Set<string>
   /**
+   * Identifiers mutated IN PLACE by this statement — a property/element
+   * write (`config[k] = …`), a known mutating method call
+   * (`items.push(...)`), or `Object.assign(target, …)` — as opposed to
+   * `assignedIdentifiers`, which tracks reassignment of the binding
+   * itself. Read by `markMutatedConstants` (analyzer.ts) to flag the
+   * matching `ConstantInfo.mutatedAfterDeclaration` (#2910): a `const`
+   * whose value is later mutated this way can no longer be treated as
+   * equal to its declaration-time initializer text.
+   */
+  mutatedIdentifiers?: Set<string>
+  /**
    * When true, the emitted statement must be prefixed with `;` to defeat
    * ASI fusion with the previous line. Tracked in IR rather than recovered
    * by emit-time text inspection — losing this is the failure mode behind
@@ -1984,6 +1995,26 @@ export interface ConstantInfo {
   isJsxFunction?: boolean
   /** When true, the initializer contains an arrow function or function expression (computed from AST). */
   containsArrow?: boolean
+  /**
+   * When true, a same-scope statement (a `for`/`while` body, or any other
+   * imperative statement) mutates this binding's value AFTER its
+   * declaration — in place (`config[k] = …`, `items.push(...)`) or by
+   * reassigning the binding itself (`let`, later `x = …`) — so `value`
+   * (the declaration's initializer text) no longer reflects what the
+   * binding actually holds by the time the rest of the component runs
+   * (#2910). Set by `markMutatedConstants` (analyzer.ts) from
+   * `InitStatementInfo.mutatedIdentifiers`/`assignedIdentifiers`.
+   *
+   * Every consumer that would otherwise re-inline `value` verbatim in
+   * place of a bare reference to `name` — `expandDynamicPropValue`,
+   * `expandConstantForReactivity`, CSR template inlining
+   * (`compute-inlinability.ts`), and `hasInitScopeOnlyConstant` — must
+   * check this first and fall back to a live reference to the binding
+   * instead. Skipping this check re-embeds a snapshot of the value from
+   * BEFORE the mutation ran, silently dropping everything the mutation
+   * was supposed to do.
+   */
+  mutatedAfterDeclaration?: boolean
   /** The kind of system construct, if the initializer is createContext() or new WeakMap(). */
   systemConstructKind?: 'createContext' | 'weakMap'
   /** Value with destructured prop refs rewritten to _p.propName, for template inlining. */

--- a/spec/compiler.md
+++ b/spec/compiler.md
@@ -370,6 +370,24 @@ rendered outside the compiler pipeline. See piconic-ai/barefootjs#1915.
    the scope's own addressable id used by portals (`bf-po`), context
    lookups, and the hydration walker — but **not** slot identity.
 
+   **A comment-scoped component resolves its own id via the comment
+   registry, not its proxy's `bf-s` (#2910).** A component whose root is a
+   `needsScopeComment` fragment or itself a single child-component call
+   (#2649) is mounted on a PROXY element — the wrapped child's own rendered
+   root, not an element the wrapper owns. That proxy's `bf-s` attribute
+   names the PROXY's (i.e. the wrapped child's) scope, not the wrapping
+   component's. `generateInitFunction` (`ir-to-client-js/generate-init.ts`)
+   therefore emits `const __scopeId = ownScopeId(__scope)` for such a root
+   instead of `__scope.getAttribute('bf-s')` — `ownScopeId`
+   (`packages/client/src/runtime/scope.ts`) reads the id `hydrateCommentScope`
+   / `findCommentChildScope` / `createComponent`'s top-level CSR mount all
+   register in `commentScopeRegistry` BEFORE running this component's init,
+   falling back to the raw attribute for an ordinary element-scoped root
+   (never registered there). Skipping this resolves every `[bf-h="<id>"]`
+   child lookup the component's own init builds — including a `.map()`-
+   produced child's static-array lookup — against the wrong id, so those
+   children silently never initialise.
+
    **Loop item root (#2833).** A loop item root does not DERIVE its `bf-s`
    from its slot (see "Pass `_bf_slot` for slotted children" below), but it
    still carries `(bf-h, bf-m)` slot identity like any other slotted child —


### PR DESCRIPTION
## Summary

Fixes #2910. Two independent bugs combine to make `@barefootjs/chart`'s `LineChart`/`Line` silently fail to render when a chart's series/config are built dynamically instead of as static JSX/object literals:

1. **A `.map()`-produced child component nested below a comment-scoped wrapper never initialised on hydration.** When a component's root is itself a single child-component call (`root.type === 'component'`, #2649 — e.g. `<ChartContainer><LineChart>{series.map(s => <Line/>)}</LineChart></ChartContainer>`), that component is mounted on a PROXY element: the rendered child's own root, not an element the wrapper itself owns. The wrapper's own `init` function resolved `__scopeId` by reading that proxy's `bf-s` attribute — which names the PROXY's (i.e. the rendered child's) own scope, not the wrapper's — so every `[bf-h="${__scopeId}"]` child lookup its init built searched for the wrong id, and `.map()`-produced children (in the chart's case, every `<Line>`) silently never initialised. In the real chart this meant `Line` never called `registerBar`, so `LineChart`'s scale never saw any series and every `<path>`'s `d` attribute stayed empty.

   Fixed with a new `ownScopeId` runtime helper (`packages/client/src/runtime/scope.ts`) that reads the id the comment-scope registry recorded during hydration instead of the proxy's own attribute; `generateInitFunction` now emits `ownScopeId(__scope)` for a comment-scoped root instead of the raw `getAttribute` read. Fixing this surfaced a second, closely related gap: `upsertChild`'s SSR lookup (`registry.ts`) needed `selfMatch: true` for the degenerate case where the deferred child IS the wrapper's own proxy element (the exact shape `<ChartContainer config={config}>` hits, since `ChartContainer` is `ReproBroken`'s own root).

2. **A `const` mutated in place after its declaration was re-inlined by its stale, pre-mutation value.** `const config = {}; for (const s of series) config[s.key] = {...}` never reassigns `config` itself, so the analyzer's existing "assigned identifiers" tracking correctly reported nothing — but `expandDynamicPropValue`/`expandConstantForReactivity` (`ir-to-client-js/prop-handling.ts`) and an earlier Phase‑1 constant-folding path (`jsx-to-ir.ts`'s `tryResolveIdentifierAsTemplateLiteral` / `tryResolveTemplateSpanFromConst`) both re-embedded the constant's DECLARATION-TIME initializer text (`"{}"`) wherever the bare `config` identifier was referenced as a prop — a snapshot from before the mutating loop ran. `ChartContainer`'s `applyChartCSSVariables(el, props.config)` therefore always received `{}`, so `--color-*` CSS custom properties were never set.

   Fixed by a new `markMutatedConstants` analyzer pass that flags a `localConstants` entry `mutatedAfterDeclaration` whenever a same-scope statement mutates it in place (`config[k] = ...`, `items.push(...)`, `Object.assign(config, ...)`) or reassigns it (`let x = ...; x = ...`). Every consumer that would otherwise inline the stale value now falls back to a live reference to the binding instead.

Also noted in the issue (array destructuring inside a `"use client"` component producing a runtime-crashing SSR output) is a separate bug the reporter said they'd file independently — not addressed here.

## Design

Investigated with an Explore agent, then the fix approach was designed by Fable before implementation, per the design doc produced for this PR (analyzer flag placement, the `ownScopeId` runtime helper, and the `upsertChild` `selfMatch` gap). One additional runtime gap (`upsertChild`'s `selfMatch`) was found and fixed during implementation/verification once end-to-end hydration tests exposed it — the design's proposed fix (`ownScopeId` alone) resolved the `__scopeId` computation but a REAL happy-dom hydration test then caught this second, adjacent bug in the deferred-child lookup.

## Verification

- Compiled the issue's exact repro against the real `ui/components/ui/chart` source and confirmed the emitted client JS now reads `config` live and resolves `__scopeId` via `ownScopeId`.
- Two new end-to-end regression tests (`packages/client/__tests__/runtime/issue-2910-*.test.ts`) compile real source through the real compiler, render real Hono SSR HTML, hydrate with the real `@barefootjs/client` runtime (happy-dom), and assert on real DOM state — confirmed each fails without its corresponding fix and passes with it.
- Two new compiler unit tests (`packages/jsx/src/__tests__/issue-2910-*.test.ts`) pin the analyzer/codegen decisions directly (mutated-const detection across `for`-loop/`.push()`/`let`-reassignment shapes, and the `__scopeId` emission choice for comment-scoped vs. element-scoped roots).
- Full suites run clean: `packages/jsx/src/__tests__` (3361 pass, same 5 pre-existing unrelated failures — confirmed present on `main` before this change, a TS-checker environment issue unrelated to this diff), `packages/client/__tests__` (710 pass, 0 fail), `packages/adapter-tests` (2532 pass, 0 fail, 5 skip — matches baseline), including the subset-conformance `coverage-map.test.ts` floor test.
- `ui/components/ui/chart/index.test.tsx` (53 pass) unaffected — the chart component source itself is unchanged.

## Test plan

- [x] `bun test packages/jsx/src/__tests__`
- [x] `bun test packages/client/__tests__`
- [x] `bun test packages/adapter-tests`
- [x] `bun test ui/components/ui/chart/index.test.tsx`
- [x] Compiled the issue's exact repro against the real chart source and manually inspected the emitted client JS

## Scope notes

This PR fixes the client/hydration-side manifestation described in the issue (the CSS custom properties and line-path drawing are entirely client-side effects). It does not additionally teach the SSR adapters (`jsx-adapter.ts`) to run a mutating init statement inside the server-rendered component body — the SSR-rendered HTML/embedded hydration-props JSON for a mutated const still reflects its pre-mutation value, but this is superseded once hydration re-runs the mutating statement client-side (verified in the end-to-end tests above), so it does not reproduce the reported symptom. Widening the SSR emission additionally is a larger, separate change (would require regenerating `expectedHtml` across the whole fixture corpus per the repo's fixture-drift rules) and is left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYQ6yKVxVmUYoyHa6x9aYN

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYQ6yKVxVmUYoyHa6x9aYN)_