### PR TITLE
Fix #2805: Go template adapter delivers dynamic jsx-children props into a child's rest bag

### DIFF
--- a/.changeset/restbag-dynamic-prop-delivery.md
+++ b/.changeset/restbag-dynamic-prop-delivery.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/go-template": patch
+---
+
+The Go template adapter now delivers a dynamic (non-bakeable) named jsx-children prop into a child component's rest bag — a prop the child only reads via its `{ ...rest }` binding rather than a declared param (e.g. `function Card({ children, ...rest }) { ... rest.header ... }`) — instead of refusing with a loud BF101. A new runtime helper (`WithBagEntry`/`bf_with_bag`, `runtime/bf.go`) sets one entry in the rest bag's `map[string]any` field on a per-call-site copy of the child's props, mirroring `WithProps`/`bf_with_props`'s existing per-declared-field delivery. The rest-bag field is also now emitted on both the child's Input and Props structs whenever the component destructures a rest binding at all, not only when it's also spread onto an element — a prerequisite gap the static bake path had too (#2805).

--- a/packages/adapter-go-template/runtime/bf.go
+++ b/packages/adapter-go-template/runtime/bf.go
@@ -199,6 +199,12 @@ func FuncMap() template.FuncMap {
 		// bf_with_children.
 		"bf_with_props": WithProps,
 
+		// Per-row/per-slot override of ONE entry in a child's rest-bag field
+		// (#2805) — the dynamic-delivery route for a jsx-children prop that
+		// only reaches the child through its `{ ...rest }` binding, which
+		// bf_with_props cannot target (no named struct field exists for it).
+		"bf_with_bag": WithBagEntry,
+
 		// Per-row props for a child whose CONSTRUCTOR derives a field from
 		// the overridden prop (#2448). bf_with_props patches fields on the
 		// shared instance and cannot re-run New<Child>Props, so a memo body
@@ -3095,6 +3101,56 @@ func WithProps(props interface{}, kv ...interface{}) (interface{}, error) {
 			return nil, fmt.Errorf("bf_with_props: field %s: %w", name, err)
 		}
 	}
+	return copyPtr.Elem().Interface(), nil
+}
+
+// WithBagEntry returns a shallow copy of props with ONE entry set in its
+// map[string]any rest-bag field (#2805) — the dynamic-delivery counterpart
+// of WithProps for a jsx-children prop that routes into a child's rest bag
+// (captured only via `{ ...rest }`, never a declared named field), which has
+// no struct field WithProps could target directly. Unlike WithProps'
+// unmatched-name passthrough, a missing/non-map bagField is an error here:
+// the compiler only emits this call after resolving a real rest-bag field on
+// the child's shape, so a miss means the generated template and struct
+// disagree — a compiler bug, not a runtime possibility to shrug off.
+func WithBagEntry(props interface{}, bagField, key string, val interface{}) (interface{}, error) {
+	v := reflect.ValueOf(props)
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Struct {
+		return props, nil
+	}
+	copyPtr := reflect.New(v.Type())
+	copyPtr.Elem().Set(v)
+	target := copyPtr.Elem().FieldByName(bagField)
+	if !target.IsValid() || !target.CanSet() || target.Kind() != reflect.Map || target.Type().Key().Kind() != reflect.String {
+		return nil, fmt.Errorf("bf_with_bag: field %s on %s is not a settable map[string]... rest bag", bagField, v.Type())
+	}
+	// The map is cloned, not mutated in place — the base instance (a
+	// template-shared static slot, or a loop row's shared constructor
+	// output, same sharing WithProps' own doc comment describes) must stay
+	// untouched by one row's override.
+	mapType := target.Type()
+	newMap := reflect.MakeMapWithSize(mapType, target.Len()+1)
+	for _, k := range target.MapKeys() {
+		newMap.SetMapIndex(k, target.MapIndex(k))
+	}
+	elemType := mapType.Elem()
+	valueToSet := reflect.Zero(elemType)
+	if val != nil {
+		rv := reflect.ValueOf(val)
+		switch {
+		case rv.Type().AssignableTo(elemType):
+			valueToSet = rv
+		case rv.Type().ConvertibleTo(elemType):
+			valueToSet = rv.Convert(elemType)
+		default:
+			return nil, fmt.Errorf("bf_with_bag: cannot assign %T to %s value", val, elemType)
+		}
+	}
+	newMap.SetMapIndex(reflect.ValueOf(key), valueToSet)
+	target.Set(newMap)
 	return copyPtr.Elem().Interface(), nil
 }
 

--- a/packages/adapter-go-template/runtime/bf_test.go
+++ b/packages/adapter-go-template/runtime/bf_test.go
@@ -2666,3 +2666,78 @@ func TestWithProps(t *testing.T) {
 		}
 	})
 }
