### PR TITLE
Fix effect leak from ref callbacks in conditional branches (#2927)

### DIFF
--- a/.changeset/branch-ref-effect-leak-fix.md
+++ b/.changeset/branch-ref-effect-leak-fix.md
@@ -1,0 +1,5 @@
+---
+"@barefootjs/client": patch
+---
+
+Fixes an effect leak (#2927): `createEffect()` called from a `ref` callback inside a conditional branch (`cond ? <A ref={...}/> : <B/>`) used to leak one effect per re-entry into that branch. `createEffect()` returns `void`, so the compiler-emitted `bindEvents` for a branch whose only reactive content is a `ref` callback has nothing to return, and `insert()`'s `branchCleanup` mechanism never ran — the effect kept firing forever even after its host element was unmounted. `insert()` now runs each branch's `bindEvents()` inside its own `createRoot()`, the same per-scope ownership mechanism `mapArray()` already gives each loop row, so disposing that root on the next branch switch cleans up whatever reactive primitives `bindEvents()` created, whether or not the compiler could enumerate them.

--- a/packages/client/__tests__/runtime/issue-2927-branch-ref-effect-leak.test.ts
+++ b/packages/client/__tests__/runtime/issue-2927-branch-ref-effect-leak.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Regression test for https://github.com/piconic-ai/barefootjs/issues/2927.
+ *
+ * `createEffect()` called from a `ref` callback inside a conditional branch
+ * used to leak one effect per re-entry into that branch: `createEffect()`
+ * returns `void`, so the compiler-emitted `bindEvents` for a branch whose
+ * only reactive content is a `ref`-triggered `createEffect()` returns
+ * `undefined` — there is nothing for `insert()`'s `branchCleanup` mechanism
+ * to call, so the previous entry's effect keeps running forever even after
+ * its host element is unmounted.
+ *
+ * This mirrors the compiled shape from the issue: `bindEvents` calls the
+ * `ref` callback (which calls `createEffect()`) and returns nothing, exactly
+ * as `emitArmBody` currently emits for a branch whose only content is a
+ * `ref` (no reactive attrs/texts/loops/nested conditionals to enumerate).
+ *
+ * Fix: `insert()` now runs every `bindEvents()` call inside its own
+ * `createRoot()` (`activateBranch()` in `runtime/insert.ts`) and disposes
+ * that root on the next branch switch — so effects created by opaque `ref`
+ * code are cleaned up structurally, without the compiler needing to know
+ * they exist.
+ */
+import { describe, test, expect, beforeAll, beforeEach } from 'bun:test'
+import { insert } from '../../src/runtime/insert'
+import { qsa } from '../../src/runtime/query'
+import { createSignal, createEffect } from '../../src/reactive'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+
+beforeAll(() => {
+  if (typeof window === 'undefined') {
+    GlobalRegistrator.register()
+  }
+})
+
+describe('conditional branch ref effect is disposed on re-entry (#2927)', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  test('createEffect() from a ref callback does not leak across branch re-entries', () => {
+    // SSR shape: condition starts false, so only the fragment's comment
+    // markers are rendered. The `host` element (and its `ref`) is only
+    // mounted on the rising edge — same shape as the existing #1071 tests.
+    document.body.innerHTML = `
+      <div bf-s="Repro_test" bf="s2">
+        <!--bf-cond-start:s0--><!--bf-cond-end:s0-->
+      </div>
+    `
+    const scope = document.querySelector('[bf-s]')!
+    const [show, setShow] = createSignal(false)
+    const [tick, setTick] = createSignal(0)
+    let effectRuns = 0
+
+    // Mirrors the compiled `bindEvents` for a branch whose only content is
+    // a `ref` — no disposer is returned, matching today's `emitArmBody`
+    // output (issue's "Compiled output" section).
+    insert(scope, 's0', () => show(), {
+      template: () => `<div bf-c="s0" id="host" bf="s1"></div>`,
+      bindEvents: (__branchScope) => {
+        const el = qsa(__branchScope, '[bf="s1"]')
+        if (el) {
+          createEffect(() => {
+            tick()
+            effectRuns++
+          })
+        }
+        // No return value — the bug this test guards against.
+      }
+    }, {
+      template: () => `<!--bf-cond-start:s0--><!--bf-cond-end:s0-->`,
+      bindEvents: () => {}
+    })
+
+    // Falsy branch: host isn't mounted, no effect yet.
+    expect(effectRuns).toBe(0)
+
+    // Rising edge: host mounts, its ref's createEffect() runs once.
+    setShow(true)
+    expect(effectRuns).toBe(1)
+
+    // Falling then rising edge again (one re-entry into the `true` branch).
+    setShow(false)
+    setShow(true)
+    const afterFirstReentry = effectRuns
+    expect(afterFirstReentry).toBe(2)
+
+    // Only ONE effect (the current one) should be live. A stale effect
+    // from the first mount would double this count.
+    setTick(1)
+    expect(effectRuns).toBe(afterFirstReentry + 1)
+
+    // Re-enter again — still only one live effect.
+    setShow(false)
+    setShow(true)
+    const afterSecondReentry = effectRuns
+
+    setTick(2)
+    expect(effectRuns).toBe(afterSecondReentry + 1)
+  })
+})

--- a/packages/client/src/runtime/insert.ts
+++ b/packages/client/src/runtime/insert.ts
@@ -6,7 +6,7 @@
  * handles event binding for both branches.
  */
 
-import { createEffect, untrack } from '@barefootjs/client/reactive'
+import { createEffect, createRoot, untrack } from '@barefootjs/client/reactive'
 import { find, findCondTarget, commentsInScope } from './query.ts'
 import { setParentScopeId, parseHTML } from './component.ts'
 import { commentScopeRegistry, getCommentScopeBoundary } from './scope.ts'
@@ -193,6 +193,40 @@ function evalBranchTemplate(branch: BranchConfig): BranchTemplateResult {
   return untrack(() => normalizeTemplate(branch.template()))
 }
 
+/**
+ * Single chokepoint for every `branch.bindEvents()` call in this module.
+ *
+ * `bindEvents()`'s own return value only captures cleanup the *compiler*
+ * knew to enumerate (reactive attrs, text effects, nested loops/conditionals
+ * — see `emitArmBody` in the compiler). It can't capture disposers created
+ * by opaque user code the compiler never parses, most notably `createEffect()`
+ * called from inside a `ref` callback (#2927): `createEffect()` returns
+ * `void`, so there is nothing for the compiler to collect in the first
+ * place, and the `ref` callback body is carried as unparsed source text.
+ *
+ * Wrapping the call in `createRoot()` closes that gap structurally instead:
+ * whatever reactive primitives run during `bindEvents()` (tracked or not,
+ * enumerated by the compiler or not) become children of this activation's
+ * root, exactly like `mapArray()` gives each row its own root. Disposing
+ * the root when the branch deactivates disposes all of them, without the
+ * compiler needing to know what they were.
+ */
+function activateBranch(
+  branch: BranchConfig,
+  scope: Element,
+  isFirstRun: boolean
+): () => void {
+  let cleanup: (() => void) | void
+  const disposeRoot = createRoot((dispose) => {
+    cleanup = branch.bindEvents(scope, { isFirstRun })
+    return dispose
+  })
+  return () => {
+    if (typeof cleanup === 'function') cleanup()
+    disposeRoot()
+  }
+}
+
 
 /**
  * Handle conditional DOM updates using branch configurations.
@@ -319,8 +353,7 @@ export function insert(
       // so branch composite loops can skip the wipe-then-rebuild path that
       // is only needed for subsequent branch swaps (the SSR-rendered DOM
       // already matches the data and mapArray reconciles by key from it).
-      const cleanup = branch.bindEvents(region.bindScope, { isFirstRun: true })
-      branchCleanup = typeof cleanup === 'function' ? cleanup : null
+      branchCleanup = activateBranch(branch, region.bindScope, true)
 
       // Auto-focus on first run too (for components created via createComponent with editing=true)
       autoFocusConditionalElement(region, id)
@@ -351,8 +384,7 @@ export function insert(
     }
 
     // Bind events to the newly inserted element (branch swap: not first run).
-    const cleanup = branch.bindEvents(region.bindScope, { isFirstRun: false })
-    branchCleanup = typeof cleanup === 'function' ? cleanup : null
+    branchCleanup = activateBranch(branch, region.bindScope, false)
 
     // Auto-focus elements with autofocus attribute (for dynamically created elements)
     autoFocusConditionalElement(region, id)

--- a/packages/client/src/runtime/insert.ts
+++ b/packages/client/src/runtime/insert.ts
@@ -227,7 +227,6 @@ function activateBranch(
   }
 }
 
-
 /**
  * Handle conditional DOM updates using branch configurations.
  *


### PR DESCRIPTION
## Summary

Fixes #2927: `createEffect()` called from a `ref` callback inside a conditional branch (`cond ? <A ref={...}/> : <B/>`) leaked one effect per re-entry into that branch. The host element was correctly unmounted, but the effect created by its `ref` kept running forever.

### Root cause

`insert()`'s `branchCleanup` mechanism disposes whatever a branch's `bindEvents()` returns before the next branch switch. But `createEffect()` returns `void`, and the compiler-emitted `bindEvents` for a branch whose only reactive content is a `ref` callback has nothing else to enumerate — so it returns `undefined`, `branchCleanup` stays `null`, and the effect the `ref` created is never disposed. Since the `ref` callback body is carried through the compiler as unparsed source text, there's no way to make the compiler collect a disposer out of it without parsing opaque user code.

### Fix

`insert()` (`packages/client/src/runtime/insert.ts`) now runs every `branch.bindEvents()` call inside its own `createRoot()` — the same ownership-scope mechanism `mapArray()` already gives each loop row. Disposing that root on the next branch switch structurally disposes whatever reactive primitives ran during `bindEvents()`, whether or not the compiler knew to enumerate them. This closes the gap for `ref`-created effects without any compiler changes.

### Testing

- Added `packages/client/__tests__/runtime/issue-2927-branch-ref-effect-leak.test.ts`, reproducing the issue's repro shape at the runtime level (mirrors today's compiled `bindEvents` output for a ref-only branch). Verified it fails without the fix (linear effect-count growth per re-entry, matching the issue's observations) and passes with it.
- Full `packages/client/__tests__/` suite: 709 pass (3 pre-existing unrelated failures, confirmed present on `main` before this change too — module resolution issue unrelated to this fix).
- `packages/adapter-tests/src/__tests__/csr-conformance.test.ts`: 382 pass, 0 fail.
- Typecheck (`tsc --noEmit`) and biome lint clean on changed files.

## Test plan

- [x] New runtime regression test added and passing
- [x] Confirmed the new test fails on the pre-fix code (reproduces the leak)
- [x] Full client runtime test suite passes (excluding pre-existing unrelated failures)
- [x] CSR conformance suite passes unchanged
- [x] Typecheck and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A1RH1zeeHJBN2D4QWqVs8u

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1RH1zeeHJBN2D4QWqVs8u)_