### PR TITLE
fix(erb): bind loop item as a real block param to fix nested-loop param shadowing (#2922)

### DIFF
--- a/.changeset/erb-nested-loop-shadowed-param-fix.md
+++ b/.changeset/erb-nested-loop-shadowed-param-fix.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/erb": patch
+---
+
+Fixes a crash when a nested `.map()`'s callback param shadows the outer loop's param name (`items.map(item => item.children.map(item => ...))`, #2922). `renderLoop` used to introduce the per-row item via a plain Ruby assignment (`item = array[_i]`) inside the loop's `each` block — Ruby assignment to a name already visible in an enclosing scope mutates that shared variable instead of shadowing it, so the inner loop's second-plus iteration read the previous inner item instead of the stable outer one and crashed with `undefined method '[]' for nil`. Now binds the item (and, where applicable, the destructure temp) as a genuine `each_with_index` block parameter, which Ruby always shadows correctly at every nesting depth, and declares any remaining plain-assigned per-row bindings (destructure sub-bindings, `.map()` preamble locals) as explicit block-local variables (`do |params; locals| ... end`) so they're never mistaken for an enclosing local either. Graduates the `static-nested-loop-shadowed-param` conformance fixture from a pinned render divergence to a normal passing regression test.

--- a/packages/adapter-erb/src/adapter/erb-adapter.ts
+++ b/packages/adapter-erb/src/adapter/erb-adapter.ts
@@ -1029,6 +1029,57 @@ export class ErbAdapter extends BaseAdapter implements IRNodeEmitter<ErbRenderCt
     // one temporary drop-to-outer window around the hoisted sort-comparator
     // emission below, since that runs OUTSIDE this loop.
     const preambleDecls = loop.preamble?.declarations ?? []
+
+    // Ruby block parameters this loop binds natively (item/value + index /
+    // key). A real block parameter always shadows a same-named enclosing
+    // local at every nesting depth — unlike a plain `x = ...` assignment
+    // inside the block, which MUTATES an already-visible enclosing `x`
+    // instead of shadowing it. That distinction is the entire bug in #2922:
+    // `items.map(item => item.children.map(item => ...))` reused the same
+    // Ruby local `item` via assignment at both nesting depths, so the inner
+    // loop's second-plus iteration read the PREVIOUS inner item instead of
+    // the stable outer one. Binding the item as a real `each_with_index`
+    // block parameter (instead of `(0...arr.length).each` + a separate
+    // `item = arr[_i]` assignment) fixes this natively — the receiver
+    // (`array`) is evaluated once, in the ENCLOSING scope, before the block
+    // opens, so a nested loop's own array expression (e.g. `item.children`)
+    // still resolves against the OUTER `item` even when the inner loop binds
+    // a same-named fresh one.
+    const itemParam = supportableDestructure ? '__bf_item' : rubyLocal(param)
+    const blockParams: string = loop.objectIteration
+      ? loop.objectIteration === 'entries'
+        ? `${rubyLocal(loop.index ?? param)}, ${rubyLocal(param)}`
+        : rubyLocal(param)
+      : loop.iterationShape === 'keys'
+        ? indexVar
+        : `${itemParam}, ${indexVar}`
+    // Ruby locals this loop introduces by PLAIN ASSIGNMENT inside the block
+    // body (destructure bindings off `__bf_item`, `.map()` preamble locals,
+    // #2447) — as opposed to a real block parameter above. Declared as
+    // explicit Ruby block-local variables (`do |params; locals| ... end`)
+    // so each gets fresh per-block scope unconditionally, the same way a
+    // block parameter does — not only when a collision with an enclosing
+    // scope is actually detected, since that's a no-op for a name with no
+    // outer counterpart. Safe here because none of these assignments' RHS
+    // ever reads its own LHS name: a destructure binding's RHS is always an
+    // accessor off `__bf_item` (itself a block parameter above), and a JS
+    // preamble `const x = ...x...` initializer is a TDZ error, so it can
+    // only read an EARLIER preamble local (already block-local by then) or
+    // the param/index (also block parameters).
+    const blockLocals = new Set<string>()
+    if (!loop.objectIteration && loop.iterationShape !== 'keys' && supportableDestructure) {
+      for (const b of loop.paramBindings ?? []) blockLocals.add(rubyLocal(b.name))
+    }
+    for (const d of preambleDecls) blockLocals.add(rubyLocal(d.name))
+    // Never list a name that's ALSO a block parameter above — Ruby rejects
+    // that as `duplicated argument name` (a JS param/index and a preamble
+    // local/destructure binding can never share a name anyway; JS itself
+    // refuses the duplicate declaration).
+    for (const p of blockParams.split(', ')) blockLocals.delete(p)
+    const blockHeader = blockLocals.size > 0
+      ? `|${blockParams}; ${[...blockLocals].join(', ')}|`
+      : `|${blockParams}|`
+
     const prevScope = this.scope
     this.scope = prevScope.enterLoopRow(loop)
     const renderedChildren = this.renderChildren(loop.children)
@@ -1091,24 +1142,29 @@ export class ErbAdapter extends BaseAdapter implements IRNodeEmitter<ErbRenderCt
       // `objectIteration` (#2168 object-entries-map): Ruby's `Hash`
       // preserves the source object's insertion order natively (unlike
       // Go's `map`/Perl's hash), so this bypasses the index-range form
-      // above entirely and uses Ruby's own native block-param binding
+      // below entirely and uses Ruby's own native block-param binding
       // (`each_pair`/`each_key`/`each_value`) — no `array[index]` lookup
       // needed, since the block directly yields the key/value.
       const method = loop.objectIteration === 'entries'
         ? 'each_pair'
         : loop.objectIteration === 'keys' ? 'each_key' : 'each_value'
-      const blockParams = loop.objectIteration === 'entries'
-        ? `${rubyLocal(loop.index ?? param)}, ${rubyLocal(param)}`
-        : rubyLocal(param)
-      lines.push(`<%- ${array}.${method} do |${blockParams}| -%>`)
+      lines.push(`<%- ${array}.${method} do ${blockHeader} -%>`)
+    } else if (loop.iterationShape === 'keys') {
+      // `.keys().map(k => ...)` — the callback param IS the index; no
+      // per-item value binding needed (or possible: there is no `array[i]`
+      // item to bind).
+      lines.push(`<%- (0...${array}.length).each do ${blockHeader} -%>`)
     } else {
-    lines.push(`<%- (0...${array}.length).each do |${indexVar}| -%>`)
-    if (loop.iterationShape !== 'keys') {
+      // Item + index as REAL Ruby block parameters of `each_with_index`
+      // (rather than an index-range `.each` + a separate `item = arr[_i]`
+      // assignment) — see this method's `blockParams`/`blockLocals` setup
+      // above for why (#2922).
+      lines.push(`<%- ${array}.each_with_index do ${blockHeader} -%>`)
       if (supportableDestructure) {
-        // Per-item local + one local per binding, built off the binding's
-        // structured `segments` path (never `b.path` — repo rule: no
-        // string-parsing of a JS-shaped accessor). See `rubyAccessorFromSegments`.
-        lines.push(`<%- __bf_item = ${array}[${indexVar}] -%>`)
+        // One local per binding, built off the binding's structured
+        // `segments` path (never `b.path` — repo rule: no string-parsing of
+        // a JS-shaped accessor). See `rubyAccessorFromSegments`. `__bf_item`
+        // itself is now the loop's own block parameter (`itemParam` above).
         for (const b of loop.paramBindings ?? []) {
           // Fixed bindings: `segments` is the FULL accessor path from the
           // item to this binding. Rest bindings: `segments` is the PARENT
@@ -1136,10 +1192,7 @@ export class ErbAdapter extends BaseAdapter implements IRNodeEmitter<ErbRenderCt
             lines.push(`<%- ${rubyLocal(b.name)} = ${accessor} -%>`)
           }
         }
-      } else {
-        lines.push(`<%- ${rubyLocal(param)} = ${array}[${indexVar}] -%>`)
       }
-    }
     }
 
     // Per-row preamble locals (#2447), in source order so a later