+
+func TestWithBagEntry(t *testing.T) {
+	type CardProps struct {
+		ScopeID string
+		Rest    map[string]interface{}
+	}
+
+	t.Run("sets a key on a nil rest map", func(t *testing.T) {
+		got, err := WithBagEntry(CardProps{ScopeID: "test_s0"}, "Rest", "header", template.HTML("<b>hi</b>"))
+		if err != nil {
+			t.Fatalf("WithBagEntry returned error: %v", err)
+		}
+		copy := got.(CardProps)
+		if copy.Rest["header"] != template.HTML("<b>hi</b>") {
+			t.Errorf("copy.Rest[header] = %v, want <b>hi</b>", copy.Rest["header"])
+		}
+	})
+
+	t.Run("adds a key to an existing map without mutating the original", func(t *testing.T) {
+		original := CardProps{Rest: map[string]interface{}{"footer": "kept"}}
+		got, err := WithBagEntry(original, "Rest", "header", "new")
+		if err != nil {
+			t.Fatalf("WithBagEntry returned error: %v", err)
+		}
+		copy := got.(CardProps)
+		if copy.Rest["header"] != "new" {
+			t.Errorf("copy.Rest[header] = %v, want new", copy.Rest["header"])
+		}
+		if copy.Rest["footer"] != "kept" {
+			t.Errorf("copy.Rest[footer] = %v, want kept (sibling key preserved)", copy.Rest["footer"])
+		}
+		if _, ok := original.Rest["header"]; ok {
+			t.Errorf("original.Rest gained %q — map was mutated in place, not cloned", "header")
+		}
+		if len(original.Rest) != 1 {
+			t.Errorf("original.Rest = %v, want unchanged single-entry map", original.Rest)
+		}
+	})
+
+	t.Run("nil value stores the map's zero element", func(t *testing.T) {
+		got, err := WithBagEntry(CardProps{}, "Rest", "header", nil)
+		if err != nil {
+			t.Fatalf("WithBagEntry returned error: %v", err)
+		}
+		copy := got.(CardProps)
+		if copy.Rest["header"] != nil {
+			t.Errorf("copy.Rest[header] = %v, want nil", copy.Rest["header"])
+		}
+		if _, ok := copy.Rest["header"]; !ok {
+			t.Error("copy.Rest missing the header key entirely, want a present nil entry")
+		}
+	})
+
+	t.Run("missing field errors", func(t *testing.T) {
+		if _, err := WithBagEntry(CardProps{}, "NoSuchField", "header", "x"); err == nil {
+			t.Error("WithBagEntry with unknown bag field: want error, got nil")
+		}
+	})
+
+	t.Run("non-map field errors", func(t *testing.T) {
+		if _, err := WithBagEntry(CardProps{}, "ScopeID", "header", "x"); err == nil {
+			t.Error("WithBagEntry targeting a non-map field: want error, got nil")
+		}
+	})
+
+	t.Run("non-struct props pass through unchanged", func(t *testing.T) {
+		got, err := WithBagEntry("not a struct", "Rest", "header", "x")
+		if err != nil {
+			t.Fatalf("WithBagEntry returned error: %v", err)
+		}
+		if got != "not a struct" {
+			t.Errorf("WithBagEntry(non-struct) = %v, want passthrough", got)
+		}
+	})
+}

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -119,15 +119,11 @@ runAdapterConformanceTests({
     'todo-app',
     // (#1897) data-table no longer skipped — loop body children + wrapper
     // struct + block-body memo baking render correctly on Go.
-    // `jsx-element-prop-fragment-conditional` (#2703) no longer skipped —
-    // renders correctly since named jsx-children props got the same
-    // `bf_with_props`/`bf_tmpl` dynamic-delivery route reserved `children`
-    // already had.
-    // #2805: this shape refuses with BF101 at compile time (see
-    // `conformance-pins.ts`) — `expectedDiagnostics` covers the diagnostic
-    // contract, and marker comparison can't apply to a fixture that
-    // produces no complete template.
-    'jsx-element-prop-rest-bag-dynamic',
+    // `jsx-element-prop-fragment-conditional` (#2703) and
+    // `jsx-element-prop-rest-bag-dynamic` (#2805) no longer skipped — both
+    // render correctly since named jsx-children props got the same
+    // dynamic-delivery route reserved `children` already had (`bf_with_props`
+    // for a declared field, `bf_with_bag` for a rest-bag key).
   ]),
   onRenderError: (err, id) => {
     if (err instanceof GoNotAvailableError) {

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -123,6 +123,7 @@ import type {
   CtorLowerEnv,
   GoTemplateAdapterOptions,
 } from "./lib/types.ts"
+import { routesToRestBag } from "./lib/types.ts"
 import { GO_TEMPLATE_PRIMITIVES } from "./lib/constants.ts"
 import { CompileState, resolveSignalParsedThroughSeedPlan } from "./lib/compile-state.ts"
 import { hasClientInteractivity, findNestedComponents } from "./analysis/component-tree.ts"
@@ -1205,12 +1206,10 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
 
     const propTypeOverrides = buildPropTypeOverrides(this.emitCtx, ir)
 
-    // Computed once (the walk is shared by all three generators). Also gates the
-    // `Spread_<N> map[string]any` field `generateInputStruct` adds for
-    // `input-bag` slots (the open-ended restPropsName spread bag).
+    // Computed once (the walk is shared by all three generators).
     const spreadSlots = collectSpreadSlots(this.emitCtx, ir.root)
 
-    this.generateInputStruct(lines, ir, componentName, nestedComponents, propTypeOverrides, spreadSlots)
+    this.generateInputStruct(lines, ir, componentName, nestedComponents, propTypeOverrides)
 
     this.state.needsStringsImport = false
     this.generatePropsStruct(lines, ir, componentName, nestedComponents, propTypeOverrides, spreadSlots)
@@ -1700,7 +1699,6 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     componentName: string,
     nestedComponents: NestedComponentInfo[],
     propTypeOverrides: Map<string, string>,
-    spreadSlots: SpreadSlotInfo[]
   ): void {
     const inputTypeName = `${componentName}Input`
     lines.push(`// ${inputTypeName} is the user-facing input type.`)
@@ -1770,22 +1768,19 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       lines.push(`\t${this.contextFieldName(c)} ${this.contextConsumerGoType(c)}`)
     }
 
-    // Input-side bag for restPropsName spreads. The destructured-rest pattern
-    // (`function({a, ...rest}: P) { <el {...rest}/> }`) is a `bagSource:
-    // 'input-bag'` slot; Go can't enumerate the open-ended key set, so the
-    // caller passes a `map[string]any`. Field + JSON tag use the rest binding
-    // name (`rest` → `Rest`) so call sites and JSON round-trips line up.
+    // Input-side bag for a destructured rest binding (`function({a, ...rest}:
+    // P) { ... }`) — Go can't enumerate the open-ended key set, so the caller
+    // passes a `map[string]any`. Field + JSON tag use the rest binding name
+    // (`rest` → `Rest`) so call sites and JSON round-trips line up. Emitted
+    // whenever the component destructures a rest binding at all (#2805) —
+    // NOT only when it's also spread onto an element (`bagSource:
+    // 'input-bag'`): a component that only READS `rest.header` needs the
+    // same field to land a value in, even though it never spreads the bag.
     const restPropsName = ir.metadata.restPropsName
     if (restPropsName) {
-      const seen = new Set<string>()
-      for (const slot of spreadSlots) {
-        if (slot.bagSource !== 'input-bag') continue
-        const fieldName = capitalizeFieldName(restPropsName)
-        if (seen.has(fieldName)) continue
-        seen.add(fieldName)
-        const jsonTag = this.toJsonTag(restPropsName)
-        lines.push(`\t${fieldName} map[string]any \`json:"${jsonTag}"\``)
-      }
+      const fieldName = capitalizeFieldName(restPropsName)
+      const jsonTag = this.toJsonTag(restPropsName)
+      lines.push(`\t${fieldName} map[string]any \`json:"${jsonTag}"\``)
     }
 
     lines.push('}')
@@ -2308,6 +2303,14 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
 
     this.emitSpreadBagInits(lines, ir, spreadSlots)
 
+    // Pass the rest-bag map straight through from Input to Props (#2805) —
+    // same field on both structs (`generateInputStruct` / `emitPropsAuxFields`),
+    // no reshaping needed since it's already `map[string]any` on both sides.
+    if (ir.metadata.restPropsName) {
+      const field = capitalizeFieldName(ir.metadata.restPropsName)
+      lines.push(`\t\t${field}: in.${field},`)
+    }
+
     lines.push('\t}')
     lines.push('}')
   }
