### PR TITLE
Fix #2760: allow a bare signal/memo getter passed directly to a component prop

### DIFF
--- a/.changeset/bf044-component-prop-getter-subset.md
+++ b/.changeset/bf044-component-prop-getter-subset.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/jsx": patch
+---
+
+BF044 (signal/memo getter passed without calling it) no longer refuses a bare getter passed directly to a component prop (`<Foo x={val} />`) — it now compiles, matching the already-legal object-literal-wrapped form (`<Foo x={{ val }} />`). Both forms are this codebase's deliberate Context-Provider idiom: the child owns *when* to call the accessor, so it can subscribe reactively at its own read site instead of the value being frozen at the parent's render time (measured: 66 real-world uses of this idiom, none a forgotten `()`). The diagnostic's entire check — top-level included, not just its nested-descent walk — is now gated on whether the position is genuinely RENDERED (a DOM attribute, a JSX text child), which a component prop never is (#2760).

--- a/.changeset/go-template-component-prop-getter-pin.md
+++ b/.changeset/go-template-component-prop-getter-pin.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/go-template": patch
+---
+
+Pins a newly-discovered divergence on the `component-prop-bare-getter` conformance fixture (#2760): a plain (non-Context) child-component prop whose value is a local signal/memo getter compiles clean but renders empty on Go's real backend — `NewCounterProps`'s constructor-time build of the nested child's `Input` struct silently omits the field. Predates #2760 and reproduces identically with the object-literal-wrapped form; tracked at #2925.

--- a/docs/core/advanced/error-codes.md
+++ b/docs/core/advanced/error-codes.md
@@ -361,19 +361,28 @@ function Child({ initialCount }: Props) {
 
 ### BF044 — Signal/Memo Getter Not Called
 
-**Trigger:** Signal/memo getter passed without calling it.
+**Trigger:** Signal/memo getter passed without calling it in a RENDERED
+position — a DOM element attribute or a JSX text child, where the value
+becomes literal output.
 
 ```tsx
 // ❌ BF044
-<Child count={count} />  // Passing getter function, not the value
+<div count={count} />  // Passing getter function, not the value
 ```
 
 **Fix:**
 
 ```tsx
 // ✅ Fixed
-<Child count={count()} />
+<div count={count()} />
 ```
+
+**Not triggered on a component prop:** `<Child count={count} />` compiles —
+a component prop is an opaque value handed to the child, not rendered
+output, and passing a live getter there is this codebase's deliberate
+Context-Provider idiom (the child calls it at its own read site). See
+[`spec/compiler.md`'s BF044 section](https://github.com/piconic-ai/barefootjs/blob/main/spec/compiler.md#signalmemo-getter-not-called-bf044)
+for the full rule.
 
 <a id="bf049"></a>
 

--- a/packages/adapter-go-template/src/render-divergences.ts
+++ b/packages/adapter-go-template/src/render-divergences.ts
@@ -37,4 +37,19 @@
 
 import type { RenderDivergences } from '@barefootjs/jsx'
 
-export const renderDivergences: RenderDivergences = {}
+export const renderDivergences: RenderDivergences = {
+  // #2925: a plain (non-Context) child-component prop whose value is a
+  // local signal/memo getter — `<Display value={count} />`, and identically
+  // `<Display value={{ v: count }} />` — compiles clean, but
+  // `NewCounterProps`'s constructor-time build of the nested `DisplaySlot0`
+  // field silently omits `Value` from the `DisplayInput{...}` literal, so Go
+  // renders the field as its zero value instead of the signal's value.
+  // `count`'s own SSR-default baking works fine (`Count: 5` lands); the gap
+  // is specifically in threading a signal-getter-valued prop into a NESTED
+  // child's own constructor-time `Input` struct. Predates #2760 (reproduces
+  // identically with the already-legal object-literal-wrapped form) — #2760
+  // only added the first fixture to exercise this idiom outside a Context
+  // Provider, which routes through `provideContext`/`useContext` instead and
+  // never hit this baker path.
+  'component-prop-bare-getter': 'signal getter handed to a plain child-component prop renders empty — constructor baker drops the field (#2925)',
+}

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -1360,6 +1360,20 @@
         "text"
       ]
     },
+    "component-prop-bare-getter": {
+      "kinds": [
+        "call",
+        "identifier",
+        "literal",
+        "member"
+      ],
+      "axes": [
+        "literal:number"
+      ],
+      "contexts": [
+        "text"
+      ]
+    },
     "component-row-loop-preamble-handler": {
       "kinds": [
         "array-literal",
@@ -6618,13 +6632,13 @@
     "array-method": 71,
     "arrow": 74,
     "binary": 104,
-    "call": 274,
+    "call": 275,
     "conditional": 31,
-    "identifier": 387,
+    "identifier": 388,
     "index-access": 14,
-    "literal": 309,
+    "literal": 310,
     "logical": 49,
-    "member": 229,
+    "member": 230,
     "object-literal": 92,
     "template-literal": 31,
     "unary": 29,
@@ -6668,7 +6682,7 @@
     "binary:>=": 1,
     "literal:boolean": 69,
     "literal:null": 26,
-    "literal:number": 140,
+    "literal:number": 141,
     "literal:string": 211,
     "logical:&&": 7,
     "logical:??": 41,

--- a/packages/adapter-tests/fixtures/component-prop-bare-getter.ts
+++ b/packages/adapter-tests/fixtures/component-prop-bare-getter.ts
@@ -1,0 +1,49 @@
+import { createFixture } from '../src/types'
+
+/**
+ * A signal getter passed DIRECTLY to a component prop, uncalled
+ * (`<Display value={count} />`) — #2760.
+ *
+ * `checkBareSignalOrMemoIdentifier` (BF044, jsx-to-ir.ts) used to refuse this
+ * unconditionally at its top-level check, while the structurally identical
+ * `<Display value={{ v: count }} />` (see
+ * `context-provider-nullish-object-fallback.ts`) passed silently — the walk
+ * only ever tested `expr`'s own top-level node, so wrapping the exact same
+ * accessor in an object literal was enough to dodge the gate. Both forms are
+ * this codebase's deliberate Context-Provider idiom: the child owns *when*
+ * to call the accessor, so it can subscribe reactively at its own read site
+ * instead of the value being frozen at the parent's render time. #2760
+ * settled the asymmetry by gating BF044's entire check — top level included —
+ * on whether the position is genuinely RENDERED (a DOM attribute, a JSX text
+ * child), which a component prop never is.
+ *
+ * `Display` reads `props.value()` inside its own JSX text child — a rendered
+ * position from `Display`'s point of view — proving the accessor reaches the
+ * child uncalled and the child's own call site is what makes it reactive
+ * (the client JS wraps that read in `createEffect`, matching how the
+ * Context-Provider idiom's consumers already read their accessor props).
+ */
+export const fixture = createFixture({
+  id: 'component-prop-bare-getter',
+  description: 'A signal getter passed directly (unwrapped) to a component prop compiles, matching the already-legal object-literal-wrapped form (#2760)',
+  source: `
+'use client'
+import { createSignal } from '@barefootjs/client'
+
+function Display(props: { value: () => number }) {
+  return <span class="value">{props.value()}</span>
+}
+
+export function Counter() {
+  const [count, setCount] = createSignal(5)
+  return (
+    <div class="root">
+      <Display value={count} />
+    </div>
+  )
+}
+`,
+  expectedHtml: `
+    <div bf-s="test" class="root"><span bf-s="test_s0" bf="s1" class="value"><!--bf:s0-->5<!--/--></span></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -637,6 +637,10 @@ import { fixture as lazyRowIndexReorder } from './lazy-row-index-reorder'
 // #2868: a reactive conditional branch's own root tag collides with the
 // enclosing loop's item param name — must not corrupt the tag on re-render.
 import { fixture as condArmTagCollision } from './cond-arm-tag-collision'
+// #2760: a signal getter passed DIRECTLY (unwrapped) to a component prop —
+// BF044 used to refuse this while the structurally identical object-literal
+// wrapped form (`context-provider-nullish-object-fallback.ts`) passed silently.
+import { fixture as componentPropBareGetter } from './component-prop-bare-getter'
 
 import type { JSXFixture } from '../src/types'
 
@@ -1074,4 +1078,5 @@ export const jsxFixtures: JSXFixture[] = [
   keyedLoopIndexReorder,
   lazyRowIndexReorder,
   condArmTagCollision,
+  componentPropBareGetter,
 ]

--- a/packages/adapter-tests/src/__tests__/client-js-scope.test.ts
+++ b/packages/adapter-tests/src/__tests__/client-js-scope.test.ts
@@ -61,6 +61,19 @@ const KNOWN_UNDECLARED: Record<string, KnownHole> = {
   // `rewritePropsObjectRef` door the init body already used (#2723), so
   // `rest.x` resolves to `_p.x` in the template the same way it always did
   // in init.
+  'component-prop-bare-getter': {
+    // #2924: a component prop whose value is a local signal/memo getter
+    // (`<Display value={count} />`) — `rewritePropsObjectRef` only knows
+    // how to rewrite references to the CURRENT component's own props/rest
+    // object; `count` is a local signal, not a prop, so there is no `_p.count`
+    // to rewrite to. The module-scope `template` lambda's `renderChild(...)`
+    // props literal keeps the bare source-level `count`, unreachable outside
+    // `initCounter`. Reproduces identically with the object-literal-wrapped
+    // form (`value={{ v: count }}`), so this predates #2760 and is orthogonal
+    // to its diagnostic-gate decision.
+    names: ['count'],
+    issue: 'https://github.com/piconic-ai/barefootjs/issues/2924',
+  },
 }
 
 /** One virtual .ts file per emitted client-JS artifact. */

--- a/packages/adapter-tests/src/csr-skip-set.ts
+++ b/packages/adapter-tests/src/csr-skip-set.ts
@@ -84,4 +84,13 @@ export const CSR_SKIP_FIXTURES: ReadonlySet<string> = new Set([
   // child needs no `$c` lookup at all (it IS `__scope`) — see
   // `ClientJsContext.commentScopeRootSlotId` and
   // `comment-wrapper-grandchild-slot-collision.test.ts`.
+  // #2924: a component prop whose value is (or contains) a local signal/memo
+  // getter — `<Display value={count} />` — compiles, but the PARENT's own
+  // module-scope `template` lambda (used on CSR-fresh-mount, not hydration)
+  // references `count` directly in `renderChild(...)`'s props literal, and
+  // `count` is only in scope inside `initCounter`, not `template`. Real
+  // divergence (a genuine `ReferenceError`, reproduced against the actual
+  // `@barefootjs/client` runtime), not a harness artifact — predates #2760
+  // and reproduces identically with the object-literal-wrapped form.
+  'component-prop-bare-getter',
 ])

--- a/packages/jsx/src/__tests__/signal-getter-not-called.test.ts
+++ b/packages/jsx/src/__tests__/signal-getter-not-called.test.ts
@@ -327,6 +327,11 @@ describe('Signal Getter Not Called (BF044)', () => {
         ['component prop, object literal member', '<Child value={{ x: count }} />'],
         ['component prop, ternary', '<Child value={count ? 1 : 2} />'],
         ['component prop, call argument', '<Child value={String(count)} />'],
+        // #2760: a bare getter passed DIRECTLY to a component prop is the
+        // same idiom as the object-literal-wrapped form above, not a
+        // forgotten `()` — the two forms are one decision, not an
+        // inconsistency to resolve by tightening the direct one.
+        ['component prop, bare getter', '<Child value={count} />'],
       ])('%s', (_label, body) => {
         expect(bf044Of(body)).toHaveLength(0)
       })

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -2376,8 +2376,9 @@ function transformExpressionInner(
   // Check for bare signal/memo identifier (BF044). A JSX text child is
   // inherently a RENDERED position — unlike a component prop, `{expr}`
   // here always becomes literal rendered output, never an opaque value
-  // handed to a consumer to call later — so nested descent is always on.
-  checkBareSignalOrMemoIdentifier(expr, ctx, { descendNested: true })
+  // handed to a consumer to call later — so the check (top-level and
+  // nested descent) always fires.
+  checkBareSignalOrMemoIdentifier(expr, ctx, { renderedPosition: true })
 
   // #547: Inline a JSX constant referenced by identifier. Unique to JSX-child
   // position — conditional branches and return position don't resolve
@@ -6621,14 +6622,14 @@ function getAttributeValue(attr: ts.JsxAttribute, ctx: TransformContext): AttrVa
     // `processComponentProps`), and only the element-attribute case is
     // a RENDERED position — a component prop is an opaque value handed
     // to the component, and this codebase's Context-Provider idiom
-    // depends on that value being an uncalled accessor (`value={{
-    // open }}`, ui/components/ui/select/index.tsx — calling it eagerly
-    // there would freeze the value at provider-render time and break
-    // every consumer's reactivity). So nested descent is gated on
-    // element-vs-component, derived from the tag this attribute lives
-    // on; the top-level bare-identifier check stays unconditional
-    // either way, unchanged from this diagnostic's original behaviour.
-    checkBareSignalOrMemoIdentifier(expr, ctx, { descendNested: isRenderedElementAttribute(attr, ctx) })
+    // depends on that value being an uncalled accessor, whether passed
+    // directly (`x={open}`, #2760) or nested in an object literal
+    // (`value={{ open }}`, ui/components/ui/select/index.tsx) — calling
+    // it eagerly there would freeze the value at provider-render time
+    // and break every consumer's reactivity. So the entire check (top
+    // level included) is gated on element-vs-component, derived from
+    // the tag this attribute lives on.
+    checkBareSignalOrMemoIdentifier(expr, ctx, { renderedPosition: isRenderedElementAttribute(attr, ctx) })
 
     // Static style object: style={{ key: 'value', ... }} → CSS string at compile time
     if (attr.name.getText(ctx.sourceFile) === 'style' && ts.isObjectLiteralExpression(expr)) {
@@ -7708,15 +7709,16 @@ function processComponentProps(
  * hyphenated (a custom element) is a real DOM node, capitalised or
  * dotted (`Select.Provider`) is a component.
  *
- * Feeds `checkBareSignalOrMemoIdentifier`'s `descendNested` gate: a
+ * Feeds `checkBareSignalOrMemoIdentifier`'s `renderedPosition` gate: a
  * DOM attribute value is a RENDERED position (this is genuinely what
  * ends up in the DOM), so a bare getter buried inside it — `style={{
  * color: val }}` — is exactly as much a forgotten `()` as a top-level
  * one. A component prop is not rendered — it's an opaque value handed
  * to the component — and this codebase's Context-Provider idiom
- * depends on that value being an UNCALLED accessor
+ * depends on that value being an UNCALLED accessor, whether passed
+ * directly (`x={open}`) or nested in an object literal
  * (`ui/components/ui/select/index.tsx`'s `value={{ open, ... }}`), so
- * nested descent must not fire there.
+ * the check must not fire there at all (#2760).
  */
 function isRenderedElementAttribute(attr: ts.JsxAttribute, ctx: TransformContext): boolean {
   const tagName = attr.parent.parent.tagName.getText(ctx.sourceFile)
@@ -7728,22 +7730,25 @@ function isRenderedElementAttribute(attr: ts.JsxAttribute, ctx: TransformContext
  * Emits BF044 when a signal/memo getter is passed without calling it.
  * e.g., value={count} instead of value={count()}
  *
- * The top-level check — is `expr` itself a bare reactive identifier —
- * always runs, unchanged from this diagnostic's original behaviour
- * (`value={count}`, `<Foo x={count} />` keep firing regardless of
- * position). `descendNested` additionally opts into walking INSIDE a
- * composite expression — call arguments, template-literal spans,
+ * `renderedPosition` gates the ENTIRE check, top-level included: only a
+ * RENDERED position (a JSX text child; a DOM element's attribute value
+ * via `isRenderedElementAttribute`) risks a forgotten `()` silently
+ * producing wrong output, so only those positions fire at all. A
+ * component prop is not rendered — it's an opaque value handed to the
+ * component — and a bare getter there is this codebase's deliberate
+ * Context-Provider idiom (measured: 66 such uses across
+ * `ui/components/**`/`site/**`, all legitimate, none a forgotten `()`),
+ * whether written directly (`<Foo x={val} />`) or nested inside an
+ * object literal (`<Foo value={{ val }} />`, already silent before this
+ * gate existed) — #2760 settled the two forms as one idiom, not an
+ * inconsistency to fix by tightening the direct form. When
+ * `renderedPosition` is true, nested descent additionally walks INSIDE
+ * a composite expression — call arguments, template-literal spans,
  * ternary branches (condition + both arms), array/object literal
  * members, binary/logical operands, parenthesized wrappers — to catch
- * a bare reference buried anywhere in that reachable set (#2755,
- * #2751: this is the single upstream gate whose shallow top-level-only
- * check let both downstream bugs through). Callers opt in only for
- * RENDERED positions (a JSX text child; a DOM element's attribute value
- * via `isRenderedElementAttribute`) — never for a component prop, where
- * a bare getter is this codebase's deliberate Context-Provider idiom
- * (measured: 66 such uses across `ui/components/**`/`site/**`, all
- * legitimate, none a forgotten `()` — widening the gate to fire there
- * would be a correctness regression, not a fix).
+ * a bare reference buried anywhere in that reachable set (#2755, #2751:
+ * this is the single upstream gate whose shallow top-level-only check
+ * let both downstream bugs through).
  *
  * Two structural exclusions apply whenever descending, both required
  * so the walk doesn't false-positive on shapes that read the name
@@ -7781,8 +7786,10 @@ function isRenderedElementAttribute(attr: ts.JsxAttribute, ctx: TransformContext
 function checkBareSignalOrMemoIdentifier(
   expr: ts.Expression,
   ctx: TransformContext,
-  options?: { descendNested?: boolean }
+  options?: { renderedPosition?: boolean }
 ): void {
+  if (!options?.renderedPosition) return
+
   const reactiveNames = new Map<string, 'signal' | 'memo'>()
   for (const signal of ctx.analyzer.signals) reactiveNames.set(signal.getter, 'signal')
   for (const memo of ctx.analyzer.memos) reactiveNames.set(memo.name, 'memo')
@@ -7804,28 +7811,26 @@ function checkBareSignalOrMemoIdentifier(
     )
   }
 
-  // Top-level check — unchanged from this diagnostic's original
-  // position-gating (fires unconditionally, everywhere), but NOW also
-  // respects the ambient loop/callback `BindingScope` a shadowed name
-  // needs — a pre-existing gap (the original single-line
-  // `if (!ts.isIdentifier(expr)) return` never consulted scope either)
-  // that stayed invisible only because a bare top-level identifier
-  // shadowed by a `.map(name => ...)` row param never happened to be
-  // exercised by any prior test. `ctx.scope` is the LIVE scope at this
-  // JSX node — already entered for the current loop row/callback frame
-  // by the time an attribute/child expression under it is checked
-  // (`enterLoopRow`/`enterCallback`, `scope/binding-scope.ts`) — so
-  // `isBound` here is a shadow-guard read in exactly the sense
-  // `spec/compiler.md`'s `BindingScope` section describes: is a signal
-  // getter of this name shadowed HERE, not "does this expression need
-  // its own reactive slot".
+  // Top-level check — `renderedPosition` (checked above) has already
+  // ruled out a component-prop position, so any call reaching here is a
+  // genuinely rendered one. Also respects the ambient loop/callback
+  // `BindingScope` a shadowed name needs — a pre-existing gap (the
+  // original single-line `if (!ts.isIdentifier(expr)) return` never
+  // consulted scope either) that stayed invisible only because a bare
+  // top-level identifier shadowed by a `.map(name => ...)` row param
+  // never happened to be exercised by any prior test. `ctx.scope` is
+  // the LIVE scope at this JSX node — already entered for the current
+  // loop row/callback frame by the time an attribute/child expression
+  // under it is checked (`enterLoopRow`/`enterCallback`,
+  // `scope/binding-scope.ts`) — so `isBound` here is a shadow-guard
+  // read in exactly the sense `spec/compiler.md`'s `BindingScope`
+  // section describes: is a signal getter of this name shadowed HERE,
+  // not "does this expression need its own reactive slot".
   if (ts.isIdentifier(expr)) {
     const kind = reactiveNames.get(expr.text)
     if (kind && !ctx.scope.isBound(expr.text)) report(expr, expr.text, kind)
     return
   }
-
-  if (!options?.descendNested) return
 
   const boundStack: Array<Set<string>> = []
   const isBound = (name: string): boolean => {

--- a/spec/compiler.md
+++ b/spec/compiler.md
@@ -1155,6 +1155,18 @@ error[BF044]: Signal getter 'count' passed without calling it
 | `onChange={setCount}` | No | Setter, not getter |
 | `value={props.checked}` | No | Property access, not bare identifier |
 | `value={count() + 1}` | No | Expression, not bare identifier |
+| `<Child x={count} />` | No | Component prop — see below |
+| `<Child x={{ v: count }} />` | No | Component prop — see below |
+
+**Component props are exempt.** The table above covers DOM element attributes and JSX text
+children — positions that are genuinely RENDERED, where a forgotten `()` silently produces
+wrong output. A component prop is not rendered; it is an opaque value handed to the child,
+and passing a live, uncalled accessor there is this codebase's deliberate Context-Provider
+idiom — `<SelectContext.Provider value={{ open, value: () => … }}>` hands descendants an
+accessor so each consumer subscribes reactively at its own read site, rather than freezing
+the value at provider-render time. This applies equally whether the accessor is passed
+directly (`<Child x={count} />`) or nested inside an object literal
+(`<Child x={{ v: count }} />`) — the two forms are one idiom, not an inconsistency (#2760).
 
 ### class= vs className= in JSX
 

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,8 +1814,14 @@
   },
   "fixtureDivergences": {
     "note": "Render-conformance section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. This answers, per fixture and per adapter, whether the construct WORKS — not just whether it compiles. A construct works either as written (✓) or with a documented `/* @client */` comment (✓†, a verified, supported escape — most refusals have one). Fixtures absent from the table below work on every adapter — most as written, some via that documented escape; the headline says how many of each. Listed fixtures need attention somewhere: a bare diagnostic code is still-open debt with no escape yet, a code led by ✗ owes no escape at all (by design), and ≠ means the fixture compiles clean but its rendered output diverges from the reference.",
-    "totalFixtures": 409,
+    "totalFixtures": 410,
     "fixtures": {
+      "component-prop-bare-getter": {
+        "go-template": {
+          "kind": "render",
+          "reason": "signal getter handed to a plain child-component prop renders empty — constructor baker drops the field (#2925)"
+        }
+      },
       "date-method-uncatalogued": {
         "blade": {
           "kind": "refusal",
@@ -3626,6 +3632,10 @@
       }
     },
     "docs": {
+      "component-prop-bare-getter": {
+        "description": "A signal getter passed directly (unwrapped) to a component prop compiles, matching the…",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/component-prop-bare-getter.ts"
+      },
       "date-method-uncatalogued": {
         "description": "Method call on a Date-typed prop refuses with BF021 (no catalogued lowering)",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/date-method-uncatalogued.ts"

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -1452,11 +1452,11 @@
       }
     },
     "call": {
-      "total": 274,
+      "total": 275,
       "cells": {
         "hono": {
-          "pass": 272,
-          "total": 274,
+          "pass": 273,
+          "total": 275,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1471,8 +1471,8 @@
           ]
         },
         "blade": {
-          "pass": 258,
-          "total": 274,
+          "pass": 259,
+          "total": 275,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1551,8 +1551,8 @@
           ]
         },
         "erb": {
-          "pass": 259,
-          "total": 274,
+          "pass": 260,
+          "total": 275,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1626,8 +1626,12 @@
         },
         "go-template": {
           "pass": 256,
-          "total": 274,
+          "total": 275,
           "gaps": [
+            {
+              "fixture": "component-prop-bare-getter",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -1717,8 +1721,8 @@
           ]
         },
         "jinja": {
-          "pass": 258,
-          "total": 274,
+          "pass": 259,
+          "total": 275,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1797,8 +1801,8 @@
           ]
         },
         "minijinja": {
-          "pass": 258,
-          "total": 274,
+          "pass": 259,
+          "total": 275,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1877,8 +1881,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 259,
-          "total": 274,
+          "pass": 260,
+          "total": 275,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1951,8 +1955,8 @@
           ]
         },
         "twig": {
-          "pass": 258,
-          "total": 274,
+          "pass": 259,
+          "total": 275,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2031,8 +2035,8 @@
           ]
         },
         "xslate": {
-          "pass": 258,
-          "total": 274,
+          "pass": 259,
+          "total": 275,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2256,11 +2260,11 @@
       }
     },
     "identifier": {
-      "total": 387,
+      "total": 388,
       "cells": {
         "hono": {
-          "pass": 383,
-          "total": 387,
+          "pass": 384,
+          "total": 388,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2283,8 +2287,8 @@
           ]
         },
         "blade": {
-          "pass": 367,
-          "total": 387,
+          "pass": 368,
+          "total": 388,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2379,8 +2383,8 @@
           ]
         },
         "erb": {
-          "pass": 367,
-          "total": 387,
+          "pass": 368,
+          "total": 388,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2474,8 +2478,12 @@
         },
         "go-template": {
           "pass": 365,
-          "total": 387,
+          "total": 388,
           "gaps": [
+            {
+              "fixture": "component-prop-bare-getter",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -2581,8 +2589,8 @@
           ]
         },
         "jinja": {
-          "pass": 367,
-          "total": 387,
+          "pass": 368,
+          "total": 388,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2677,8 +2685,8 @@
           ]
         },
         "minijinja": {
-          "pass": 367,
-          "total": 387,
+          "pass": 368,
+          "total": 388,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2773,8 +2781,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 366,
-          "total": 387,
+          "pass": 367,
+          "total": 388,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2875,8 +2883,8 @@
           ]
         },
         "twig": {
-          "pass": 367,
-          "total": 387,
+          "pass": 368,
+          "total": 388,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2971,8 +2979,8 @@
           ]
         },
         "xslate": {
-          "pass": 365,
-          "total": 387,
+          "pass": 366,
+          "total": 388,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3144,11 +3152,11 @@
       }
     },
     "literal": {
-      "total": 309,
+      "total": 310,
       "cells": {
         "hono": {
-          "pass": 308,
-          "total": 309,
+          "pass": 309,
+          "total": 310,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -3157,8 +3165,8 @@
           ]
         },
         "blade": {
-          "pass": 297,
-          "total": 309,
+          "pass": 298,
+          "total": 310,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3213,8 +3221,8 @@
           ]
         },
         "erb": {
-          "pass": 296,
-          "total": 309,
+          "pass": 297,
+          "total": 310,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3274,8 +3282,12 @@
         },
         "go-template": {
           "pass": 295,
-          "total": 309,
+          "total": 310,
           "gaps": [
+            {
+              "fixture": "component-prop-bare-getter",
+              "issues": []
+            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -3341,8 +3353,8 @@
           ]
         },
         "jinja": {
-          "pass": 297,
-          "total": 309,
+          "pass": 298,
+          "total": 310,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3397,8 +3409,8 @@
           ]
         },
         "minijinja": {
-          "pass": 297,
-          "total": 309,
+          "pass": 298,
+          "total": 310,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3453,8 +3465,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 295,
-          "total": 309,
+          "pass": 296,
+          "total": 310,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3521,8 +3533,8 @@
           ]
         },
         "twig": {
-          "pass": 297,
-          "total": 309,
+          "pass": 298,
+          "total": 310,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3577,8 +3589,8 @@
           ]
         },
         "xslate": {
-          "pass": 295,
-          "total": 309,
+          "pass": 296,
+          "total": 310,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3806,11 +3818,11 @@
       }
     },
     "member": {
-      "total": 229,
+      "total": 230,
       "cells": {
         "hono": {
-          "pass": 226,
-          "total": 229,
+          "pass": 227,
+          "total": 230,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3829,8 +3841,8 @@
           ]
         },
         "blade": {
-          "pass": 210,
-          "total": 229,
+          "pass": 211,
+          "total": 230,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3921,8 +3933,8 @@
           ]
         },
         "erb": {
-          "pass": 210,
-          "total": 229,
+          "pass": 211,
+          "total": 230,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4012,8 +4024,12 @@
         },
         "go-template": {
           "pass": 208,
-          "total": 229,
+          "total": 230,
           "gaps": [
+            {
+              "fixture": "component-prop-bare-getter",
+              "issues": []
+            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -4115,8 +4131,8 @@
           ]
         },
         "jinja": {
-          "pass": 210,
-          "total": 229,
+          "pass": 211,
+          "total": 230,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4207,8 +4223,8 @@
           ]
         },
         "minijinja": {
-          "pass": 210,
-          "total": 229,
+          "pass": 211,
+          "total": 230,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4299,8 +4315,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 209,
-          "total": 229,
+          "pass": 210,
+          "total": 230,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4397,8 +4413,8 @@
           ]
         },
         "twig": {
-          "pass": 210,
-          "total": 229,
+          "pass": 211,
+          "total": 230,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4489,8 +4505,8 @@
           ]
         },
         "xslate": {
-          "pass": 208,
-          "total": 229,
+          "pass": 209,
+          "total": 230,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -8121,15 +8137,15 @@
       }
     },
     "literal:number": {
-      "total": 140,
+      "total": 141,
       "cells": {
         "hono": {
-          "pass": 140,
-          "total": 140
+          "pass": 141,
+          "total": 141
         },
         "blade": {
-          "pass": 135,
-          "total": 140,
+          "pass": 136,
+          "total": 141,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8154,8 +8170,8 @@
           ]
         },
         "erb": {
-          "pass": 134,
-          "total": 140,
+          "pass": 135,
+          "total": 141,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8185,8 +8201,12 @@
         },
         "go-template": {
           "pass": 134,
-          "total": 140,
+          "total": 141,
           "gaps": [
+            {
+              "fixture": "component-prop-bare-getter",
+              "issues": []
+            },
             {
               "fixture": "fill-unsupported",
               "issues": []
@@ -8216,8 +8236,8 @@
           ]
         },
         "jinja": {
-          "pass": 135,
-          "total": 140,
+          "pass": 136,
+          "total": 141,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8242,8 +8262,8 @@
           ]
         },
         "minijinja": {
-          "pass": 135,
-          "total": 140,
+          "pass": 136,
+          "total": 141,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8268,8 +8288,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 133,
-          "total": 140,
+          "pass": 134,
+          "total": 141,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8306,8 +8326,8 @@
           ]
         },
         "twig": {
-          "pass": 135,
-          "total": 140,
+          "pass": 136,
+          "total": 141,
           "gaps": [
             {
               "fixture": "fill-unsupported",
@@ -8332,8 +8352,8 @@
           ]
         },
         "xslate": {
-          "pass": 133,
-          "total": 140,
+          "pass": 134,
+          "total": 141,
           "gaps": [
             {
               "fixture": "fill-unsupported",


### PR DESCRIPTION
## Summary

Resolves #2760's tracked BF044 inconsistency: `<Foo x={val} />` (a bare signal/memo getter passed directly to a component prop) refused with BF044, while `<Foo x={{ val }} />` (the identical accessor wrapped in an object literal) passed silently. Per the issue's own analysis and user confirmation, the two forms are one deliberate idiom (this codebase's Context-Provider pattern — measured: 66 real-world uses, none a forgotten `()`), not an inconsistency to resolve by tightening the direct form.

- `checkBareSignalOrMemoIdentifier` (`packages/jsx/src/jsx-to-ir.ts`) now gates its entire check — top-level included, not just its nested-descent walk — on whether the position is genuinely RENDERED (a DOM attribute, a JSX text child). A component prop never is, so both forms now compile identically. Renamed the option `descendNested` → `renderedPosition` since it now controls both levels.
- Added a positive test case (`signal-getter-not-called.test.ts`) and documented the exemption in `spec/compiler.md`'s BF044 section, plus `docs/core/advanced/error-codes.md`'s BF044 example (caught by Pullfrog review — its example used exactly the now-exempted shape).
- New conformance fixture `component-prop-bare-getter` (`packages/adapter-tests/fixtures/`) proves the newly-legal form compiles and renders correctly, per `spec/subset-conformance.md`'s change-time coupling rule.

## Two pre-existing defects surfaced (not caused by this change)

Building the fixture exercised this idiom outside a Context Provider for the first time in the corpus (the 66 real-world uses all route through `provideContext`/`useContext`, never a plain child-component prop), which surfaced two independent, pre-existing bugs that reproduce **identically with the already-legal object-literal-wrapped form** — verified directly against both forms before filing:

- **#2924** — the CSR-fresh-mount `template` lambda (`hydrate('X', { template: ... })`, module scope) references a local signal getter from `renderChild(...)`'s props literal, a guaranteed `ReferenceError` whenever the component is created via CSR without SSR hydration. Pinned in `csr-skip-set.ts` (`CSR_SKIP_FIXTURES`) and `client-js-scope.test.ts`'s `KNOWN_UNDECLARED` scope-gate ledger.
- **#2925** — go-template's constructor-time nested-child-props baker (`NewCounterProps`) silently omits the field when its value is a signal getter, so Go renders it as the zero value instead of the signal's value. Pinned in `render-divergences.ts` (adapter-conformance `skipJsx`).

Both are filed as `known-limitation + bug` with full repro, root-cause analysis, and fix directions in their issue bodies, following the repo's fixture-first defect workflow.

## Test plan

- [x] `bun test packages/jsx/src/__tests__/signal-getter-not-called.test.ts packages/jsx/src/__tests__/invalid-signal-usage.audit.test.ts packages/jsx/src/__tests__/doc-examples.test.ts` — clean, including the new positive case.
- [x] `bun test packages/jsx/src packages/adapter-tests/src packages/compat/src packages/compat/__tests__ ui/components` — 7788 pass, 0 fail.
- [x] `GOTOOLCHAIN=go1.25.6 bun test packages/adapter-go-template/src` — 2111 pass, 0 fail (with real `go run` execution), including the new fixture correctly rendering the CSR-skip/render-divergence pins.
- [x] `bun test packages/adapter-erb/src packages/adapter-jinja/src packages/adapter-rust/src -t "component-prop-bare-getter"` — clean on all three (ERB/Jinja/minijinja route the accessor through live template evaluation, not a static constructor baker, so they don't hit #2925's class of bug).
- [x] `bun run packages/adapter-tests/scripts/generate-expected-html.ts` — regenerated `expectedHtml` for the new fixture from the Hono reference; clean beyond the intended addition.
- [x] `bun packages/adapter-tests/scripts/coverage-map.ts` / `bun run support-matrix:lock` / `bun run compat:lock` — regenerated all derived lock artifacts, 0 diagnostics.
- [x] CI — all checks green (34/34), including `e2e-blade`/`e2e-php`/`e2e-laravel` confirming the PHP-backed adapters are unaffected. Pullfrog reviewed twice (initial finding: stale `docs/core/advanced/error-codes.md` example — fixed; follow-up: no new issues).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JoiEowwf1mVvYywj5AesY