### PR TITLE
Settle #2321 as a permanent known-limitation (docs only)

### DIFF
--- a/packages/adapter-tests/fixtures/static-array-from-props-with-component.ts
+++ b/packages/adapter-tests/fixtures/static-array-from-props-with-component.ts
@@ -27,13 +27,16 @@ import { createFixture } from '../src/types'
  * declare the matching diagnostics via `expectedDiagnostics` on
  * their own test file (#1266).
  * The remaining template-adapter refusal (computed component-scope const as
- * the loop source) is tracked in #2321. It has a verified `/* @client *\/`
- * escape — `static-array-from-props-with-component-client` — that defers
- * the whole loop (the `entries` computation and the `Tag` child body
- * included) to the browser; SSR renders the `<ul>` empty on every DSL
- * adapter. That escape does NOT fix #2321: template adapters still cannot
- * lower a props-derived computed const at SSR time, so #2321 stays open
- * as an SSR capability gap.
+ * the loop source) is tracked in #2321, now settled as a permanent design
+ * position (not a capability gap to close): precompute the array where
+ * it's already computable and pass the RESULT as a prop (the
+ * `-precomputed` escape below) — the better fix, since it keeps full SSR
+ * output — or use the verified `/* @client *\/` escape
+ * (`static-array-from-props-with-component-client`), which defers the
+ * whole loop (the `entries` computation and the `Tag` child body included)
+ * to the browser and renders the `<ul>` empty on every DSL adapter's SSR.
+ * No template adapter will gain a general binding for an arbitrary
+ * computed local; see #2321 for the full reasoning.
  */
 export const fixture = createFixture({
   id: 'static-array-from-props-with-component',

--- a/packages/adapter-tests/fixtures/static-array-from-props.ts
+++ b/packages/adapter-tests/fixtures/static-array-from-props.ts
@@ -18,12 +18,15 @@ import { createFixture } from '../src/types'
  * shape assert the corresponding diagnostic via `expectedDiagnostics`
  * on their own test file (#1266).
  * The remaining template-adapter refusal (computed component-scope const as
- * the loop source) is tracked in #2321. It has a verified `/* @client *\/`
- * escape — `static-array-from-props-client` — that defers the whole loop
- * (the `entries` computation included) to the browser; SSR renders the
- * loop host empty on every DSL adapter. That escape does NOT fix #2321:
- * template adapters still cannot lower a props-derived computed const at
- * SSR time, so #2321 stays open as an SSR capability gap.
+ * the loop source) is tracked in #2321, now settled as a permanent design
+ * position (not a capability gap to close): precompute the array where
+ * it's already computable and pass the RESULT as a prop — the better fix,
+ * since it keeps full SSR output — or use the verified `/* @client *\/`
+ * escape below (`static-array-from-props-client`), which defers the whole
+ * loop (the `entries` computation included) to the browser and renders the
+ * loop host empty on every DSL adapter's SSR. No template adapter will
+ * gain a general binding for an arbitrary computed local; see #2321 for
+ * the full reasoning.
  */
 export const fixture = createFixture({
   id: 'static-array-from-props',


### PR DESCRIPTION
## Summary

#2321 asked which of three directions to take for a computed component-scope `const` (e.g. `Object.entries(props.x).filter(...)`) used as a `.map()` loop source — a shape that refuses with BF101 on all 8 non-Hono template adapters:

1. Derived-const lowering through the `ParsedExpr` pipeline (a new builtin lowering plugin per adapter — 8-adapter feature work).
2. Seed the value at the render boundary (changes the adapter data contract).
3. Declare it out of contract — require users to precompute the value and pass it as a prop, keep the loud BF101.

**Decided: option 3.** No code changes were needed — this was already the implemented and documented behavior:
- `spec/compiler.md`'s BF101 section already leads its help message with "precompute the array server-side and pass it as a prop."
- Every adapter's `conformance-pins.ts` already pins the refusal with `issue: .../2321`.
- Both fixtures (`static-array-from-props`, `static-array-from-props-with-component`) already ship a `prop-precompute` escape twin proving the workaround.

This PR only:
- Relabels the GitHub issue `enhancement` → bare `known-limitation` (accepted permanent design position, no fix planned), matching the #2356 precedent — and keeps it **open** as the permanent by-design tracker (same as #2356), not closed.
- Updates both fixtures' docstrings, which described this as an open SSR capability gap ("#2321 stays open as an SSR capability gap") — now they describe it as the settled decision and point at the precompute-and-pass-as-prop escape as the primary recommended fix.

## Test plan

- [x] Docstring-only change to two `.ts` fixture files — confirmed both still import cleanly (`bun -e "import(...)"`).
- [x] No functional/behavioral change — `spec/compiler.md`, `conformance-pins.ts`, and the fixtures' `escapes` arrays are untouched.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JoiEowwf1mVvYywj5AesY

---
_Generated by [Claude Code](https://claude.ai/code/session_016JoiEowwf1mVvYywj5AesY)_