--- a/packages/adapter-erb/src/render-divergences.ts
+++ b/packages/adapter-erb/src/render-divergences.ts
@@ -15,16 +15,4 @@ import type { RenderDivergences } from '@barefootjs/jsx'
 // at value position and the runtime evaluator's `object-literal` case
 // now merges it, so the seed classifies `derived` and SSRs identically
 // to Hono.
-export const renderDivergences: RenderDivergences = {
-  // #2922: the static-nested-loop bake reuses the SAME Ruby local variable
-  // name (`item`, the JS source's own param name) for both the outer and
-  // inner loop via plain assignment rather than a block parameter — Ruby
-  // assignment to a name already visible in an enclosing scope mutates
-  // that shared variable instead of shadowing it. On the inner loop's
-  // second-plus iteration, `item = item[:children][_i]` reads `item` as
-  // whatever the PREVIOUS inner iteration left it (a leaf child, no
-  // `:children` key), not the stable outer item — `nil[_i]` raises
-  // `NoMethodError`. Compiles clean (no diagnostic); crashes on render.
-  'static-nested-loop-shadowed-param':
-    'https://github.com/piconic-ai/barefootjs/issues/2922',
-}
+export const renderDivergences: RenderDivergences = {}

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -3542,12 +3542,6 @@
           }
         }
       },
