### PR TITLE
Move D: cross-component prop elision — measured, not implemented

### DIFF
--- a/packages/adapter-hono/bench/hydration-props-bench.ts
+++ b/packages/adapter-hono/bench/hydration-props-bench.ts
@@ -1,0 +1,478 @@
+#!/usr/bin/env bun
+/**
+ * Move D bench: hydration-props measurement + decision artifact.
+ *
+ * Move D of the "Prop Boundary Contract" design (spec/compiler.md, "Cross-
+ * component prop elision (Move D)") asked whether a THIRD elision mechanism
+ * — refining `usedProps` transitively across a component boundary so a
+ * parent stops serializing a prop it only forwards to a child that never
+ * reads it — is worth building on top of the two that already ship:
+ *
+ *   (a) `analyzeClientNeeds` (packages/jsx/src/ir-to-client-js/index.ts) —
+ *       a root mount only serializes props its OWN client code reads
+ *       (`usedProps`), not every prop it was given.
+ *   (b) The `__bfChild` / `__bfNoSerialize` gate (packages/adapter-hono/src/
+ *       adapter/hono-adapter.ts) — a compiled CHILD component never
+ *       serializes props at all; it receives them live via `initChild`.
+ *
+ * This script produces the numbers behind that decision:
+ *
+ *   M1 — per-prop bf-p cost. `serializeHydrationProps` (stringify) +
+ *        `JSON.parse` (mirrors the client's `parseProps` in
+ *        packages/client/src/runtime/hydrate.ts) cost, measured as a linear
+ *        regression SLOPE across prop count N, not the absolute cost at
+ *        N=1 (which is dominated by fixed per-call overhead).
+ *
+ *   M2 — eligible-population census. Compiles every `.tsx` under `site/ui`
+ *        and counts how many parent -> child prop forwards are BARE
+ *        IDENTIFIERS naming one of the parent's own `usedProps`, and of
+ *        those, how many name a prop the child's OWN `usedProps` does not
+ *        contain (the residual case Move D would have to eliminate).
+ *
+ * Run: bun run packages/adapter-hono/bench/hydration-props-bench.ts
+ *
+ * Figures are wall-clock on the calling machine (see printed environment
+ * line) — compare shapes/slopes, not absolute numbers across hosts.
+ */
+
+import { resolve } from 'node:path'
+import { readdir } from 'node:fs/promises'
+import ts from 'typescript'
+import {
+  compileJSX,
+  createProgramForCorpus,
+  TestAdapter,
+  type ComponentIR,
+  type IRNode,
+  type AttrValue,
+} from '@barefootjs/jsx'
+import { serializeHydrationProps } from '../src/utils.ts'
+
+// =============================================================================
+// M1 — per-prop serialize/parse cost
+// =============================================================================
+
+type Shape = 'number' | 'string16' | 'object'
+
+const SHAPES: Shape[] = ['number', 'string16', 'object']
+const NS_LIST = [1, 5, 20, 50]
+const WARMUP = 1000
+const MEASURED = 200_000
+const RUNS = 5
+
+function shapeValue(shape: Shape, i: number): unknown {
+  switch (shape) {
+    case 'number':
+      return i * 7 + 1
+    case 'string16':
+      // Exactly 16 characters.
+      return 'abcdefghijklmnop'
+    case 'object':
+      return { id: i, name: `item-${i}`, tags: ['alpha', 'beta', 'gamma'] }
+  }
+}
+
+function buildProps(n: number, shape: Shape): Record<string, unknown> {
+  const props: Record<string, unknown> = {}
+  for (let i = 0; i < n; i++) {
+    props[`p${i}`] = shapeValue(shape, i)
+  }
+  return props
+}
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b)
+  const mid = Math.floor(sorted.length / 2)
+  return sorted.length % 2 === 1 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2
+}
+
+interface CellResult {
+  n: number
+  shape: Shape
+  stringifyNs: number
+  parseNs: number
+  bytes: number
+}
+
+/** One (N, shape) cell: WARMUP iterations discarded, then RUNS medians of MEASURED iterations each. */
+function benchCell(n: number, shape: Shape): CellResult {
+  const props = buildProps(n, shape)
+
+  for (let i = 0; i < WARMUP; i++) {
+    const json = serializeHydrationProps(props, 'Bench', {})
+    if (json) JSON.parse(json)
+  }
+
+  const stringifyRunsNs: number[] = []
+  const parseRunsNs: number[] = []
+  let bytes = 0
+
+  for (let run = 0; run < RUNS; run++) {
+    let json: string | undefined
+
+    const t0 = Bun.nanoseconds()
+    for (let i = 0; i < MEASURED; i++) {
+      json = serializeHydrationProps(props, 'Bench', {})
+    }
+    const t1 = Bun.nanoseconds()
+    stringifyRunsNs.push((t1 - t0) / MEASURED)
+    bytes = json ? json.length : 0
+
+    const t2 = Bun.nanoseconds()
+    for (let i = 0; i < MEASURED; i++) {
+      JSON.parse(json as string)
+    }
+    const t3 = Bun.nanoseconds()
+    parseRunsNs.push((t3 - t2) / MEASURED)
+  }
+
+  return {
+    n,
+    shape,
+    stringifyNs: median(stringifyRunsNs),
+    parseNs: median(parseRunsNs),
+    bytes,
+  }
+}
+
+/** Ordinary least-squares slope + intercept of ys against xs. */
+function linreg(xs: number[], ys: number[]): { slope: number; intercept: number } {
+  const n = xs.length
+  const sumX = xs.reduce((a, b) => a + b, 0)
+  const sumY = ys.reduce((a, b) => a + b, 0)
+  const sumXY = xs.reduce((acc, x, i) => acc + x * ys[i], 0)
+  const sumXX = xs.reduce((acc, x) => acc + x * x, 0)
+  const denom = n * sumXX - sumX * sumX
+  const slope = denom === 0 ? 0 : (n * sumXY - sumX * sumY) / denom
+  const intercept = (sumY - slope * sumX) / n
+  return { slope, intercept }
+}
+
+interface ShapeSlopes {
+  shape: Shape
+  stringify: { slope: number; intercept: number }
+  parse: { slope: number; intercept: number }
+  bytes: { slope: number; intercept: number }
+}
+
+function runM1(): { cells: CellResult[]; slopes: ShapeSlopes[] } {
+  const cells: CellResult[] = []
+  for (const shape of SHAPES) {
+    for (const n of NS_LIST) {
+      cells.push(benchCell(n, shape))
+    }
+  }
+
+  const slopes: ShapeSlopes[] = SHAPES.map((shape) => {
+    const rows = cells.filter((c) => c.shape === shape)
+    const xs = rows.map((r) => r.n)
+    return {
+      shape,
+      stringify: linreg(xs, rows.map((r) => r.stringifyNs)),
+      parse: linreg(xs, rows.map((r) => r.parseNs)),
+      bytes: linreg(xs, rows.map((r) => r.bytes)),
+    }
+  })
+
+  return { cells, slopes }
+}
+
+function printM1(cells: CellResult[], slopes: ShapeSlopes[]): void {
+  console.log('\n=== M1: per-prop bf-p cost ===\n')
+  console.log(
+    'shape'.padEnd(10) +
+      'N'.padStart(5) +
+      'stringify(ns)'.padStart(16) +
+      'parse(ns)'.padStart(12) +
+      'bytes'.padStart(8),
+  )
+  for (const c of cells) {
+    console.log(
+      c.shape.padEnd(10) +
+        String(c.n).padStart(5) +
+        c.stringifyNs.toFixed(1).padStart(16) +
+        c.parseNs.toFixed(1).padStart(12) +
+        String(c.bytes).padStart(8),
+    )
+  }
+
+  console.log('\n--- linear regression across N (slope = cost per additional prop) ---\n')
+  console.log(
+    'shape'.padEnd(10) +
+      'stringify ns/prop'.padStart(20) +
+      'stringify intercept'.padStart(22) +
+      'parse ns/prop'.padStart(16) +
+      'parse intercept'.padStart(18) +
+      'bytes/prop'.padStart(13) +
+      'bytes intercept'.padStart(18),
+  )
+  for (const s of slopes) {
+    console.log(
+      s.shape.padEnd(10) +
+        s.stringify.slope.toFixed(2).padStart(20) +
+        s.stringify.intercept.toFixed(1).padStart(22) +
+        s.parse.slope.toFixed(2).padStart(16) +
+        s.parse.intercept.toFixed(1).padStart(18) +
+        s.bytes.slope.toFixed(2).padStart(13) +
+        s.bytes.intercept.toFixed(1).padStart(18),
+    )
+  }
+}
+
+// =============================================================================
+// M2 — eligible-population census
+// =============================================================================
+
+/**
+ * Mirrors `findTsxFiles` in packages/jsx/bench/compiler-bench.ts. Not
+ * imported directly — it is a private helper of that bench script, not a
+ * package export, and this script lives in a different package
+ * (`@barefootjs/hono`) — so the walk is duplicated verbatim rather than
+ * reached across a package boundary that isn't a real dependency edge.
+ */
+async function findTsxFiles(dir: string): Promise<string[]> {
+  const out: string[] = []
+  const entries = await readdir(dir, { withFileTypes: true }).catch(() => [])
+  for (const entry of entries) {
+    const full = resolve(dir, entry.name)
+    if (entry.isDirectory()) {
+      out.push(...(await findTsxFiles(full)))
+    } else if (entry.name.endsWith('.tsx') && !entry.name.includes('.test.') && !entry.name.includes('.preview.')) {
+      out.push(full)
+    }
+  }
+  return out
+}
+
+const BARE_IDENTIFIER = /^[A-Za-z_$][A-Za-z0-9_$]*$/
+
+function bareIdentifierOf(value: AttrValue): string | null {
+  if (value.kind !== 'expression') return null
+  const expr = value.expr.trim()
+  return BARE_IDENTIFIER.test(expr) ? expr : null
+}
+
+interface ForwardedProp {
+  parentName: string
+  childName: string
+  propName: string
+}
+
+/** A prop-bearing occurrence of a child component: an `IRComponent` node
+ *  or a loop row (`IRLoopChildComponent`) — both carry `{ name, props }`. */
+interface ComponentOccurrence {
+  name: string
+  props: Array<{ name: string; value: AttrValue }>
+}
+
+function checkOccurrence(
+  occ: ComponentOccurrence,
+  parentName: string,
+  parentUsedProps: ReadonlySet<string>,
+  out: ForwardedProp[],
+): void {
+  for (const prop of occ.props) {
+    const ident = bareIdentifierOf(prop.value)
+    if (ident && parentUsedProps.has(ident)) {
+      out.push({ parentName, childName: occ.name, propName: ident })
+    }
+  }
+}
+
+/** Walk one component's IR tree, recording every bare-identifier prop
+ *  forward that names one of the PARENT's own `usedProps`. */
+function collectForwardedProps(
+  node: IRNode,
+  parentName: string,
+  parentUsedProps: ReadonlySet<string>,
+  out: ForwardedProp[],
+): void {
+  switch (node.type) {
+    case 'component': {
+      checkOccurrence(node, parentName, parentUsedProps, out)
+      for (const prop of node.props) {
+        if (prop.value.kind === 'jsx-children') {
+          for (const child of prop.value.children) {
+            collectForwardedProps(child, parentName, parentUsedProps, out)
+          }
+        }
+      }
+      for (const child of node.children) collectForwardedProps(child, parentName, parentUsedProps, out)
+      break
+    }
+    case 'element':
+    case 'fragment':
+    case 'provider':
+      for (const child of node.children) collectForwardedProps(child, parentName, parentUsedProps, out)
+      break
+    case 'conditional':
+      collectForwardedProps(node.whenTrue, parentName, parentUsedProps, out)
+      collectForwardedProps(node.whenFalse, parentName, parentUsedProps, out)
+      break
+    case 'if-statement':
+      collectForwardedProps(node.consequent, parentName, parentUsedProps, out)
+      if (node.alternate) collectForwardedProps(node.alternate, parentName, parentUsedProps, out)
+      break
+    case 'loop': {
+      for (const child of node.children) collectForwardedProps(child, parentName, parentUsedProps, out)
+      if (node.childComponent) {
+        checkOccurrence(node.childComponent, parentName, parentUsedProps, out)
+        for (const child of node.childComponent.children) {
+          collectForwardedProps(child, parentName, parentUsedProps, out)
+        }
+      }
+      for (const nested of node.nestedComponents ?? []) {
+        checkOccurrence(nested, parentName, parentUsedProps, out)
+        for (const child of nested.children) {
+          collectForwardedProps(child, parentName, parentUsedProps, out)
+        }
+      }
+      break
+    }
+    case 'async':
+      collectForwardedProps(node.fallback, parentName, parentUsedProps, out)
+      for (const child of node.children) collectForwardedProps(child, parentName, parentUsedProps, out)
+      break
+    case 'slot':
+    case 'text':
+    case 'expression':
+      break
+  }
+}
+
+interface M2Result {
+  totalComponents: number
+  componentsWithUsedProps: number
+  totalForwarded: number
+  eligible: number
+  unresolvedChild: number
+  examples: ForwardedProp[]
+}
+
+async function runM2(): Promise<M2Result> {
+  const corpus = resolve(import.meta.dirname, '../../../site/ui')
+  const files = await findTsxFiles(corpus)
+
+  const program = createProgramForCorpus(files, {
+    compilerOptions: { jsx: ts.JsxEmit.ReactJSX },
+  })
+  const adapter = new TestAdapter()
+
+  const componentIRs: ComponentIR[] = []
+
+  // `usedProps` is computed before client-JS pruning runs, so the census
+  // below is unaffected by it — but a handful of `site/ui` files trip
+  // `pruneUnusedPropExtractions`'s internal `console.warn` (pre-existing,
+  // unrelated to Move D). Silenced here so the printed report stays clean.
+  const realWarn = console.warn
+  console.warn = () => {}
+  try {
+    for (const filePath of files) {
+      const source = await Bun.file(filePath).text()
+      let result: ReturnType<typeof compileJSX>
+      try {
+        result = compileJSX(source, filePath, { adapter, program, outputIR: true })
+      } catch {
+        continue
+      }
+      for (const file of result.files) {
+        if (file.type !== 'ir') continue
+        try {
+          componentIRs.push(JSON.parse(file.content) as ComponentIR)
+        } catch {
+          // Skip IR that failed to round-trip through JSON (shouldn't happen —
+          // compileJSX writes it via JSON.stringify itself).
+        }
+      }
+    }
+  } finally {
+    console.warn = realWarn
+  }
+
+  // componentName -> usedProps, built across the WHOLE corpus so a child
+  // defined in a different file than its parent still resolves.
+  const usedPropsByName = new Map<string, Set<string>>()
+  for (const ir of componentIRs) {
+    const usedProps = ir.metadata.clientAnalysis?.usedProps ?? []
+    usedPropsByName.set(ir.metadata.componentName, new Set(usedProps))
+  }
+
+  const forwarded: ForwardedProp[] = []
+  for (const ir of componentIRs) {
+    const parentUsedProps = usedPropsByName.get(ir.metadata.componentName) ?? new Set()
+    if (parentUsedProps.size === 0) continue
+    collectForwardedProps(ir.root, ir.metadata.componentName, parentUsedProps, forwarded)
+  }
+
+  let eligible = 0
+  let unresolvedChild = 0
+  const examples: ForwardedProp[] = []
+  for (const fwd of forwarded) {
+    const childUsedProps = usedPropsByName.get(fwd.childName)
+    if (!childUsedProps) {
+      unresolvedChild++
+      continue
+    }
+    if (!childUsedProps.has(fwd.propName)) {
+      eligible++
+      if (examples.length < 10) examples.push(fwd)
+    }
+  }
+
+  const componentsWithUsedProps = [...usedPropsByName.values()].filter((s) => s.size > 0).length
+
+  return {
+    totalComponents: componentIRs.length,
+    componentsWithUsedProps,
+    totalForwarded: forwarded.length,
+    eligible,
+    unresolvedChild,
+    examples,
+  }
+}
+
+function printM2(result: M2Result, slopes: ShapeSlopes[]): void {
+  console.log('\n=== M2: eligible-population census (site/ui) ===\n')
+  console.log(`components compiled: ${result.totalComponents}`)
+  console.log(`components with a non-empty usedProps (candidate parents): ${result.componentsWithUsedProps}`)
+  console.log(`total bare-identifier prop forwards matching parent usedProps: ${result.totalForwarded}`)
+  console.log(`  of which child component unresolved (skipped from eligible): ${result.unresolvedChild}`)
+  console.log(`eligible (child's own usedProps does NOT contain the forwarded name): ${result.eligible}`)
+  const ratio = result.totalForwarded === 0 ? 0 : result.eligible / result.totalForwarded
+  console.log(`eligible / total forwarded ratio: ${(ratio * 100).toFixed(1)}%`)
+
+  if (result.examples.length > 0) {
+    console.log('\nexamples (up to 10):')
+    for (const ex of result.examples) {
+      console.log(`  <${ex.parentName}> -> <${ex.childName}> prop "${ex.propName}"`)
+    }
+  }
+
+  console.log('\n--- estimated total savings (eligible count x M1 slope) ---')
+  for (const s of slopes) {
+    const stringifyNs = result.eligible * s.stringify.slope
+    const parseNs = result.eligible * s.parse.slope
+    const bytesTotal = result.eligible * s.bytes.slope
+    console.log(
+      `  ${s.shape.padEnd(10)} stringify: ${(stringifyNs / 1000).toFixed(2)} us total` +
+        `  parse: ${(parseNs / 1000).toFixed(2)} us total` +
+        `  bytes: ${bytesTotal.toFixed(1)} bytes total`,
+    )
+  }
+}
+
+// =============================================================================
+// main
+// =============================================================================
+
+async function main(): Promise<void> {
+  console.log(`environment: bun ${Bun.version}, ${process.platform}/${process.arch}, measured ${new Date().toISOString()}`)
+
+  const { cells, slopes } = runM1()
+  printM1(cells, slopes)
+
+  const m2 = await runM2()
+  printM2(m2, slopes)
+}
+
+main()