@@ -2476,11 +2479,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       const childShape = this.childComponentShapes.get(declaredName)
       const restBagEntries: string[] = []
       const emitChildField = (jsxName: string, goValue: string): void => {
-        if (
-          childShape &&
-          childShape.restBagField &&
-          !childShape.paramNames.has(jsxName)
-        ) {
+        if (routesToRestBag(childShape, jsxName)) {
           restBagEntries.push(`${JSON.stringify(jsxName)}: ${goValue}`)
           return
         }
@@ -3435,6 +3434,17 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     for (const slot of spreadSlots) {
       const jsonTag = '-'
       lines.push(`\t${slot.slotId} map[string]any \`json:"${jsonTag}"\``)
+    }
+
+    // Rest-bag field mirroring the Input-side one `generateInputStruct` emits
+    // (#2805) — a value routed into it (a jsx-children prop the child only
+    // reads via its rest binding, e.g. `rest.header`) needs somewhere to
+    // land on the struct the template actually executes against. Never
+    // serialised: rest-bag values reach the client through `BfCallerProps`
+    // the same way reserved `children` does, not through `bf-p` JSON.
+    if (ir.metadata.restPropsName) {
+      const fieldName = capitalizeFieldName(ir.metadata.restPropsName)
+      lines.push(`\t${fieldName} map[string]any \`json:"-"\``)
     }
   }
 
@@ -5131,6 +5141,25 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       return this.rootFieldRef(property)
     }
 
+    // A member access on the component's own destructured rest binding
+    // (`function({ children, ...rest }) { ... rest.header ... }`) reads off
+    // the rest-bag's `map[string]any` field (#2805) — case-tolerant
+    // `bf_get`, the same route `isMapRootedPropChain` below uses for an
+    // inline-object-typed prop, since a source-cased key is what both the
+    // static bake (`emitChildField`) and the dynamic-delivery route
+    // (`queueDynamicPropDefine`) write. `scope.isBound` guards against an
+    // INNER `.map(({ ...rest }) => ...)` binding of the same name shadowing
+    // the outer rest bag (the shared shadow-guard predicate — see
+    // `spec/compiler.md`'s `BindingScope` section).
+    if (
+      object.kind === 'identifier' &&
+      this.state.restPropsName &&
+      object.name === this.state.restPropsName &&
+      !this.scope.isBound(object.name)
+    ) {
+      return `bf_get ${this.rootFieldRef(object.name)} ${JSON.stringify(property)}`
+    }
+
     // A member chain rooted in a `useContext` local whose `createContext`
     // default is object-shaped (#2087 — `defaultKind === 'object'`) reads off
     // a `map[string]interface{}` field, not a struct: plain Go template dot
@@ -6739,12 +6768,13 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       if (prop.name === 'key' || prop.name === 'children') continue
       if (prop.name.startsWith('on') && prop.name.length > 2) continue
       if (prop.name.includes('-')) continue
-      // A prop that routes into the child's rest bag (`emitChildField`'s
-      // same routing rule) has no named Go field to override — `bf_with_props`
-      // would silently no-op the pair via its unknown-field passthrough.
-      // Leave it on the constructor-only path (unchanged from before this
-      // fix) rather than emit a pipeline argument that can never land.
-      if (childShape?.restBagField && !childShape.paramNames.has(prop.name)) continue
+      // A prop that routes into the child's rest bag (`routesToRestBag`,
+      // `emitChildField`'s same routing rule) has no named Go field to
+      // override via `bf_with_props`. Unlike `queueDynamicPropDefine`'s
+      // named-children-prop route (#2805, `bf_with_bag`), a loop-row VALUE
+      // override into a rest-bag key is left on the constructor-only path —
+      // out of scope here, tracked separately (#2920).
+      if (routesToRestBag(childShape, prop.name)) continue
       // `literal` / `boolean-shorthand` / `boolean-attr` carry no runtime
       // expression to re-evaluate per row; `spread` / `jsx-children` are
       // handled elsewhere (`emitSpreadBagInits`, `queueLoopBodyChildrenDefine`).