-      "static-nested-loop-shadowed-param": {
-        "erb": {
-          "kind": "render",
-          "reason": "https://github.com/piconic-ai/barefootjs/issues/2922"
-        }
-      },
       "tag-cloud": {
         "blade": {
           "kind": "refusal",
@@ -3731,10 +3725,6 @@
       "static-nested-loop-ref": {
         "description": "a ref callback and a signal-derived text inside a nested .map() under a static (non-signal) outer…",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-nested-loop-ref.ts"
-      },
-      "static-nested-loop-shadowed-param": {
-        "description": "a nested .map() whose param name shadows the outer loop param resolves to the INNER item, not the…",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/static-nested-loop-shadowed-param.ts"
       },
       "tag-cloud": {
         "description": "flatMap block-body tag list — hydration adoption, in-place leaf patch, add, and remove",

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -79,7 +79,7 @@
           ]
         },
         "erb": {
-          "pass": 101,
+          "pass": 102,
           "total": 113,
           "gaps": [
             {
@@ -122,10 +122,6 @@
             },
             {
               "fixture": "some-typeof-predicate",
-              "issues": []
-            },
-            {
-              "fixture": "static-nested-loop-shadowed-param",
               "issues": []
             },
             {
@@ -2383,7 +2379,7 @@
           ]
         },
         "erb": {
-          "pass": 369,
+          "pass": 370,
           "total": 389,
           "gaps": [
             {
@@ -2465,10 +2461,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
-            },
-            {
-              "fixture": "static-nested-loop-shadowed-param",
-              "issues": []
             },
             {
               "fixture": "tag-cloud",
@@ -3221,7 +3213,7 @@
           ]
         },
         "erb": {
-          "pass": 298,
+          "pass": 299,
           "total": 311,
           "gaps": [
             {
@@ -3269,10 +3261,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
-            },
-            {
-              "fixture": "static-nested-loop-shadowed-param",
-              "issues": []
             },
             {
               "fixture": "tag-cloud",
@@ -3933,7 +3921,7 @@
           ]
         },
         "erb": {
-          "pass": 211,
+          "pass": 212,
           "total": 230,
           "gaps": [
             {
@@ -4011,10 +3999,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
-            },
-            {
-              "fixture": "static-nested-loop-shadowed-param",
-              "issues": []
             },
             {
               "fixture": "tag-cloud",
@@ -4649,7 +4633,7 @@
           ]
         },
         "erb": {
-          "pass": 88,
+          "pass": 89,
           "total": 92,
           "gaps": [
             {
@@ -4661,10 +4645,6 @@
               "issues": [
                 "https://github.com/piconic-ai/barefootjs/issues/2321"
               ]
-            },
-            {
-              "fixture": "static-nested-loop-shadowed-param",
-              "issues": []
             },
             {
               "fixture": "tag-cloud",
@@ -8170,7 +8150,7 @@
           ]
         },
         "erb": {
-          "pass": 136,
+          "pass": 137,
           "total": 142,
           "gaps": [
             {
@@ -8187,10 +8167,6 @@
             },
             {
               "fixture": "reduce-typeof-body",
-              "issues": []
-            },
-            {
-              "fixture": "static-nested-loop-shadowed-param",
               "issues": []
             },
             {


### PR DESCRIPTION
## Summary

Fixes #2922: a nested `.map()` whose inner callback param reuses the outer loop's param name (`items.map(item => item.children.map(item => ...))`) crashed the ERB adapter's generated Ruby at render time with `undefined method '[]' for nil (NoMethodError)`.

## Root cause

`renderLoop` (`packages/adapter-erb/src/adapter/erb-adapter.ts`) introduced a `.map()` row's item via a **plain Ruby assignment** (`item = array[_i]`) inside the loop's `each` block. Ruby's scoping rule for plain assignment is: if a local of that name is already visible in an *enclosing* scope, the assignment **mutates** that shared variable instead of shadowing it (only a real block *parameter*, or an explicit block-local declared via `|params; locals|`, gets fresh per-block scope). So on the inner loop's second-plus iteration, `item = item[:children][_i]` read the RHS `item` as whatever the *previous inner iteration* left it — a leaf child with no `:children` key — instead of the stable outer item, and `nil[_i]` raised `NoMethodError`.

## Fix

- Bind the item (and the destructure temp `__bf_item`, where applicable) as a real **`each_with_index` block parameter** instead of an index-range `.each` + a separate assignment. A genuine Ruby block parameter always shadows a same-named enclosing local, at any nesting depth, because the receiver (`array`) is evaluated once in the *enclosing* scope before the block opens — so a nested loop's own array expression (e.g. `item.children`) still resolves against the *outer* `item` even when the inner loop binds a fresh same-named one.
- Declare the remaining plain-assigned per-row bindings (destructure sub-bindings, `.map()` preamble locals, #2447) as explicit Ruby **block-local variables** (`do |params; locals| ... end`), applied unconditionally rather than only when a collision is detected — a no-op for a name with no outer counterpart, and safe because none of these assignments' RHS ever reads its own LHS name.

No changes to identifier-resolution code (`expr/emitters.ts` / `emit-context.ts`): those already emit a bare Ruby local name for a loop-bound identifier, and Ruby's own lexical scoping now does the right thing given the corrected block structure.

## Changes

- `packages/adapter-erb/src/adapter/erb-adapter.ts`: the fix described above.
- `packages/adapter-erb/src/render-divergences.ts`: removes the `static-nested-loop-shadowed-param` pin — the fixture now renders correctly and graduates to a normal passing regression test.
- `ui/compat.lock.json`, `ui/support-matrix.lock.json`: regenerated to drop the now-resolved divergence entries.
- `.changeset/erb-nested-loop-shadowed-param-fix.md`: patch changeset for `@barefootjs/erb`.

## Test plan

- [x] Reproduced the exact crash from #2922 against real Ruby (`erb` stdlib) before the fix.
- [x] Confirmed the fixed `.erb` output renders correctly via real Ruby and matches the fixture's `expectedHtml` byte-for-byte.
- [x] Full `packages/adapter-erb` conformance suite: **1751 pass, 22 skip, 0 fail** (verified both before — where the same failures exist on `main`, confirming they're a pre-existing, unrelated environment gap — and after the fix, with no regressions).
- [x] `bunx tsgo --noEmit` and `biome check` clean on the changed files.
- [x] Regenerated `ui/compat.lock.json` / `ui/support-matrix.lock.json`; diffs are exactly the graduated fixture's divergence entries disappearing, nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017AEkVQuwMv4vULJ7Ziw9CF

---
_Generated by [Claude Code](https://claude.ai/code/session_017AEkVQuwMv4vULJ7Ziw9CF)_