--- a/packages/adapter-hono/bench/hydration-props-bench.ts
+++ b/packages/adapter-hono/bench/hydration-props-bench.ts
@@ -65,7 +65,6 @@ function shapeValue(shape: Shape, i: number): unknown {
     case 'number':
       return i * 7 + 1
     case 'string16':
-      // Exactly 16 characters.
       return 'abcdefghijklmnop'
     case 'object':
       return { id: i, name: `item-${i}`, tags: ['alpha', 'beta', 'gamma'] }
@@ -94,7 +93,6 @@ interface CellResult {
   bytes: number
 }
 
-/** One (N, shape) cell: WARMUP iterations discarded, then RUNS medians of MEASURED iterations each. */
 function benchCell(n: number, shape: Shape): CellResult {
   const props = buildProps(n, shape)
 
@@ -258,27 +256,6 @@ interface ForwardedProp {
   propName: string
 }
 
-/** A prop-bearing occurrence of a child component: an `IRComponent` node
- *  or a loop row (`IRLoopChildComponent`) — both carry `{ name, props }`. */
-interface ComponentOccurrence {
-  name: string
-  props: Array<{ name: string; value: AttrValue }>
-}
-
-function checkOccurrence(
-  occ: ComponentOccurrence,
-  parentName: string,
-  parentUsedProps: ReadonlySet<string>,
-  out: ForwardedProp[],
-): void {
-  for (const prop of occ.props) {
-    const ident = bareIdentifierOf(prop.value)
-    if (ident && parentUsedProps.has(ident)) {
-      out.push({ parentName, childName: occ.name, propName: ident })
-    }
-  }
-}
-
 /** Walk one component's IR tree, recording every bare-identifier prop
  *  forward that names one of the PARENT's own `usedProps`. */
 function collectForwardedProps(
@@ -289,8 +266,11 @@ function collectForwardedProps(
 ): void {
   switch (node.type) {
     case 'component': {
-      checkOccurrence(node, parentName, parentUsedProps, out)
       for (const prop of node.props) {
+        const ident = bareIdentifierOf(prop.value)
+        if (ident && parentUsedProps.has(ident)) {
+          out.push({ parentName, childName: node.name, propName: ident })
+        }
         if (prop.value.kind === 'jsx-children') {
           for (const child of prop.value.children) {
             collectForwardedProps(child, parentName, parentUsedProps, out)
@@ -313,22 +293,14 @@ function collectForwardedProps(
       collectForwardedProps(node.consequent, parentName, parentUsedProps, out)
       if (node.alternate) collectForwardedProps(node.alternate, parentName, parentUsedProps, out)
       break
-    case 'loop': {
+    // `childComponent` and `nestedComponents` are deliberately NOT visited:
+    // both are derived projections of components already reachable through
+    // `children` (`jsx-to-ir.ts`'s `childComponent = children[0]` and
+    // `collectNestedComponents(children)`), so counting them would inflate
+    // the census denominator two- to threefold for every loop body.
+    case 'loop':
       for (const child of node.children) collectForwardedProps(child, parentName, parentUsedProps, out)
-      if (node.childComponent) {
-        checkOccurrence(node.childComponent, parentName, parentUsedProps, out)
-        for (const child of node.childComponent.children) {
-          collectForwardedProps(child, parentName, parentUsedProps, out)
-        }
-      }
-      for (const nested of node.nestedComponents ?? []) {
-        checkOccurrence(nested, parentName, parentUsedProps, out)
-        for (const child of nested.children) {
-          collectForwardedProps(child, parentName, parentUsedProps, out)
-        }
-      }
       break
-    }
     case 'async':
       collectForwardedProps(node.fallback, parentName, parentUsedProps, out)
       for (const child of node.children) collectForwardedProps(child, parentName, parentUsedProps, out)
@@ -342,6 +314,7 @@ function collectForwardedProps(
 
 interface M2Result {
   totalComponents: number
+  nameCollisions: number
   componentsWithUsedProps: number
   totalForwarded: number
   eligible: number
@@ -352,6 +325,13 @@ interface M2Result {
 async function runM2(): Promise<M2Result> {
   const corpus = resolve(import.meta.dirname, '../../../site/ui')
   const files = await findTsxFiles(corpus)
+  // An empty corpus would print the same "0 eligible" as a genuine census,
+  // and 0 is exactly the finding this script exists to report — so refuse
+  // rather than hand back an unfalsifiable zero.
+  if (files.length === 0) {
+    console.error(`No .tsx files found under ${corpus}`)
+    process.exit(1)
+  }
 
   const program = createProgramForCorpus(files, {
     compilerOptions: { jsx: ts.JsxEmit.ReactJSX },
@@ -390,10 +370,16 @@ async function runM2(): Promise<M2Result> {
   }
 
   // componentName -> usedProps, built across the WHOLE corpus so a child
-  // defined in a different file than its parent still resolves.
+  // defined in a different file than its parent still resolves. The key is
+  // the bare name, so two same-named components collapse onto one entry and
+  // a forward could be scored against the wrong child's `usedProps` —
+  // counted and reported rather than resolved, since the census only needs
+  // the collision count to stay small enough not to move the result.
   const usedPropsByName = new Map<string, Set<string>>()
+  let nameCollisions = 0
   for (const ir of componentIRs) {
     const usedProps = ir.metadata.clientAnalysis?.usedProps ?? []
+    if (usedPropsByName.has(ir.metadata.componentName)) nameCollisions++
     usedPropsByName.set(ir.metadata.componentName, new Set(usedProps))
   }
 
@@ -423,6 +409,7 @@ async function runM2(): Promise<M2Result> {
 
   return {
     totalComponents: componentIRs.length,
+    nameCollisions,
     componentsWithUsedProps,
     totalForwarded: forwarded.length,
     eligible,
@@ -434,6 +421,7 @@ async function runM2(): Promise<M2Result> {
 function printM2(result: M2Result, slopes: ShapeSlopes[]): void {
   console.log('\n=== M2: eligible-population census (site/ui) ===\n')
   console.log(`components compiled: ${result.totalComponents}`)
+  console.log(`  of which same-named (child lookup is name-keyed, so these collapse): ${result.nameCollisions}`)
   console.log(`components with a non-empty usedProps (candidate parents): ${result.componentsWithUsedProps}`)
   console.log(`total bare-identifier prop forwards matching parent usedProps: ${result.totalForwarded}`)
   console.log(`  of which child component unresolved (skipped from eligible): ${result.unresolvedChild}`)
@@ -475,4 +463,7 @@ async function main(): Promise<void> {
   printM2(m2, slopes)
 }
 
-main()
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/spec/compiler.md
+++ b/spec/compiler.md
@@ -1195,6 +1195,97 @@ reactivity is a property of the consumer's declared type.**
   this question and deleted without ever being emitted, once `tsc` was confirmed to cover it
   (`packages/jsx/src/__tests__/props-type-mismatch.audit.test.ts`).
 
+#### Cross-component prop elision (Move D) — measured, not implemented
+
+**The question.** Moves A–C established the prop boundary contract above and closed the
+function-prop hydration hole at the Hono root (Adapter API §"`bf-p` Props Serialization").
+The remaining question they left open: after those three moves, should `usedProps` be
+refined a THIRD way — transitively across a component boundary, so a parent elides a prop
+it forwards to a child that never reads it itself (`<Parent x={val}><Child y={x} />
+</Parent>` where `Child`'s own `usedProps` doesn't include `y`)? A design consult (Fable)
+scoped Move D to measuring this, not building it — the working hypothesis was that most of
+what such elision would do is already shipped by two other mechanisms.
+
+**What already elides.**
+
+- **(a) Per-component `usedProps`.** `analyzeClientNeeds`
+  (`packages/jsx/src/ir-to-client-js/index.ts:173`) walks a component's own IR and computes
+  `usedProps` — the subset of a root mount's incoming props its OWN client code actually
+  reads. A prop the component never references client-side is never serialized, regardless
+  of how many props the caller originally passed.
+- **(b) The `__bfChild` / `__bfNoSerialize` gate.** A component compiled as a CHILD of
+  another (`__bfChild` true at runtime) never serializes ANY props at all — it receives them
+  LIVE via `initChild`, not through `bf-p`. This is unconditional per-component: the gate is
+  `if (!__bfChild && !__bfNoSerialize)` in the generated init
+  (`packages/adapter-hono/src/adapter/hono-adapter.ts:632`, decided by `hasPropsToSerialize`
+  around line 518-520 of the same file). See also "`bf-p` Props Serialization" above for
+  the same gate's function-prop-safety side effect from Move C.
+
+Between (a) and (b), the ONLY case a transitive refinement could still improve is narrow: a
+prop a ROOT mount reads client-side for no other reason than forwarding it into a compiled
+child's props, where that child's own code never reads it. That residual case is what Move D
+measured.
+
+**Measured** (CI sandbox, `bun 1.3.11`, linux/x64, 2026-09-11 — reproduce with the script at
+the bottom of this section; absolute numbers are host-dependent, compare shapes/slopes):
+
+- **M1 — per-prop `bf-p` cost**, as the linear-regression slope of `serializeHydrationProps`
+  (stringify) and `JSON.parse` (mirroring the client's `parseProps`,
+  `packages/client/src/runtime/hydrate.ts:326`) cost against prop count N ∈ {1, 5, 20, 50}
+  (the slope isolates per-prop marginal cost from N=1's fixed per-call overhead):
+
+  | value shape | stringify ns/prop | parse ns/prop | bytes/prop |
+  |---|---|---|---|
+  | number | 37.0 | 65.4 | 9.57 |
+  | 16-char string | 48.9 | 98.7 | 24.84 |
+  | `{id, name, tags:[3]}` object | 199.0 | 690.9 | 64.53 |
+
+  Even the heaviest shape measured (a small nested object) costs under 1 microsecond per
+  prop to stringify and under 1 microsecond to parse. This is the ceiling on what eliding
+  any one prop could save.
+
+- **M2 — eligible-population census**, compiling every `.tsx` under `site/ui` (506
+  components) and counting parent → child prop forwards that are a BARE IDENTIFIER naming
+  one of the parent's own `usedProps`:
+
+  | | count |
+  |---|---|
+  | components with a non-empty `usedProps` (candidate parents) | 38 |
+  | total such bare-identifier forwards | 6 |
+  | — of which the child component couldn't be resolved in-corpus | 3 |
+  | **eligible** (child's own `usedProps` does NOT contain the forwarded name) | **0** |
+
+  Zero. Every resolvable forward in `site/ui` turned out to be a prop the child ALSO reads
+  client-side, so nothing is left over-serialized once (a) and (b) are both in place — the
+  residual case Move D targeted essentially doesn't occur in this corpus. Estimated total
+  savings (eligible count × M1 slope) is therefore 0 ns / 0 bytes across every value shape,
+  for this corpus.
+
+**Why not implemented.** Independent of the measured savings being ~0 today, building this
+would cost more than a typical subset extension:
+
+- `analyzeClientNeeds` operates per-IR — one component's tree, compiled in isolation.
+  Transitive refinement needs the CHILD's `usedProps`, which means cross-file resolution
+  reaching into the build hot path (`bf build`), not a local analysis.
+- Every one of the ~9 backend adapters has its OWN `bf-p`-equivalent prop producer. A
+  cross-component answer computed once and consumed nine different ways is exactly the "one
+  decision, two implementations" defect pattern this codebase's CLAUDE.md warns against
+  (see "Reference Adapter" / "One decision, two implementations, no test comparing them")
+  unless it's built as a single shared implementation from day one — real design and
+  maintenance cost for a change the measurement above shows saves nothing today.
+- As a widening of what the compiler elides, it would need conformance fixtures landed in
+  the same PR per `spec/subset-conformance.md`'s change-time coupling rule — more cost for
+  zero measured benefit.
+
+**Revisit when** any of: the M2 eligible fraction exceeds roughly 25% of serialized props in
+a real app (today: 0%); the measured per-prop slope moves from nanoseconds into
+microseconds (e.g. if `JSON.stringify`/`JSON.parse` were ever replaced by a heavier
+deep-revival codec); or profiling shows `bf-p` attribute size actually dominating HTML
+payload weight in practice, rather than staying in the hundreds-of-bytes-per-component range
+(see "Why `"use client"` is cheap here" for the analogous client-JS-bundle-size figure).
+
+**Reproduce:** `bun run packages/adapter-hono/bench/hydration-props-bench.ts`.
+
 ### class= vs className= in JSX
 
 JSX requires `className` for CSS class attributes. `class` is a reserved keyword in JavaScript and cannot be used as a JSX attribute name.

--- a/spec/compiler.md
+++ b/spec/compiler.md
@@ -1218,7 +1218,7 @@ what such elision would do is already shipped by two other mechanisms.
   LIVE via `initChild`, not through `bf-p`. This is unconditional per-component: the gate is
   `if (!__bfChild && !__bfNoSerialize)` in the generated init
   (`packages/adapter-hono/src/adapter/hono-adapter.ts:632`, decided by `hasPropsToSerialize`
-  around line 518-520 of the same file). See also "`bf-p` Props Serialization" above for
+  at line 473 of the same file). See also "`bf-p` Props Serialization" above for
   the same gate's function-prop-safety side effect from Move C.
 
 Between (a) and (b), the ONLY case a transitive refinement could still improve is narrow: a
@@ -1250,6 +1250,7 @@ the bottom of this section; absolute numbers are host-dependent, compare shapes/
 
   | | count |
   |---|---|
+  | same-named components (the child lookup is name-keyed, so these collapse) | 4 |
   | components with a non-empty `usedProps` (candidate parents) | 38 |
   | total such bare-identifier forwards | 6 |
   | — of which the child component couldn't be resolved in-corpus | 3 |


### PR DESCRIPTION
## What Move D was scoped to investigate

Moves A–C (#2931, #2932, #2933) established the prop boundary contract and closed the function-prop hydration hole at the Hono root. Move D's open question: should `usedProps` be refined a THIRD way — **transitively across a component boundary**, so a parent elides a `bf-p` prop it only forwards to a compiled child that never reads it itself?

A design consult with Fable (already completed before this PR) scoped Move D as a **measurement task, not an implementation task**: the working hypothesis was that most of what such elision would do is already shipped by two mechanisms that predate Move D:

- **(a)** `analyzeClientNeeds` (`packages/jsx/src/ir-to-client-js/index.ts:173`) — a root mount only serializes the props its own client code actually reads (`usedProps`), not every prop it was given.
- **(b)** The `__bfChild` / `__bfNoSerialize` gate (`packages/adapter-hono/src/adapter/hono-adapter.ts:632`) — a component compiled as a CHILD never serializes any props at all; it gets them live via `initChild`.

The only case a transitive refinement could still help: a root mount reads a prop client-side for no reason other than forwarding it into a compiled child that itself never reads it.

## What this PR delivers

1. `packages/adapter-hono/bench/hydration-props-bench.ts` — a bench script with two measurements:
   - **M1**: per-prop `bf-p` cost (`serializeHydrationProps` stringify + `JSON.parse`, mirroring the client's `parseProps`), as a linear-regression **slope** across prop count N ∈ {1, 5, 20, 50} for three value shapes (number / 16-char string / small nested object) — isolating marginal per-prop cost from N=1's fixed overhead.
   - **M2**: an eligible-population census — compiles every `.tsx` under `site/ui` and counts parent → child prop forwards that are a bare identifier naming one of the parent's own `usedProps`, then checks how many of those name a prop the child's own `usedProps` does NOT contain (the residual case Move D would have to eliminate).
2. A new `spec/compiler.md` subsection, **"Cross-component prop elision (Move D) — measured, not implemented"**, right after "The prop boundary contract" section, with the real measured numbers and the decision writeup.

## Measured numbers (this run: CI sandbox, bun 1.3.11, linux/x64, 2026-09-11)

**M1 — per-prop cost (linear regression slope):**

| value shape | stringify ns/prop | parse ns/prop | bytes/prop |
|---|---|---|---|
| number | 37.0 | 65.4 | 9.57 |
| 16-char string | 48.9 | 98.7 | 24.84 |
| `{id, name, tags:[3]}` object | 199.0 | 690.9 | 64.53 |

Even the heaviest shape measured costs under 1 microsecond per prop to stringify and parse.

**M2 — eligible-population census (site/ui, 506 compiled components):**

| | count |
|---|---|
| components with non-empty `usedProps` (candidate parents) | 38 |
| total bare-identifier forwards matching parent `usedProps` | 6 |
| — of which child component unresolved in-corpus | 3 |
| **eligible** (child's own `usedProps` does NOT contain the name) | **0** |

Zero eligible props. Estimated total savings (eligible count × M1 slope) is 0 ns / 0 bytes for this corpus across every value shape.

## Verdict: not implemented, here's why

Independent of the ~0 measured savings today:

- `analyzeClientNeeds` operates per-IR (single component). Transitive refinement would need cross-file resolution reaching into the build hot path (`bf build`), not a local analysis.
- Every one of the ~9 backend adapters has its own `bf-p`-equivalent prop producer — a shared cross-component answer risks becoming exactly the "one decision, two implementations, no test comparing them" defect pattern this repo's CLAUDE.md warns against, unless built as a single shared implementation from day one.
- As a widening of what the compiler elides, it would require conformance fixtures in the same PR per `spec/subset-conformance.md`'s change-time coupling rule.

The measured savings don't justify that cost.

## Revisit when

- The M2 eligible fraction exceeds roughly 25% of serialized props in a real app (today: 0%), or
- The per-prop slope moves from nanoseconds into microseconds (e.g. `JSON.stringify`/`parse` replaced by a heavier codec), or
- Profiling shows `bf-p` attribute size actually dominating HTML payload weight in practice.

## Reproduce

```
bun run packages/adapter-hono/bench/hydration-props-bench.ts
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JoiEowwf1mVvYywj5AesY


---
_Generated by [Claude Code](https://claude.ai/code/session_016JoiEowwf1mVvYywj5AesY)_