@@ -7926,12 +7956,17 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
    * a loop row never reaches `collectStaticChildInstances`).
    *
    * Returns the flat `"FieldName" (bf_tmpl "name" .) ...` argument list ready
-   * to splice into `bf_with_props`, or null when no named prop needs it —
-   * batches every prop that needs dynamic delivery into ONE `bf_with_props`
-   * call rather than nesting one per prop.
+   * to splice into `bf_with_props` (`fieldArgs`, null when no declared-field
+   * prop needs it), plus any props that instead route into the child's
+   * rest bag (`bagEntries`, #2805) — each needs its OWN `bf_with_bag` call
+   * at the call site rather than a `bf_with_props` argument pair, since
+   * `WithProps` only ever targets a named struct field.
    */
-  private queueDynamicPropDefine(comp: IRComponent): string | null {
+  private queueDynamicPropDefine(
+    comp: IRComponent,
+  ): { fieldArgs: string | null; bagEntries: Array<{ bagField: string; key: string; defineName: string }> } {
     const args: string[] = []
+    const bagEntries: Array<{ bagField: string; key: string; defineName: string }> = []
     // #2822: cross-file shapes/field-name maps are keyed by the child's own
     // declared name, not the caller-local alias — see `importAliases`.
     const declaredName = this.resolveChildName(comp.name)
@@ -7942,30 +7977,22 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       if (this.extractTextChildren(children) !== null) continue
       if (this.extractHtmlChildren(children) !== null) continue
       if (this.extractScopedHtmlChildren(children) !== null) continue
-      // A prop routed into the child's rest bag (no declared param —
-      // `loopRowChildPropOverrides`'s identical guard, above) has no named
-      // Go field for `bf_with_props`/`WithProps` to target at all; `WithProps`
-      // silently no-ops on an unmatched field name. Refuse loudly instead of
-      // delivering the value against a field name that can never land —
-      // this shape had no dynamic-delivery route before this method existed
-      // either (the blanket BF101 this method's caller replaced was
-      // unconditional for any unbakeable named prop), so this keeps it loud
-      // rather than trading that refusal for a silent dropped render.
-      if (childShape?.restBagField && !childShape.paramNames.has(prop.name)) {
-        this.state.errors.push({
-          code: 'BF101',
-          severity: 'error',
-          message: `JSX-valued prop '${prop.name}' on <${comp.name}> is dynamic and routes into the child's rest-bag prop ('${childShape.restBagField}') rather than a declared field — there is no named Go struct field for 'bf_with_props' to target`,
-          loc: prop.loc,
-        })
-        continue
-      }
       const name = `${this.state.componentName}__prop_${prop.name}_${comp.slotId}`
       if (!this.state.pendingChildrenDefines.some(d => d.name === name)) {
         this.state.pendingChildrenDefines.push({
           name,
           content: this.renderChildren(children),
         })
+      }
+      // A prop routed into the child's rest bag (no declared param —
+      // `emitChildField`/`loopRowChildPropOverrides`'s identical guard) has
+      // no named Go field for `bf_with_props`/`WithProps` to target; route
+      // it through `bf_with_bag`/`WithBagEntry` instead (#2805), keyed by
+      // the RAW JSX attribute name — a rest-bag entry has no local alias to
+      // resolve through `childPropFieldNames` the way a declared field does.
+      if (routesToRestBag(childShape, prop.name)) {
+        bagEntries.push({ bagField: childShape!.restBagField!, key: prop.name, defineName: name })
+        continue
       }
       // `bf_with_props`/`WithProps` patches the child's Props struct, keyed
       // by the child's own LOCAL destructured field name — not necessarily
@@ -7979,7 +8006,7 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       const fieldName = this.childPropFieldNames.get(declaredName)?.get(prop.name) ?? capitalizeFieldName(prop.name)
       args.push(`${JSON.stringify(fieldName)} (bf_tmpl ${JSON.stringify(name)} .)`)
     }
-    return args.length > 0 ? args.join(' ') : null
+    return { fieldArgs: args.length > 0 ? args.join(' ') : null, bagEntries }
   }
 
   /**
@@ -8102,10 +8129,18 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       // via a companion define. Props helper stays INNER, same ordering
       // rule as the loop-nested branch above: `bf_with_children` applies
       // last, on the props-patched value.
-      const propArgs = this.queueDynamicPropDefine(comp)
-      const base = propArgs
-        ? `(bf_with_props .${comp.name}${suffix} ${propArgs})`
+      const propResult = this.queueDynamicPropDefine(comp)
+      let base = propResult.fieldArgs
+        ? `(bf_with_props .${comp.name}${suffix} ${propResult.fieldArgs})`
         : `.${comp.name}${suffix}`
+      // Each rest-bag prop (#2805) wraps in its OWN `bf_with_bag` call,
+      // outside the (optional) `bf_with_props` wrap — the two helpers patch
+      // disjoint fields (a declared struct field vs. a rest-bag map key), so
+      // ordering between them doesn't matter; `bf_with_props` stays
+      // innermost only because it was already there.
+      for (const entry of propResult.bagEntries) {
+        base = `(bf_with_bag ${base} ${JSON.stringify(entry.bagField)} ${JSON.stringify(entry.key)} (bf_tmpl ${JSON.stringify(entry.defineName)} .))`
+      }
       templateCall = childrenDefine
         ? `{{template "${declaredName}" (bf_with_children ${base} (bf_tmpl "${childrenDefine}" .))}}`
         : `{{template "${declaredName}" ${base}}}`

--- a/packages/adapter-go-template/src/adapter/lib/types.ts
+++ b/packages/adapter-go-template/src/adapter/lib/types.ts
@@ -115,6 +115,23 @@ export interface ChildComponentShape {
 }
 
 /**
+ * True when a JSX attribute the parent passes has no declared field on the
+ * child at all and can only reach it through the child's rest-bag spread
+ * (`function Card({ children, ...rest }) { ... rest.header ... }`) — the
+ * shape #2805's `bf_with_bag` route exists for. Shared by every call site
+ * that must decide field-targeted delivery (`bf_with_props`) vs rest-bag
+ * delivery (`bf_with_bag`) for the SAME prop: the static bake
+ * (`emitChildField`), the dynamic named-children-prop route
+ * (`queueDynamicPropDefine`), and the loop-row override route
+ * (`loopRowChildPropOverrides`) all answer this question and must agree —
+ * "one decision, two implementations" is exactly the defect class a single
+ * shared predicate closes.
+ */
+export function routesToRestBag(shape: ChildComponentShape | undefined, jsxName: string): boolean {
+  return !!shape?.restBagField && !shape.paramNames.has(jsxName)
+}
+
+/**
  * Top-level (non-loop) JSX intrinsic-element spread slot. The adapter emits one
  * `Spread_<slotId> map[string]any` field on the component's Props struct and
  * initialises it in `NewXxxProps` from the source JS expression. Loop-internal

--- a/packages/adapter-go-template/src/conformance-pins.ts
+++ b/packages/adapter-go-template/src/conformance-pins.ts
@@ -62,23 +62,13 @@ export const conformancePins: ConformancePins = {
   // no open issue tracks further work here.
   'jsx-element-prop-ternary': [{ code: 'BF021', severity: 'error' }],
   'jsx-element-prop-array': [{ code: 'BF021', severity: 'error' }],
-  // `jsx-element-prop-fragment-conditional` (#2703) is NOT pinned here — it
-  // renders correctly since `queueDynamicPropDefine` (go-template-adapter.ts)
-  // extended the reserved `children` slot's `bf_with_children`/`bf_tmpl`
-  // dynamic-delivery route to named jsx-children props.
-  // #2805: a named jsx-children prop routed into the child's rest bag (no
-  // declared param — only reachable via the child's `...rest` spread) has
-  // no named Go struct field for `bf_with_props`/`WithProps` to target at
-  // all. `queueDynamicPropDefine` refuses loudly with BF101 rather than
-  // silently no-op through `WithProps`'s unmatched-field passthrough.
-  // `unescapable`: the capability gap (a rest-bag delivery route) is #2805
-  // itself, not authored yet, so no `/* @client */` escape twin exists.
-  'jsx-element-prop-rest-bag-dynamic': [{
-    code: 'BF101',
-    severity: 'error',
-    issue: 'https://github.com/piconic-ai/barefootjs/issues/2805',
-    unescapable: { issue: 'https://github.com/piconic-ai/barefootjs/issues/2805' },
-  }],
+  // `jsx-element-prop-fragment-conditional` (#2703) and
+  // `jsx-element-prop-rest-bag-dynamic` (#2805, graduated) are NOT pinned
+  // here — both render correctly: `queueDynamicPropDefine`
+  // (go-template-adapter.ts) extended the reserved `children` slot's
+  // dynamic-delivery route to named jsx-children props, and #2805 further
+  // extended it to a prop that routes into the child's rest bag (`bf_with_bag`
+  // / `WithBagEntry`, `runtime/bf.go`) rather than a declared field.
   // #2700: a `derived` signal/memo (non-empty free set) seeded from an
   // object literal the constructor-time baker can't reproduce (identifier/
   // member/call operands defer, `parsed-literal-to-go.ts`) now refuses

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -2949,6 +2949,16 @@
         "text"
       ]
     },
+    "jsx-element-prop-rest-bag-static": {
+      "kinds": [
+        "identifier",
+        "member"
+      ],
+      "axes": [],
+      "contexts": [
+        "text"
+      ]
+    },
     "jsx-element-prop-ternary": {
       "kinds": [
         "identifier",
@@ -6610,11 +6620,11 @@
     "binary": 104,
     "call": 274,
     "conditional": 31,
-    "identifier": 386,
+    "identifier": 387,
     "index-access": 14,
     "literal": 309,
     "logical": 49,
-    "member": 228,
+    "member": 229,
     "object-literal": 92,
     "template-literal": 31,
     "unary": 29,

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -468,6 +468,7 @@ import { fixture as textareaRowBreakoutComposite } from './textarea-row-breakout
 import { fixture as jsxElementPropFragmentConditional } from './jsx-element-prop-fragment-conditional'
 import { fixture as jsxElementPropRenamedDestructure } from './jsx-element-prop-renamed-destructure'
 import { fixture as jsxElementPropRestBagDynamic } from './jsx-element-prop-rest-bag-dynamic'
+import { fixture as jsxElementPropRestBagStatic } from './jsx-element-prop-rest-bag-static'
 import { fixture as grandchildComposition } from './grandchild-composition'
 import { fixture as compositeRowChildComponent } from './composite-row-child-component'
 import { fixture as compositeRowChildDerivedProp } from './composite-row-child-derived-prop'
@@ -985,6 +986,7 @@ export const jsxFixtures: JSXFixture[] = [
   jsxElementPropFragmentConditional,
   jsxElementPropRenamedDestructure,
   jsxElementPropRestBagDynamic,
+  jsxElementPropRestBagStatic,
   grandchildComposition,
   compositeRowChildComponent,
   compositeRowChildDerivedProp,

--- a/packages/adapter-tests/fixtures/jsx-element-prop-rest-bag-dynamic.ts
+++ b/packages/adapter-tests/fixtures/jsx-element-prop-rest-bag-dynamic.ts
@@ -7,22 +7,16 @@ import { createFixture } from '../src/types'
  * spread (`{ children, ...rest }`), the same routing `emitChildField`
  * already special-cases for the STATIC bake path.
  *
- * Regression pin for a gap Pullfrog's review caught on go-template PR #2804
- * (`queueDynamicPropDefine`, go-template-adapter.ts): a prop routed into
- * the child's rest bag has no named Go struct field at all for
- * `bf_with_props`/`WithProps` to target — `loopRowChildPropOverrides`
- * already guards against this exact shape (`childShape?.restBagField &&
- * !childShape.paramNames.has(prop.name)`) for its own `bf_with_props` call
- * site, but `queueDynamicPropDefine` initially didn't, which would have
- * silently no-op'd the dynamic value via `WithProps`'s unmatched-field
- * passthrough — turning the BLANKET `BF101` refusal this PR's first commit
- * replaced (unconditional for any unbakeable named prop) into a silent
- * wrong render for exactly this shape. `queueDynamicPropDefine` mirrors
- * the same guard and refuses loudly with `BF101` instead.
- *
- * This fixture is pinned on go-template only (`conformance-pins.ts`);
- * every other adapter renders it correctly, same as its sibling
- * `jsx-element-prop-fragment-conditional`.
+ * Regression test for #2805 (originally a gap Pullfrog's review caught on
+ * go-template PR #2804): `queueDynamicPropDefine` now routes a prop with no
+ * declared field through `bf_with_bag`/`WithBagEntry` (`runtime/bf.go`)
+ * instead of `bf_with_props`/`WithProps`, which can only ever target a named
+ * struct field — the child's `Rest map[string]any` field (now emitted
+ * whenever a component destructures a rest binding at all, not only when it
+ * also spreads it onto an element — see `generateInputStruct` /
+ * `emitPropsAuxFields`) receives the value under the raw JSX attribute name,
+ * and the read (`rest.header`) resolves it via `bf_get` (`member()`'s
+ * `restPropsName` branch).
  */
 export const fixture = createFixture({
   id: 'jsx-element-prop-rest-bag-dynamic',

--- a/packages/adapter-tests/fixtures/jsx-element-prop-rest-bag-static.ts
+++ b/packages/adapter-tests/fixtures/jsx-element-prop-rest-bag-static.ts
@@ -1,0 +1,45 @@
+import { createFixture } from '../src/types'
+
+/**
+ * Static (non-dynamic) twin of `jsx-element-prop-rest-bag-dynamic`: a named
+ * jsx-children prop (`header`) with a value that folds to a constant, on a
+ * child that does NOT declare `header` as a param — it's captured only via
+ * the child's rest-bag spread (`{ children, ...rest }`), never spread onto
+ * an element itself. Proves the STATIC bake path (`emitChildField`) and the
+ * read lowering (`member()`'s `restPropsName` branch, `bf_get`) independently
+ * of #2805's dynamic-delivery route, since this shape never reaches
+ * `queueDynamicPropDefine` at all — the value bakes straight into the
+ * constructor's `Rest: map[string]any{"header": ...}` literal.
+ */
+export const fixture = createFixture({
+  id: 'jsx-element-prop-rest-bag-static',
+  description: 'A named jsx-children prop with a static value, captured only by the child\'s rest-bag spread',
+  source: `
+import { Card } from './Card'
+export function JsxElementPropRestBagStatic() {
+  return (
+    <Card header={<strong>Title</strong>}>
+      <p>body text</p>
+    </Card>
+  )
+}
+`,
+  components: {
+    './Card': `
+export function Card({ children, ...rest }: { children?: any; [key: string]: any }) {
+  return (
+    <section>
+      <header>{rest.header}</header>
+      <div>{children}</div>
+    </section>
+  )
+}
+`,
+  },
+  expectedHtml: `
+    <section bf-s="test_s0">
+      <header bf="s1"><!--bf:s0--><strong bf-s="test">Title</strong><!--/--></header>
+      <div><p>body text</p></div>
+    </section>
+  `,
+})

--- a/packages/compat/src/__tests__/compat-engine.test.ts
+++ b/packages/compat/src/__tests__/compat-engine.test.ts
@@ -49,22 +49,22 @@ describe('compileForCompat', () => {
     // successor to #2038), #2321 (static-array-from-props computed loop
     // source), #2700 (a `derived` object-literal signal/memo the
     // constructor-time baker can't reproduce, `signal-object-spread-init`),
-    // #2805 (a named jsx-children prop routed into a child's rest bag,
-    // `jsx-element-prop-rest-bag-dynamic`), and #2909 (a signal/memo call
-    // read inside a nested static loop's row, `static-nested-loop-ref`)
-    // surface here even though this test only exercises the
-    // nested-filter-callback shape. Five pins are no longer among them,
-    // each because the shape got a real lowering rather than a narrower
-    // refusal: #2319 (dangerous-inner-html-dynamic → a faithful raw-output
-    // lowering), #2208 (static-array-children → the loop-source gate bakes
-    // a fully-static array-of-objects const), #2448 (loop-row child prop
-    // override feeding a derived field → the child rebuilds itself per row
-    // through `bf_reprops`), #2898 (a conditional inside a static array's
-    // row with no nested loop → `isFoldableTree` now bakes it), and #2893
-    // (a nested `.map()`'s own structural bail → the bake now recurses into
-    // a nested loop; `static-nested-loop-conditional` graduated outright,
-    // `static-nested-loop-ref` still refuses but for the narrower #2909
-    // reason). See `go-template`'s `conformance-pins.ts`.
+    // and #2909 (a signal/memo call read inside a nested static loop's row,
+    // `static-nested-loop-ref`) surface here even though this test only
+    // exercises the nested-filter-callback shape. Six pins are no longer
+    // among them, each because the shape got a real lowering rather than a
+    // narrower refusal: #2319 (dangerous-inner-html-dynamic → a faithful
+    // raw-output lowering), #2208 (static-array-children → the loop-source
+    // gate bakes a fully-static array-of-objects const), #2448 (loop-row
+    // child prop override feeding a derived field → the child rebuilds
+    // itself per row through `bf_reprops`), #2898 (a conditional inside a
+    // static array's row with no nested loop → `isFoldableTree` now bakes
+    // it), #2893 (a nested `.map()`'s own structural bail → the bake now
+    // recurses into a nested loop; `static-nested-loop-conditional`
+    // graduated outright, `static-nested-loop-ref` still refuses but for the
+    // narrower #2909 reason), and #2805 (a named jsx-children prop routed
+    // into a child's rest bag → `bf_with_bag`/`WithBagEntry` delivers it
+    // instead of refusing). See `go-template`'s `conformance-pins.ts`.
     expect(cell.diagnostics).toEqual([
       {
         code: 'BF101',
@@ -73,7 +73,6 @@ describe('compileForCompat', () => {
           'https://github.com/piconic-ai/barefootjs/issues/2320',
           'https://github.com/piconic-ai/barefootjs/issues/2321',
           'https://github.com/piconic-ai/barefootjs/issues/2700',
-          'https://github.com/piconic-ai/barefootjs/issues/2805',
           'https://github.com/piconic-ai/barefootjs/issues/2909',
         ],
       },

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-conformance section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. This answers, per fixture and per adapter, whether the construct WORKS — not just whether it compiles. A construct works either as written (✓) or with a documented `/* @client */` comment (✓†, a verified, supported escape — most refusals have one). Fixtures absent from the table below work on every adapter — most as written, some via that documented escape; the headline says how many of each. Listed fixtures need attention somewhere: a bare diagnostic code is still-open debt with no escape yet, a code led by ✗ owes no escape at all (by design), and ≠ means the fixture compiles clean but its rendered output diverges from the reference.",
-    "totalFixtures": 408,
+    "totalFixtures": 409,
     "fixtures": {
       "date-method-uncatalogued": {
         "blade": {
@@ -2549,20 +2549,6 @@
           "codes": [
             "BF021"
           ]
-        }
-      },
-      "jsx-element-prop-rest-bag-dynamic": {
-        "go-template": {
-          "kind": "refusal",
-          "codes": [
-            "BF101"
-          ],
-          "issues": [
-            "https://github.com/piconic-ai/barefootjs/issues/2805"
-          ],
-          "escape": {
-            "state": "debt"
-          }
         }
       },
       "jsx-element-prop-ternary": {
@@ -3675,10 +3661,6 @@
       "jsx-element-prop-array": {
         "description": "Array literal wrapping JSX at a non-children prop position refuses with BF021",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/jsx-element-prop-array.ts"
-      },
-      "jsx-element-prop-rest-bag-dynamic": {
-        "description": "A named jsx-children prop with a genuinely dynamic value, captured only by the child's rest-bag…",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/jsx-element-prop-rest-bag-dynamic.ts"
       },
       "jsx-element-prop-ternary": {
         "description": "Ternary wrapping JSX at a non-children prop position refuses with BF021",

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -2256,11 +2256,11 @@
       }
     },
     "identifier": {
-      "total": 386,
+      "total": 387,
       "cells": {
         "hono": {
-          "pass": 382,
-          "total": 386,
+          "pass": 383,
+          "total": 387,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2283,8 +2283,8 @@
           ]
         },
         "blade": {
-          "pass": 366,
-          "total": 386,
+          "pass": 367,
+          "total": 387,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2379,8 +2379,8 @@
           ]
         },
         "erb": {
-          "pass": 366,
-          "total": 386,
+          "pass": 367,
+          "total": 387,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2473,8 +2473,8 @@
           ]
         },
         "go-template": {
-          "pass": 363,
-          "total": 386,
+          "pass": 365,
+          "total": 387,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2517,12 +2517,6 @@
             {
               "fixture": "jsx-element-prop-array",
               "issues": []
-            },
-            {
-              "fixture": "jsx-element-prop-rest-bag-dynamic",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2805"
-              ]
             },
             {
               "fixture": "jsx-element-prop-ternary",
@@ -2587,8 +2581,8 @@
           ]
         },
         "jinja": {
-          "pass": 366,
-          "total": 386,
+          "pass": 367,
+          "total": 387,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2683,8 +2677,8 @@
           ]
         },
         "minijinja": {
-          "pass": 366,
-          "total": 386,
+          "pass": 367,
+          "total": 387,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2779,8 +2773,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 365,
-          "total": 386,
+          "pass": 366,
+          "total": 387,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2881,8 +2875,8 @@
           ]
         },
         "twig": {
-          "pass": 366,
-          "total": 386,
+          "pass": 367,
+          "total": 387,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2977,8 +2971,8 @@
           ]
         },
         "xslate": {
-          "pass": 364,
-          "total": 386,
+          "pass": 365,
+          "total": 387,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3279,7 +3273,7 @@
           ]
         },
         "go-template": {
-          "pass": 294,
+          "pass": 295,
           "total": 309,
           "gaps": [
             {
@@ -3301,12 +3295,6 @@
             {
               "fixture": "flatmap-typeof-projection",
               "issues": []
-            },
-            {
-              "fixture": "jsx-element-prop-rest-bag-dynamic",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2805"
-              ]
             },
             {
               "fixture": "jsx-element-prop-ternary",
@@ -3818,11 +3806,11 @@
       }
     },
     "member": {
-      "total": 228,
+      "total": 229,
       "cells": {
         "hono": {
-          "pass": 225,
-          "total": 228,
+          "pass": 226,
+          "total": 229,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3841,8 +3829,8 @@
           ]
         },
         "blade": {
-          "pass": 209,
-          "total": 228,
+          "pass": 210,
+          "total": 229,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3933,8 +3921,8 @@
           ]
         },
         "erb": {
-          "pass": 209,
-          "total": 228,
+          "pass": 210,
+          "total": 229,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4023,8 +4011,8 @@
           ]
         },
         "go-template": {
-          "pass": 206,
-          "total": 228,
+          "pass": 208,
+          "total": 229,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4067,12 +4055,6 @@
             {
               "fixture": "jsx-element-prop-array",
               "issues": []
-            },
-            {
-              "fixture": "jsx-element-prop-rest-bag-dynamic",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2805"
-              ]
             },
             {
               "fixture": "jsx-element-prop-ternary",
@@ -4133,8 +4115,8 @@
           ]
         },
         "jinja": {
-          "pass": 209,
-          "total": 228,
+          "pass": 210,
+          "total": 229,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4225,8 +4207,8 @@
           ]
         },
         "minijinja": {
-          "pass": 209,
-          "total": 228,
+          "pass": 210,
+          "total": 229,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4317,8 +4299,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 208,
-          "total": 228,
+          "pass": 209,
+          "total": 229,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4415,8 +4397,8 @@
           ]
         },
         "twig": {
-          "pass": 209,
-          "total": 228,
+          "pass": 210,
+          "total": 229,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4507,8 +4489,8 @@
           ]
         },
         "xslate": {
-          "pass": 207,
-          "total": 228,
+          "pass": 208,
+          "total": 229,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -7945,15 +7927,9 @@
           ]
         },
         "go-template": {
-          "pass": 65,
+          "pass": 66,
           "total": 69,
           "gaps": [
-            {
-              "fixture": "jsx-element-prop-rest-bag-dynamic",
-              "issues": [
-                "https://github.com/piconic-ai/barefootjs/issues/2805"
-              ]
-            },
             {
               "fixture": "jsx-element-prop-ternary",
               "issues": []


### PR DESCRIPTION
## Summary

Stacked on #2914 (#2893).

A named jsx-children prop with a genuinely dynamic value, on a child that captures it only via a rest-bag spread (`function Card({ children, ...rest }) { ... rest.header ... }`, no declared param), previously refused loudly with `BF101` — `queueDynamicPropDefine` had no way to target the value at a struct field `bf_with_props`/`WithProps` could patch (`WithProps` only ever targets a named field; it silently no-ops on an unmatched name).

- Adds `WithBagEntry`/`bf_with_bag` (`runtime/bf.go`): the rest-bag counterpart of `WithProps` — sets ONE entry in a `map[string]any` field on a cloned copy of the props, rather than a named struct field. Unlike `WithProps`' unmatched-field passthrough, a missing/non-map bag field is a hard error (the compiler only emits this call after resolving a real rest-bag field, so a miss means the template and struct disagree — a compiler bug, not a runtime possibility).
- `generateInputStruct`/`emitPropsAuxFields` (go-template-adapter.ts) now emit the rest-bag `map[string]any` field whenever a component destructures a rest binding AT ALL, not only when it's also spread onto an element (`{...rest}` on a JSX element) — a prerequisite gap the STATIC bake path had too: a component that only *reads* `rest.header` (never spreads it) had no `Rest` field to land a baked value in either. `jsx-element-prop-rest-bag-static` proves this half independently.
- `member()`'s read lowering now routes a member access on the component's own rest binding (`rest.header`) through `bf_get` (the same case-tolerant runtime getter `isMapRootedPropChain` already uses for inline-object-typed props), guarded by `scope.isBound` against an INNER `.map(({ ...rest }) => ...)` binding shadowing the outer rest bag.
- `queueDynamicPropDefine` routes a rest-bag-destined prop through `bf_with_bag` instead of refusing. Extracted a shared `routesToRestBag(shape, jsxName)` predicate (`adapter/lib/types.ts`) — the same routing decision was previously answered independently in three places (`emitChildField`, `loopRowChildPropOverrides`, and this call site); now all three call the one function.
- Graduates `jsx-element-prop-rest-bag-dynamic` off its `BF101` pin.

`loopRowChildPropOverrides`' own rest-bag-routed loop-ROW-VALUE override (a per-row rest-bag prop on a component nested inside a loop) stays on the constructor-only path — out of scope here, filed as #2920 now that `bf_with_bag` exists to wire it through.

Fixes #2805.

## Test plan

- [x] `tsgo --noEmit` on `packages/adapter-go-template` — clean.
- [x] `go build ./...` / `go test ./...` in `packages/adapter-go-template/runtime` (go1.25.6 toolchain) — clean, including new `TestWithBagEntry` (6 subtests).
- [x] `bun run packages/adapter-tests/scripts/generate-expected-html.ts` — regenerated expected HTML for both new/changed fixtures from the Hono reference adapter; clean beyond intended fixture changes. Manually verified the STATIC fixture's initial hand-written guess was wrong (needed the hoisted-JSX scope wrapper) and let the generator produce the correct value rather than hand-authoring it.
- [x] `bun packages/adapter-tests/scripts/coverage-map.ts` / `bun run support-matrix:lock` / `bun run compat:lock` — regenerated all derived lock artifacts, no diagnostics.
- [x] `GOTOOLCHAIN=go1.25.6 bun test packages/adapter-go-template/src` — 2110 pass, 0 fail, **with real `go run` execution** (not skipped) — 4117 expect() calls confirm the generated Go actually compiles and renders both new fixtures to the exact expected HTML.
- [x] `bun test packages/compat/__tests__/support-matrix.test.ts packages/compat/src/__tests__/escape-coverage.test.ts packages/compat/src/__tests__/compat-engine.test.ts` — 303 pass, 0 fail (updated the BF101 issue-URL union `compat-engine.test.ts` asserts, dropping #2805 now that it's graduated).
- [ ] CI

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JoiEowwf1mVvYywj5AesY

---
_Generated by [Claude Code](https://claude.ai/code/session_016JoiEowwf1mVvYywj5AesY)_