### PR TITLE
fix(jsx): body-destructured prop defaults render correctly on SSR across all adapters (#2943)

### DIFF
--- a/.changeset/body-destructured-prop-default-ssr.md
+++ b/.changeset/body-destructured-prop-default-ssr.md
@@ -1,0 +1,20 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/hono": patch
+"@barefootjs/go-template": patch
+"@barefootjs/jinja": patch
+"@barefootjs/xslate": patch
+"@barefootjs/mojolicious": patch
+"@barefootjs/erb": patch
+"@barefootjs/blade": patch
+"@barefootjs/twig": patch
+"@barefootjs/rust": patch
+---
+
+Fixes #2943: a BODY-destructured prop's default (`function Foo(props: Props) { const { label = 'none' } = props; ... }`, renamed or not) now renders correctly on SSR across every backend, matching the parameter-destructured form (`function Foo({ label = 'none' })`). Previously `extractPropsFromTypeMembers` built `propsParams` purely from the TYPE annotation, with no notion of a body destructure's own default — every template-based adapter's presence-guard classification (`collectNullableOptionalProps` and its per-language equivalents) treated the prop as defaultless and OMITTED the attribute entirely when the caller didn't pass it, instead of falling back to the default the way Hono's real JS destructuring naturally does. A RENAMED default (`const { label: text = 'none' } = props`) was worse: it had no `propsParams` entry at all, so Jinja/Xslate/ERB/Blade/Twig/Rust read an undefined template variable unconditionally, Mojolicious fataled under Perl strict mode, and Go's Input struct had no field mapping for it — a `go run` compile error, not a soft divergence.
+
+Fixed at the source: the analyzer now overlays a body-destructure default directly onto `ir.metadata.propsParams` (an unrenamed default overlays the existing type-member entry; a renamed one ADDS a second entry carrying `sourceName`, so the original un-renamed prop stays correctly classified too) — the same shared `ParamInfo` every consumer (each adapter's SSR classification, `extractSsrDefaults`'s stash seed, the CSR-fresh-mount `template:` lambda) already reads for a parameter-destructured default. A previous, narrower workaround in `jsx-to-ir.ts` (`_destructuredPropInfoByName`'s overlay, added for #2934) is removed as redundant now that the default lives on `propsParams` itself.
+
+Two adapter-specific fixes were needed for the renamed+default shape: Hono's hydration-payload serialization now reads `props[sourceName ?? name]` instead of `props[name]` (a renamed synthesized entry has no real property under its local name), and Go's generated Input struct de-duplicates fields that share a caller-facing name, with an `interface{}`-safe fallback extraction for the case where the SAME underlying prop is also read bare elsewhere in the same component (which independently flips that field to a nillable `interface{}` type).
+
+Graduates the `body-destructured-props-live` fixture on all 8 non-Hono adapters (their `renderDivergences` pins are removed) and adds `body-destructured-prop-default-renamed`, a new fixture covering the renamed+default shape across all 9 adapters.

--- a/integrations/chi/components.go
+++ b/integrations/chi/components.go
@@ -55,7 +55,7 @@ type BodyLiveChildInput struct {
 	BfParent string // Optional: parent scope id
 	BfMount string // Optional: slot id in parent
 	Value int
-	Label interface{}
+	Label string
 	OnPick interface{}
 }
 
@@ -70,7 +70,7 @@ type BodyLiveChildProps struct {
 	Scripts *bf.ScriptCollector `json:"-"`
 	BfCallerProps map[string]interface{} `json:"-"`
 	Value int `json:"value"`
-	Label interface{} `json:"label"`
+	Label string `json:"label"`
 	OnPick interface{} `json:"onPick"`
 	Seen int `json:"-"`
 	Doubled interface{} `json:"-"`
@@ -928,9 +928,7 @@ func NewBodyLiveChildProps(in BodyLiveChildInput) BodyLiveChildProps {
 
 	bfCallerProps := map[string]interface{}{}
 	bfCallerProps["value"] = in.Value
-	if in.Label != nil {
-		bfCallerProps["label"] = in.Label
-	}
+	bfCallerProps["label"] = in.Label
 	bfCallerProps["onPick"] = in.OnPick
 
 	return BodyLiveChildProps{
@@ -939,7 +937,7 @@ func NewBodyLiveChildProps(in BodyLiveChildInput) BodyLiveChildProps {
 		BfMount: in.BfMount,
 		BfCallerProps: bfCallerProps,
 		Value: in.Value,
-		Label: in.Label,
+		Label: func() string { if in.Label == "" { return "none" }; return in.Label }(),
 		OnPick: in.OnPick,
 		Seen: 0,
 		Doubled: in.Value * 2,

--- a/integrations/echo/components.go
+++ b/integrations/echo/components.go
@@ -55,7 +55,7 @@ type BodyLiveChildInput struct {
 	BfParent string // Optional: parent scope id
 	BfMount string // Optional: slot id in parent
 	Value int
-	Label interface{}
+	Label string
 	OnPick interface{}
 }
 
@@ -70,7 +70,7 @@ type BodyLiveChildProps struct {
 	Scripts *bf.ScriptCollector `json:"-"`
 	BfCallerProps map[string]interface{} `json:"-"`
 	Value int `json:"value"`
-	Label interface{} `json:"label"`
+	Label string `json:"label"`
 	OnPick interface{} `json:"onPick"`
 	Seen int `json:"-"`
 	Doubled interface{} `json:"-"`
@@ -928,9 +928,7 @@ func NewBodyLiveChildProps(in BodyLiveChildInput) BodyLiveChildProps {
 
 	bfCallerProps := map[string]interface{}{}
 	bfCallerProps["value"] = in.Value
-	if in.Label != nil {
-		bfCallerProps["label"] = in.Label
-	}
+	bfCallerProps["label"] = in.Label
 	bfCallerProps["onPick"] = in.OnPick
 
 	return BodyLiveChildProps{
@@ -939,7 +937,7 @@ func NewBodyLiveChildProps(in BodyLiveChildInput) BodyLiveChildProps {
 		BfMount: in.BfMount,
 		BfCallerProps: bfCallerProps,
 		Value: in.Value,
-		Label: in.Label,
+		Label: func() string { if in.Label == "" { return "none" }; return in.Label }(),
 		OnPick: in.OnPick,
 		Seen: 0,
 		Doubled: in.Value * 2,

--- a/integrations/gin/components.go
+++ b/integrations/gin/components.go
@@ -55,7 +55,7 @@ type BodyLiveChildInput struct {
 	BfParent string // Optional: parent scope id
 	BfMount string // Optional: slot id in parent
 	Value int
-	Label interface{}
+	Label string
 	OnPick interface{}
 }
 
@@ -70,7 +70,7 @@ type BodyLiveChildProps struct {
 	Scripts *bf.ScriptCollector `json:"-"`
 	BfCallerProps map[string]interface{} `json:"-"`
 	Value int `json:"value"`
-	Label interface{} `json:"label"`
+	Label string `json:"label"`
 	OnPick interface{} `json:"onPick"`
 	Seen int `json:"-"`
 	Doubled interface{} `json:"-"`
@@ -928,9 +928,7 @@ func NewBodyLiveChildProps(in BodyLiveChildInput) BodyLiveChildProps {
 
 	bfCallerProps := map[string]interface{}{}
 	bfCallerProps["value"] = in.Value
-	if in.Label != nil {
-		bfCallerProps["label"] = in.Label
-	}
+	bfCallerProps["label"] = in.Label
 	bfCallerProps["onPick"] = in.OnPick
 
 	return BodyLiveChildProps{
@@ -939,7 +937,7 @@ func NewBodyLiveChildProps(in BodyLiveChildInput) BodyLiveChildProps {
 		BfMount: in.BfMount,
 		BfCallerProps: bfCallerProps,
 		Value: in.Value,
-		Label: in.Label,
+		Label: func() string { if in.Label == "" { return "none" }; return in.Label }(),
 		OnPick: in.OnPick,
 		Seen: 0,
 		Doubled: in.Value * 2,

--- a/integrations/nethttp/components.go
+++ b/integrations/nethttp/components.go
@@ -55,7 +55,7 @@ type BodyLiveChildInput struct {
 	BfParent string // Optional: parent scope id
 	BfMount string // Optional: slot id in parent
 	Value int
-	Label interface{}
+	Label string
 	OnPick interface{}
 }
 
@@ -70,7 +70,7 @@ type BodyLiveChildProps struct {
 	Scripts *bf.ScriptCollector `json:"-"`
 	BfCallerProps map[string]interface{} `json:"-"`
 	Value int `json:"value"`
-	Label interface{} `json:"label"`
+	Label string `json:"label"`
 	OnPick interface{} `json:"onPick"`
 	Seen int `json:"-"`
 	Doubled interface{} `json:"-"`
@@ -928,9 +928,7 @@ func NewBodyLiveChildProps(in BodyLiveChildInput) BodyLiveChildProps {
 
 	bfCallerProps := map[string]interface{}{}
 	bfCallerProps["value"] = in.Value
-	if in.Label != nil {
-		bfCallerProps["label"] = in.Label
-	}
+	bfCallerProps["label"] = in.Label
 	bfCallerProps["onPick"] = in.OnPick
 
 	return BodyLiveChildProps{
@@ -939,7 +937,7 @@ func NewBodyLiveChildProps(in BodyLiveChildInput) BodyLiveChildProps {
 		BfMount: in.BfMount,
 		BfCallerProps: bfCallerProps,
 		Value: in.Value,
-		Label: in.Label,
+		Label: func() string { if in.Label == "" { return "none" }; return in.Label }(),
 		OnPick: in.OnPick,
 		Seen: 0,
 		Doubled: in.Value * 2,

--- a/packages/adapter-blade/src/render-divergences.ts
+++ b/packages/adapter-blade/src/render-divergences.ts
@@ -15,15 +15,10 @@ import type { RenderDivergences } from '@barefootjs/jsx'
 // at value position and the runtime evaluator's `object-literal` case
 // now merges it, so the seed classifies `derived` and SSRs identically
 // to Hono.
-export const renderDivergences: RenderDivergences = {
-  // #2943: a BODY-destructured prop default (`const { label = 'none' } =
-  // props`) never reaches `ParamInfo.defaultValue` (`extractPropsFromTypeMembers`
-  // is type-member info only) nor the SSR stash seed (`extractSsrDefaults`
-  // skips defaults in props-object mode), so the adapter's presence guard
-  // OMITS `data-label` when the caller passes nothing — Hono's real
-  // destructuring default renders `data-label="none"`. The parameter-
-  // destructured twin (`destructured-props-live`) is correct on this
-  // adapter.
-  'body-destructured-props-live':
-    'body-destructured prop default omits the attribute instead of rendering the default on SSR (https://github.com/piconic-ai/barefootjs/issues/2943)',
-}
+// #2943 graduated: a BODY-destructured prop's default now reaches
+// `ParamInfo.defaultValue` directly (the analyzer overlays it onto
+// `propsParams` at the binding's own declaration), so `extractSsrDefaults`
+// seeds the evaluated default and the adapter's presence guard no longer
+// treats the prop as defaultless — `data-label` now renders `'none'` here
+// exactly like Hono, both for a plain default and a renamed one.
+export const renderDivergences: RenderDivergences = {}

--- a/packages/adapter-erb/src/render-divergences.ts
+++ b/packages/adapter-erb/src/render-divergences.ts
@@ -15,15 +15,10 @@ import type { RenderDivergences } from '@barefootjs/jsx'
 // at value position and the runtime evaluator's `object-literal` case
 // now merges it, so the seed classifies `derived` and SSRs identically
 // to Hono.
-export const renderDivergences: RenderDivergences = {
-  // #2943: a BODY-destructured prop default (`const { label = 'none' } =
-  // props`) never reaches `ParamInfo.defaultValue` (`extractPropsFromTypeMembers`
-  // is type-member info only) nor the SSR stash seed (`extractSsrDefaults`
-  // skips defaults in props-object mode), so the adapter's presence guard
-  // OMITS `data-label` when the caller passes nothing — Hono's real
-  // destructuring default renders `data-label="none"`. The parameter-
-  // destructured twin (`destructured-props-live`) is correct on this
-  // adapter.
-  'body-destructured-props-live':
-    'body-destructured prop default omits the attribute instead of rendering the default on SSR (https://github.com/piconic-ai/barefootjs/issues/2943)',
-}
+// #2943 graduated: a BODY-destructured prop's default now reaches
+// `ParamInfo.defaultValue` directly (the analyzer overlays it onto
+// `propsParams` at the binding's own declaration), so `extractSsrDefaults`
+// seeds the evaluated default and the adapter's presence guard no longer
+// treats the prop as defaultless — `data-label` now renders `'none'` here
+// exactly like Hono, both for a plain default and a renamed one.
+export const renderDivergences: RenderDivergences = {}

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -1726,6 +1726,14 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
 
     const nestedArrayFields = this.propDerivedNestedArrayFields(nestedComponents)
 
+    // #2943: a body-destructure-with-default rename (`const { label: text =
+    // 'none' } = props`) adds a SECOND `propsParams` entry (`text`,
+    // `sourceName: 'label'`) alongside the original `label` entry — both
+    // share ONE caller-facing field name here (`Label`), so the naive
+    // per-entry loop below would emit it twice, a Go compile error
+    // (`Label redeclared`). Track emitted field names and keep only the
+    // first entry for a given name.
+    const emittedInputFields = new Set<string>()
     for (const param of ir.metadata.propsParams) {
       // #2525: caller-facing name, not the local destructure binding — a
       // caller-side composite `BadgeInput{N: 5}` literal is written against
@@ -1734,7 +1742,9 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       // `{{.X}}` executes against) stays keyed by the local binding — see
       // `emitPropsDataFields`.
       const fieldName = capitalizeFieldName(param.sourceName ?? param.name)
+      if (emittedInputFields.has(fieldName)) continue
       if (this.isNestedArrayShadowed(param, nestedArrayFields)) continue
+      emittedInputFields.add(fieldName)
       const goType = resolvePropGoType(this.emitCtx, param, propTypeOverrides)
       lines.push(`\t${fieldName} ${goType}`)
     }
@@ -1785,6 +1795,31 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
 
     lines.push('}')
     lines.push('')
+  }
+
+  /**
+   * The Go type the Input struct ACTUALLY emits for `fieldName` —
+   * `generateInputStruct`'s own first-entry-wins dedup (#2943: a
+   * body-destructure-with-default rename like `{ label: text = 'none' }`
+   * adds a second `propsParams` entry sharing `label`'s caller-facing
+   * field name), replayed here so a default-application site downstream
+   * (`generatePropsStruct`) picks the wrapper that matches the type the
+   * field was ACTUALLY declared with — not the type `text`'s OWN
+   * `ParamInfo` would resolve to in isolation, which can disagree when an
+   * earlier, non-defaulted entry for the same field (e.g. a bare
+   * `props.label` read elsewhere) won the interface{}-nillable flip.
+   */
+  private resolveInputFieldGoType(
+    ir: ComponentIR,
+    fieldName: string,
+    propTypeOverrides: Map<string, string>,
+  ): string | undefined {
+    for (const param of ir.metadata.propsParams) {
+      if (capitalizeFieldName(param.sourceName ?? param.name) === fieldName) {
+        return resolvePropGoType(this.emitCtx, param, propTypeOverrides)
+      }
+    }
+    return undefined
   }
 
   private generatePropsStruct(
@@ -2175,7 +2210,25 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       } else {
         const paramDefault = goPropDefault(param.defaultValue)
         const memoFold = memoFallbacks.get(fieldName)
-        if (paramDefault !== null) {
+        const outputType = resolvePropGoType(this.emitCtx, param, propTypeOverrides)
+        if (
+          paramDefault !== null &&
+          outputType !== 'interface{}' &&
+          this.resolveInputFieldGoType(ir, inputField, propTypeOverrides) === 'interface{}'
+        ) {
+          // #2943: the shared Input FIELD this default reads from resolved
+          // to `interface{}` — not `param`'s (concrete, since it has its
+          // OWN default) `outputType` — because another `propsParams` entry
+          // sharing this field name (a bare `props.X` read elsewhere) won
+          // the nillable flip. `applyGoFallback`'s zero-value check assumes
+          // the ref is already `outputType`-typed, which `in.<inputField>`
+          // no longer is; nil-check then type-assert back to `outputType`
+          // instead (the TS type contract guarantees a caller-supplied
+          // value is that type whenever it isn't nil).
+          lines.push(
+            `\t\t${fieldName}: func() ${outputType} { if in.${inputField} == nil { return ${paramDefault} }; return in.${inputField}.(${outputType}) }(),`,
+          )
+        } else if (paramDefault !== null) {
           lines.push(`\t\t${fieldName}: ${applyGoFallback(`in.${inputField}`, paramDefault)},`)
         } else if (memoFold !== undefined && memoFold.goType === 'string') {
           lines.push(`\t\t${fieldName}: ${applyGoFallback(`in.${inputField}`, memoFold.goFallback)},`)

--- a/packages/adapter-go-template/src/render-divergences.ts
+++ b/packages/adapter-go-template/src/render-divergences.ts
@@ -52,15 +52,14 @@ export const renderDivergences: RenderDivergences = {
   // Provider, which routes through `provideContext`/`useContext` instead and
   // never hit this baker path.
   'component-prop-bare-getter': 'signal getter handed to a plain child-component prop renders empty — constructor baker drops the field (#2925)',
-
-  // #2943: a BODY-destructured prop default (`const { label = 'none' } =
-  // props`) never reaches `ParamInfo.defaultValue` (`extractPropsFromTypeMembers`
-  // is type-member info only) nor the SSR stash seed (`extractSsrDefaults`
-  // skips defaults in props-object mode), so the adapter's presence guard
-  // (`{{if ne .Label nil}}`) OMITS `data-label` when the caller passes
-  // nothing — Hono's real destructuring default renders
-  // `data-label="none"`. The parameter-destructured twin
-  // (`destructured-props-live`) is correct on this adapter.
-  'body-destructured-props-live':
-    'body-destructured prop default omits the attribute instead of rendering the default on SSR (https://github.com/piconic-ai/barefootjs/issues/2943)',
 }
+
+// #2943 graduated: a BODY-destructured prop's default now reaches
+// `ParamInfo.defaultValue` directly (the analyzer overlays it onto
+// `propsParams` at the binding's own declaration), so `extractSsrDefaults`
+// seeds the evaluated default and the adapter's presence guard no longer
+// treats the prop as defaultless — `data-label` now renders `'none'` here
+// exactly like Hono, both for a plain default and a renamed one (the
+// renamed shape also needed a duplicate-Input-field dedup and an
+// `interface{}`-safe fallback extraction in `generateInputStruct` /
+// `generatePropsStruct` — see their docstrings).

--- a/packages/adapter-hono/src/adapter/hono-adapter.ts
+++ b/packages/adapter-hono/src/adapter/hono-adapter.ts
@@ -636,8 +636,16 @@ export class HonoAdapter extends JsxAdapter implements IRNodeEmitter<HonoRenderC
         // deliberately is NOT skipped here: dropping it silently is the bug
         // Move C fixes — `serializeHydrationProps` below decides, via
         // `liveOnlyProps`, whether the client actually needed it.
-        // Use propsObjectName.propName for SolidJS-style, direct propName for destructured
-        const propAccess = propsObjectName ? `${propsObjectName}.${p.name}` : p.name
+        // Use propsObjectName.sourceKey for SolidJS-style, direct propName
+        // for destructured. `sourceName ?? p.name` matters for props-object
+        // mode specifically (#2943): a body-destructure-with-default rename
+        // (`const { label: text = 'none' } = props`) adds a `text` entry
+        // whose real property on `props` is `label`, not `text` — `props`
+        // has no `text` key. The parameter-destructured form needs no such
+        // fallback: that mode already binds a real local under the RENAMED
+        // name at the destructure itself, so `p.name` (the local) is
+        // correct there.
+        const propAccess = propsObjectName ? `${propsObjectName}.${p.sourceName ?? p.name}` : p.name
         // The `bf-p` blob key is always the caller-facing name (#2524 CSR
         // half) — every non-Hono `_p` producer/consumer keys the same way,
         // so a renaming destructure (`{ n: count }`) must serialize under

--- a/packages/adapter-jinja/src/render-divergences.ts
+++ b/packages/adapter-jinja/src/render-divergences.ts
@@ -15,15 +15,10 @@ import type { RenderDivergences } from '@barefootjs/jsx'
 // at value position and the runtime evaluator's `object-literal` case
 // now merges it, so the seed classifies `derived` and SSRs identically
 // to Hono.
-export const renderDivergences: RenderDivergences = {
-  // #2943: a BODY-destructured prop default (`const { label = 'none' } =
-  // props`) never reaches `ParamInfo.defaultValue` (`extractPropsFromTypeMembers`
-  // is type-member info only) nor the SSR stash seed (`extractSsrDefaults`
-  // skips defaults in props-object mode), so `collectNullableOptionalProps`
-  // treats `label` as a no-default optional and emits a presence guard that
-  // OMITS `data-label` when the caller passes nothing — Hono's real
-  // destructuring default renders `data-label="none"`. The parameter-
-  // destructured twin (`destructured-props-live`) is correct on this adapter.
-  'body-destructured-props-live':
-    'body-destructured prop default omits the attribute instead of rendering the default on SSR (https://github.com/piconic-ai/barefootjs/issues/2943)',
-}
+// #2943 graduated: a BODY-destructured prop's default now reaches
+// `ParamInfo.defaultValue` directly (the analyzer overlays it onto
+// `propsParams` at the binding's own declaration), so `extractSsrDefaults`
+// seeds the evaluated default and `collectNullableOptionalProps` no longer
+// treats the prop as defaultless — `data-label` now renders `'none'` here
+// exactly like Hono, both for a plain default and a renamed one.
+export const renderDivergences: RenderDivergences = {}

--- a/packages/adapter-mojolicious/src/render-divergences.ts
+++ b/packages/adapter-mojolicious/src/render-divergences.ts
@@ -15,15 +15,10 @@ import type { RenderDivergences } from '@barefootjs/jsx'
 // at value position and the runtime evaluator's `object-literal` case
 // now merges it, so the seed classifies `derived` and SSRs identically
 // to Hono.
-export const renderDivergences: RenderDivergences = {
-  // #2943: a BODY-destructured prop default (`const { label = 'none' } =
-  // props`) never reaches `ParamInfo.defaultValue` (`extractPropsFromTypeMembers`
-  // is type-member info only) nor the SSR stash seed (`extractSsrDefaults`
-  // skips defaults in props-object mode), so the adapter's presence guard
-  // (`<% if (defined $label) { %>`) OMITS `data-label` when the caller
-  // passes nothing — Hono's real destructuring default renders
-  // `data-label="none"`. The parameter-destructured twin
-  // (`destructured-props-live`) is correct on this adapter.
-  'body-destructured-props-live':
-    'body-destructured prop default omits the attribute instead of rendering the default on SSR (https://github.com/piconic-ai/barefootjs/issues/2943)',
-}
+// #2943 graduated: a BODY-destructured prop's default now reaches
+// `ParamInfo.defaultValue` directly (the analyzer overlays it onto
+// `propsParams` at the binding's own declaration), so `extractSsrDefaults`
+// seeds the evaluated default and the adapter's presence guard no longer
+// treats the prop as defaultless — `data-label` now renders `'none'` here
+// exactly like Hono, both for a plain default and a renamed one.
+export const renderDivergences: RenderDivergences = {}

--- a/packages/adapter-rust/src/render-divergences.ts
+++ b/packages/adapter-rust/src/render-divergences.ts
@@ -17,15 +17,10 @@ import type { RenderDivergences } from '@barefootjs/jsx'
 // at value position and the runtime evaluator's `object-literal` case
 // now merges it, so the seed classifies `derived` and SSRs identically
 // to Hono.
-export const renderDivergences: RenderDivergences = {
-  // #2943: a BODY-destructured prop default (`const { label = 'none' } =
-  // props`) never reaches `ParamInfo.defaultValue` (`extractPropsFromTypeMembers`
-  // is type-member info only) nor the SSR stash seed (`extractSsrDefaults`
-  // skips defaults in props-object mode), so the adapter's presence guard
-  // OMITS `data-label` when the caller passes nothing — Hono's real
-  // destructuring default renders `data-label="none"`. The parameter-
-  // destructured twin (`destructured-props-live`) is correct on this
-  // adapter.
-  'body-destructured-props-live':
-    'body-destructured prop default omits the attribute instead of rendering the default on SSR (https://github.com/piconic-ai/barefootjs/issues/2943)',
-}
+// #2943 graduated: a BODY-destructured prop's default now reaches
+// `ParamInfo.defaultValue` directly (the analyzer overlays it onto
+// `propsParams` at the binding's own declaration), so `extractSsrDefaults`
+// seeds the evaluated default and the adapter's presence guard no longer
+// treats the prop as defaultless — `data-label` now renders `'none'` here
+// exactly like Hono, both for a plain default and a renamed one.
+export const renderDivergences: RenderDivergences = {}

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -923,6 +923,22 @@
         "text"
       ]
     },
+    "body-destructured-prop-default-renamed": {
+      "kinds": [
+        "identifier",
+        "literal",
+        "logical",
+        "member"
+      ],
+      "axes": [
+        "literal:string",
+        "logical:??"
+      ],
+      "contexts": [
+        "attribute",
+        "text"
+      ]
+    },
     "body-destructured-props-live": {
       "kinds": [
         "binary",
@@ -6675,11 +6691,11 @@
     "binary": 106,
     "call": 277,
     "conditional": 33,
-    "identifier": 390,
+    "identifier": 391,
     "index-access": 14,
-    "literal": 312,
-    "logical": 50,
-    "member": 231,
+    "literal": 313,
+    "logical": 51,
+    "member": 232,
     "object-literal": 92,
     "template-literal": 31,
     "unary": 29,
@@ -6724,9 +6740,9 @@
     "literal:boolean": 71,
     "literal:null": 26,
     "literal:number": 143,
-    "literal:string": 213,
+    "literal:string": 214,
     "logical:&&": 7,
-    "logical:??": 42,
+    "logical:??": 43,
     "logical:||": 16,
     "lowering:date": 4,
     "lowering:formatDate": 2,

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -923,6 +923,22 @@
         "text"
       ]
     },
+    "body-destructured-prop-default-renamed": {
+      "kinds": [
+        "identifier",
+        "literal",
+        "logical",
+        "member"
+      ],
+      "axes": [
+        "literal:string",
+        "logical:??"
+      ],
+      "contexts": [
+        "attribute",
+        "text"
+      ]
+    },
     "body-destructured-props-live": {
       "kinds": [
         "binary",
@@ -6690,11 +6706,11 @@
     "binary": 106,
     "call": 277,
     "conditional": 33,
-    "identifier": 391,
+    "identifier": 392,
     "index-access": 14,
-    "literal": 313,
-    "logical": 50,
-    "member": 231,
+    "literal": 314,
+    "logical": 51,
+    "member": 232,
     "object-literal": 92,
     "template-literal": 31,
     "unary": 29,
@@ -6739,9 +6755,9 @@
     "literal:boolean": 71,
     "literal:null": 26,
     "literal:number": 143,
-    "literal:string": 214,
+    "literal:string": 215,
     "logical:&&": 7,
-    "logical:??": 42,
+    "logical:??": 43,
     "logical:||": 16,
     "lowering:date": 4,
     "lowering:formatDate": 2,

--- a/packages/adapter-tests/fixtures/body-destructured-prop-default-renamed.ts
+++ b/packages/adapter-tests/fixtures/body-destructured-prop-default-renamed.ts
@@ -1,0 +1,62 @@
+import { createFixture } from '../src/types'
+
+/**
+ * A RENAMED body-destructured prop WITH a default (`const { label: text =
+ * 'none' } = props`), rendered into an attribute — #2943.
+ *
+ * The twin of `body-destructured-props-live` (the UNRENAMED default,
+ * `const { label = 'none' } = props`) and of `children-passthrough-renamed`
+ * (a RENAME with no default). Neither existing fixture alone exercised
+ * BOTH at once: before #2943, `extractPropsFromTypeMembers` built
+ * `propsParams` purely from the TYPE annotation, with no notion of a body
+ * destructure's own default — so `text` got no `propsParams` entry at all.
+ * Every non-Hono template adapter's presence-guard classification and
+ * `extractSsrDefaults`'s SSR stash then had nothing to seed `text` from:
+ * Jinja/Mojo/etc. read the undefined local `text`/`$text` UNCONDITIONALLY
+ * (no default fallback anywhere), and Go's Input struct had no `Text`
+ * field mapping at all — a `go run` compile error, not a soft divergence.
+ *
+ * Fixed: the analyzer now overlays the default onto a SECOND `propsParams`
+ * entry (`text`, `sourceName: 'label'`) alongside the original `label`
+ * entry, so `text` is seeded and classified exactly like a parameter-
+ * destructured default (`function Foo({ label: text = 'none' })`) would
+ * be. `label` itself stays a real, separately-classified binding — this
+ * fixture ALSO reads `props.label` directly (in a nullish-guarded
+ * attribute) to pin that the rename doesn't clobber or duplicate the
+ * original prop's own classification/stash entry.
+ *
+ * Hono is correct by construction here (it just runs the real JS
+ * destructuring default), so `expectedHtml` is generated from it
+ * unmodified — this fixture graduates the sibling `renderDivergences`
+ * pins that #2943 registered on all 8 non-Hono adapters, it doesn't need
+ * its own.
+ *
+ * Named `RenamedDefaultLabel`, not `Child` — the compiled `init<Name>`
+ * function for a component literally named `Child` collides with the CSR
+ * conformance harness's own `initChild` shim (`csr-render.ts`), the same
+ * class of reserved-identifier collision the earlier `BodyLiveChild`
+ * rename (#2934/#2943) fixed for the Go integrations' `LiveChild` clash.
+ */
+export const fixture = createFixture({
+  id: 'body-destructured-prop-default-renamed',
+  description: 'A renamed body-destructured prop default renders the default on SSR (#2943)',
+  source: `
+function RenamedDefaultLabel(props: { value: number; label?: string }) {
+  const { value, label: text = 'none' } = props
+  return (
+    <div data-label={text} data-raw-label={props.label}>
+      {value}:{text}
+    </div>
+  )
+}
+export { RenamedDefaultLabel }
+`,
+  props: { value: 1 },
+  dataPoints: [
+    { name: 'default-applied', props: { value: 1 } },
+    { name: 'caller-value-wins', props: { value: 1, label: 'named' } },
+  ],
+  expectedHtml: `
+    <div bf-s="test" bf="s2" data-label="none"><!--bf:s0-->1<!--/-->:<!--bf:s1-->none<!--/--></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -24,6 +24,7 @@ import { fixture as reactiveProps } from './reactive-props'
 import { fixture as propsReactivityComparison } from './props-reactivity-comparison'
 import { fixture as destructuredPropsLive } from './destructured-props-live'
 import { fixture as bodyDestructuredPropsLive } from './body-destructured-props-live'
+import { fixture as bodyDestructuredPropDefaultRenamed } from './body-destructured-prop-default-renamed'
 import { fixture as form } from './form'
 import { fixture as portal } from './portal'
 import { fixture as todoApp } from './todo-app'
@@ -657,6 +658,7 @@ export const jsxFixtures: JSXFixture[] = [
   propsReactivityComparison,
   destructuredPropsLive,
   bodyDestructuredPropsLive,
+  bodyDestructuredPropDefaultRenamed,
   form,
   portal,
   todoApp,

--- a/packages/adapter-tests/generated-data-points.json
+++ b/packages/adapter-tests/generated-data-points.json
@@ -625,6 +625,47 @@
       }
     }
   ],
+  "body-destructured-prop-default-renamed": [
+    {
+      "name": "gen:value:zero",
+      "props": {
+        "value": 0
+      }
+    },
+    {
+      "name": "gen:value:negative",
+      "props": {
+        "value": -7
+      }
+    },
+    {
+      "name": "gen:value:large",
+      "props": {
+        "value": 1234567890
+      }
+    },
+    {
+      "name": "gen:label:empty",
+      "props": {
+        "value": 1,
+        "label": ""
+      }
+    },
+    {
+      "name": "gen:label:markup",
+      "props": {
+        "value": 1,
+        "label": "<b>&\"'</b>"
+      }
+    },
+    {
+      "name": "gen:label:multibyte",
+      "props": {
+        "value": 1,
+        "label": "日本語"
+      }
+    }
+  ],
   "branch-local-filter-join": [
     {
       "name": "gen:on:true",

--- a/packages/adapter-twig/src/render-divergences.ts
+++ b/packages/adapter-twig/src/render-divergences.ts
@@ -15,15 +15,10 @@ import type { RenderDivergences } from '@barefootjs/jsx'
 // at value position and the runtime evaluator's `object-literal` case
 // now merges it, so the seed classifies `derived` and SSRs identically
 // to Hono.
-export const renderDivergences: RenderDivergences = {
-  // #2943: a BODY-destructured prop default (`const { label = 'none' } =
-  // props`) never reaches `ParamInfo.defaultValue` (`extractPropsFromTypeMembers`
-  // is type-member info only) nor the SSR stash seed (`extractSsrDefaults`
-  // skips defaults in props-object mode), so the adapter's presence guard
-  // OMITS `data-label` when the caller passes nothing — Hono's real
-  // destructuring default renders `data-label="none"`. The parameter-
-  // destructured twin (`destructured-props-live`) is correct on this
-  // adapter.
-  'body-destructured-props-live':
-    'body-destructured prop default omits the attribute instead of rendering the default on SSR (https://github.com/piconic-ai/barefootjs/issues/2943)',
-}
+// #2943 graduated: a BODY-destructured prop's default now reaches
+// `ParamInfo.defaultValue` directly (the analyzer overlays it onto
+// `propsParams` at the binding's own declaration), so `extractSsrDefaults`
+// seeds the evaluated default and the adapter's presence guard no longer
+// treats the prop as defaultless — `data-label` now renders `'none'` here
+// exactly like Hono, both for a plain default and a renamed one.
+export const renderDivergences: RenderDivergences = {}

--- a/packages/adapter-xslate/src/render-divergences.ts
+++ b/packages/adapter-xslate/src/render-divergences.ts
@@ -22,16 +22,11 @@ import type { RenderDivergences } from '@barefootjs/jsx'
 // the real name off that capture — the same in-template recompute the other
 // six template-stash backends already had. Keep the file even when the set
 // is empty — the next divergence lands here, not in a re-created file.
-export const renderDivergences: RenderDivergences = {
-  // #2943: a BODY-destructured prop default (`const { label = 'none' } =
-  // props`) never reaches `ParamInfo.defaultValue` (`extractPropsFromTypeMembers`
-  // is type-member info only) nor the SSR stash seed (`extractSsrDefaults`
-  // skips defaults in props-object mode), so the adapter's nullable-optional
-  // prop classification treats `label` as a no-default optional and emits a
-  // presence guard that OMITS `data-label` when the caller passes nothing —
-  // Hono's real destructuring default renders `data-label="none"`. The
-  // parameter-destructured twin (`destructured-props-live`) is correct on
-  // this adapter.
-  'body-destructured-props-live':
-    'body-destructured prop default omits the attribute instead of rendering the default on SSR (https://github.com/piconic-ai/barefootjs/issues/2943)',
-}
+// #2943 graduated: a BODY-destructured prop's default now reaches
+// `ParamInfo.defaultValue` directly (the analyzer overlays it onto
+// `propsParams` at the binding's own declaration), so `extractSsrDefaults`
+// seeds the evaluated default and the adapter's nullable-optional
+// classification no longer treats the prop as defaultless — `data-label`
+// now renders `'none'` here exactly like Hono, both for a plain default
+// and a renamed one.
+export const renderDivergences: RenderDivergences = {}

--- a/packages/jsx/src/__tests__/body-destructured-prop-default-propsparams.test.ts
+++ b/packages/jsx/src/__tests__/body-destructured-prop-default-propsparams.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Pins #2943's fix: a BODY-destructured prop's default (`const { label =
+ * 'none' } = props`) is now visible on `ir.metadata.propsParams` itself —
+ * the SAME shared `ParamInfo` a parameter-destructured default
+ * (`function Foo({ label = 'none' })`) already populated via
+ * `extractPropsFromTypeMembers`'s sibling path. Before this fix,
+ * `extractPropsFromTypeMembers` built `propsParams` purely from the TYPE
+ * annotation, with no notion of a body destructure's own default — every
+ * downstream SSR consumer of `ParamInfo.defaultValue`/`.optional` (each
+ * template adapter's presence-guard classification, `extractSsrDefaults`'s
+ * stash seed) then treated the prop as defaultless, guarding the attribute
+ * and omitting it entirely instead of falling back to the default the way
+ * Hono's real JS destructuring naturally does.
+ *
+ * See `analyzer.ts`'s `collectConstant` (the body-destructure branch) and
+ * `bindingElementDefaultFields` (the helper it now shares with the
+ * parameter-destructured path in `extractProps`).
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { analyzeComponent } from '../analyzer'
+import { buildMetadata } from '../compiler'
+
+function propsParamsFor(source: string) {
+  const ctx = analyzeComponent(source, 'test.tsx')
+  return buildMetadata(ctx).propsParams
+}
+
+describe('body-destructured prop defaults overlay onto propsParams (#2943)', () => {
+  test('unrenamed default: the type-member entry gets defaultValue/parsed/optional', () => {
+    const propsParams = propsParamsFor(`
+      function Foo(props: { label?: string }) {
+        const { label = 'none' } = props
+        return <div data-label={label} />
+      }
+    `)
+    expect(propsParams).toEqual([
+      {
+        name: 'label',
+        type: { kind: 'primitive', raw: 'string', primitive: 'string' },
+        optional: true,
+        defaultValue: "'none'",
+        parsed: { kind: 'literal', value: 'none', literalType: 'string' },
+      },
+    ])
+  })
+
+  test('renamed default: ADDS a second entry (sourceName-bearing) rather than replacing the original', () => {
+    // `label` itself stays a real, separately-classified binding (no
+    // default of its own — a bare `props.label` read elsewhere is still
+    // correctly guarded/stash-seeded), and `text` carries `sourceName:
+    // 'label'` so every `sourceName ?? name` consumer resolves the
+    // caller-facing key.
+    const propsParams = propsParamsFor(`
+      function Foo(props: { label?: string }) {
+        const { label: text = 'none' } = props
+        return <div data-label={text} />
+      }
+    `)
+    expect(propsParams).toHaveLength(2)
+    expect(propsParams.find(p => p.name === 'label')).toEqual({
+      name: 'label',
+      type: { kind: 'primitive', raw: 'string', primitive: 'string' },
+      optional: true,
+    })
+    expect(propsParams.find(p => p.name === 'text')).toEqual({
+      name: 'text',
+      type: { kind: 'primitive', raw: 'string', primitive: 'string' },
+      optional: true,
+      sourceName: 'label',
+      defaultValue: "'none'",
+      parsed: { kind: 'literal', value: 'none', literalType: 'string' },
+    })
+  })
+
+  test('untyped `props` param: synthesizes a propsParams entry with `type: unknown` (matching the parameter form\'s own fallback)', () => {
+    const propsParams = propsParamsFor(`
+      function Foo(props) {
+        const { label = 'none' } = props
+        return <div data-label={label} />
+      }
+    `)
+    expect(propsParams).toEqual([
+      {
+        name: 'label',
+        type: { kind: 'unknown', raw: 'unknown' },
+        optional: true,
+        defaultValue: "'none'",
+        parsed: { kind: 'literal', value: 'none', literalType: 'string' },
+      },
+    ])
+  })
+
+  test('arrow-function default (#2940): defaultContainsArrow is set and `parsed` is a real structured arrow, not a truncated re-parse', () => {
+    const propsParams = propsParamsFor(`
+      function Foo(props: { fmt?: (v: number) => string }) {
+        const { fmt = (v) => 'v' + v } = props
+        return <div>{fmt(1)}</div>
+      }
+    `)
+    expect(propsParams).toHaveLength(1)
+    const fmt = propsParams[0]!
+    expect(fmt.name).toBe('fmt')
+    expect(fmt.optional).toBe(true)
+    expect(fmt.defaultValue).toBe("(v) => 'v' + v")
+    expect(fmt.defaultContainsArrow).toBe(true)
+    expect(fmt.parsed?.kind).toBe('arrow')
+  })
+
+  test('renamed, NO default (#2788 shape, unaffected): still just one propsParams entry — no `kids` synthesized', () => {
+    // Defaultless renames stay on the pre-existing #2788 path
+    // (`resolveBodyDestructuredPropAliases`'s SSR-stash local-name-seeding
+    // safety net) — this fix's overlay only fires when `el.initializer`
+    // is present, so it must never duplicate that mechanism's work.
+    const propsParams = propsParamsFor(`
+      function Foo(props: { children?: string }) {
+        const { children: kids } = props
+        return <span>{kids}</span>
+      }
+    `)
+    expect(propsParams).toEqual([
+      {
+        name: 'children',
+        type: { kind: 'primitive', raw: 'string', primitive: 'string' },
+        optional: true,
+      },
+    ])
+  })
+
+  test('a `let` binding still gets the default overlaid — the default is a declaration-time fact, independent of live-rewrite safety', () => {
+    // Unlike `resolveBodyPropAliases`'s `requireLiveRewriteSafe` gate
+    // (which excludes `let`/mutated locals because turning them into a
+    // LIVE `_p.X` read could silently write through to the caller's
+    // prop), a static SSR default has no such hazard — it describes what
+    // the source looked like at its own declaration line, nothing more.
+    const propsParams = propsParamsFor(`
+      function Foo(props: { label?: string }) {
+        let { label = 'none' } = props
+        label = label.toUpperCase()
+        return <div data-label={label} />
+      }
+    `)
+    expect(propsParams).toEqual([
+      {
+        name: 'label',
+        type: { kind: 'primitive', raw: 'string', primitive: 'string' },
+        optional: true,
+        defaultValue: "'none'",
+        parsed: { kind: 'literal', value: 'none', literalType: 'string' },
+      },
+    ])
+  })
+})

--- a/packages/jsx/src/__tests__/body-destructured-props-live.test.ts
+++ b/packages/jsx/src/__tests__/body-destructured-props-live.test.ts
@@ -82,13 +82,19 @@ describe('body-destructured props compile to live reads', () => {
   test('the CSR template lambda also reads a defaulted body alias live, matching the parameter form (#2934)', () => {
     // This is the sibling bug the init-body fix alone doesn't cover: the
     // CSR `template:` lambda (used for a fresh client-side mount with no
-    // SSR markup) is built at Phase 1 from a SEPARATE `ParamInfo` cache
-    // (`jsx-to-ir.ts`'s `_destructuredPropInfoByName`) that, for a
-    // props-object-mode component, held only type-member info with no
-    // default of its own — so `data-label={label}` compiled to a bare
-    // `_p.label` there, omitting the attribute entirely on a CSR-fresh
-    // mount where `_p.label` is `undefined`, instead of applying the
-    // `'none'` default like the parameter-destructured form already did.
+    // SSR markup) is built at Phase 1 from `ctx.analyzer.propsParams`
+    // (via `jsx-to-ir.ts`'s `_destructuredPropInfoByName` cache), which
+    // for a props-object-mode component used to hold only type-member
+    // info with no default of its own — so `data-label={label}` compiled
+    // to a bare `_p.label` there, omitting the attribute entirely on a
+    // CSR-fresh mount where `_p.label` is `undefined`, instead of
+    // applying the `'none'` default like the parameter-destructured form
+    // already did. Fixed at the source (#2943): the analyzer now overlays
+    // a body-destructure default directly onto `propsParams` itself
+    // (`collectConstant`, `analyzer.ts`) — the SAME shared `ParamInfo`
+    // every other consumer (SSR prop classification, `extractSsrDefaults`)
+    // reads, so this CSR cache needs no separate default-resolution logic
+    // of its own anymore.
     const source = `
       'use client'
       function Child(props: { label?: string }) {
@@ -102,6 +108,24 @@ describe('body-destructured props compile to live reads', () => {
     expect(content).toContain("escapeTextOrMarkup((_p.label ?? 'none'))")
     // Never the bare, default-dropping form.
     expect(content).not.toMatch(/\(_p\.label\) != null/)
+  })
+
+  test('a RENAMED body-destructured prop WITH A DEFAULT (`label: text = "none"`) applies the default in the CSR template lambda too (#2943)', () => {
+    // The renamed twin of the unrenamed test above. Before #2943 this
+    // combination had no fixture and no dedicated check — the CSR
+    // template lambda's default application only ever reached an
+    // UNRENAMED alias.
+    const source = `
+      'use client'
+      function Child(props: { label?: string }) {
+        const { label: text = 'none' } = props
+        return <div data-label={text}>{text}</div>
+      }
+    `
+    const { content } = compileClientJs(source, 'Child.tsx')
+    expect(content).not.toMatch(/const text = /)
+    expect(content).toContain("escapeAttr((_p.label ?? 'none'))")
+    expect(content).toContain("escapeTextOrMarkup((_p.label ?? 'none'))")
   })
 
   test('a renamed body-destructured prop (`onPick: pick`) reads the caller-facing key live everywhere', () => {

--- a/packages/jsx/src/__tests__/ssr-defaults.test.ts
+++ b/packages/jsx/src/__tests__/ssr-defaults.test.ts
@@ -352,6 +352,49 @@ describe('extractSsrDefaults', () => {
     expect(defaults?.text).toEqual({ propName: 'text', value: null })
   })
 
+  test('bare-props-form BODY-destructured default (#2943) seeds the evaluated default, not null', () => {
+    // Before #2943, `extractPropsFromTypeMembers` built `propsParams` from
+    // the TYPE annotation alone, with no notion of a body destructure's
+    // own default — this entry seeded `value: null` regardless, and every
+    // non-Hono template adapter's presence-guard classification omitted
+    // the attribute entirely instead of falling back to `'none'`. The
+    // analyzer now overlays the default directly onto `propsParams`
+    // (`collectConstant`), so this is the SAME code path as the
+    // parameter-destructured "destructured prop defaults" test above —
+    // just reached through a body destructure instead.
+    const metadata = metadataFor(`
+      function Foo(props: { label?: string }) {
+        const { label = 'none' } = props
+        return <div data-label={label} />
+      }
+    `)
+    const defaults = extractSsrDefaults(metadata)
+    expect(defaults?.label).toEqual({ propName: 'label', value: 'none' })
+  })
+
+  test('bare-props-form BODY-destructured RENAMED default (#2943): two entries, each correctly classified', () => {
+    // `const { label: text = 'none' } = props` — `label` remains a real,
+    // separately-classified binding (no default of its own: a bare
+    // `props.label` read elsewhere in the same component still needs its
+    // own presence guard / stash entry), and `text` gets its OWN entry
+    // with `propName: 'label'` (the caller-facing key) and the evaluated
+    // default. `deriveStashFromDefaults` then seeds `text` from the
+    // caller's `label` when supplied, else `'none'` — never from `text`
+    // itself (`props` has no `text` key at all).
+    const metadata = metadataFor(`
+      function Foo(props: { label?: string }) {
+        const { label: text = 'none' } = props
+        return <div data-label={text} />
+      }
+    `)
+    const defaults = extractSsrDefaults(metadata)
+    expect(defaults?.label).toEqual({ propName: 'label', value: null })
+    expect(defaults?.text).toEqual({ propName: 'label', value: 'none' })
+
+    expect(deriveStashFromDefaults(defaults!, { label: 'named' })).toMatchObject({ text: 'named' })
+    expect(deriveStashFromDefaults(defaults!, {})).toMatchObject({ text: 'none' })
+  })
+
   test('bare-props-form body-destructure rename (#2788) seeds the SSR stash under the LOCAL name', () => {
     // `function Foo(props: Props) { const { children: kids } = props }` —
     // propsParams here comes from the TYPE annotation and has no notion of

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -3130,6 +3130,30 @@ function getSystemConstructKind(node: ts.Node): 'createContext' | 'weakMap' | un
   return undefined
 }
 
+/**
+ * The default-value-shaped fields a binding element's own `initializer`
+ * contributes to a `ParamInfo` — `defaultValue`'s source text, `parsed`'s
+ * structured mirror (from the initializer's OWN AST node, no re-parse),
+ * and `defaultContainsArrow`. Shared by the parameter-destructured path
+ * (`extractProps`'s Pattern 1, below) and the BODY-destructure-from-props
+ * path (`collectConstant`'s object-binding-pattern branch, #2943) so "what
+ * does this default look like structurally" has one implementation, not
+ * two independently-drifting ones.
+ */
+function bindingElementDefaultFields(
+  initializer: ts.Expression | undefined,
+  ctx: AnalyzerContext,
+): Pick<ParamInfo, 'defaultValue' | 'parsed' | 'defaultContainsArrow'> {
+  const defaultValue = initializer ? ctx.getJS(initializer) : undefined
+  const defaultContainsArrow = initializer ? nodeContainsArrow(initializer) : false
+  const parsedDefault = initializer ? tsNodeToParsedExpr(initializer) : undefined
+  return {
+    defaultValue,
+    ...(parsedDefault && parsedDefault.kind !== 'unsupported' && { parsed: parsedDefault }),
+    defaultContainsArrow: defaultContainsArrow || undefined,
+  }
+}
+
 function collectConstant(
   node: ts.VariableDeclaration,
   ctx: AnalyzerContext,
@@ -3191,6 +3215,55 @@ function collectConstant(
         // _isModule === false; binding lives in init scope.
         origin: { phase: 'hydrate', scope: 'init', effect: 'pure' },
       })
+
+      // #2943: a BODY destructure's default (`const { label = 'none' } =
+      // props`) has no other way to reach `ParamInfo.defaultValue` —
+      // `extractPropsFromTypeMembers` builds `propsParams` purely from the
+      // TYPE annotation, which has no notion of a body-level default. Every
+      // downstream consumer that reads `ParamInfo.defaultValue`/`.optional`
+      // (each adapter's "does this attribute need a presence guard"
+      // classification, `extractSsrDefaults`'s SSR-stash seed, the
+      // CSR-fresh-mount `template:` lambda) needs the default visible here,
+      // on the SAME shared `ParamInfo` the parameter-destructured form
+      // already populates via `bindingElementDefaultFields` above — not on
+      // a second, parallel structure only the CSR lambda used to consult.
+      //
+      // A `let` binding or one `markMutatedConstants` later flags as
+      // mutated is still a perfectly valid default AT its declaration —
+      // this is a static, compile-time fact about the source, not a
+      // liveness question, so (unlike `resolveBodyPropAliases`'s
+      // `requireLiveRewriteSafe` gate) nothing here excludes them.
+      if (el.initializer) {
+        const defaultFields = bindingElementDefaultFields(el.initializer, ctx)
+        const existing = ctx.propsParams.find(p => !p.isRest && p.sourceName === undefined && p.name === sourceKey)
+        if (localName === sourceKey) {
+          // Unrenamed: overlay onto the type-member entry `sourceKey`
+          // already has (or synthesize one for an untyped `props` param,
+          // matching the parameter-destructured form's own `unknown`
+          // fallback for an unannotated `{ x = 1 }`). Never clobber a
+          // default some earlier binding element already established.
+          if (existing) {
+            if (existing.defaultValue === undefined) Object.assign(existing, { optional: true, ...defaultFields })
+          } else {
+            ctx.propsParams.push({ name: localName, type: { kind: 'unknown', raw: 'unknown' }, optional: true, ...defaultFields })
+          }
+        } else if (!ctx.propsParams.some(p => p.name === localName)) {
+          // Renamed (`const { label: text = 'none' } = props`): ADD a
+          // second entry rather than replacing `sourceKey`'s — a bare
+          // `props.label` read elsewhere in the same component is still a
+          // real, separately-classified binding (no default, needs its own
+          // presence guard / stash entry), and `text` needs `sourceName` so
+          // every `sourceName ?? name` consumer resolves the caller-facing
+          // key correctly.
+          ctx.propsParams.push({
+            name: localName,
+            type: existing?.type ?? { kind: 'unknown', raw: 'unknown' },
+            optional: true,
+            sourceName: sourceKey,
+            ...defaultFields,
+          })
+        }
+      }
     }
     return
   }
@@ -3449,7 +3522,6 @@ function extractProps(param: ts.ParameterDeclaration, ctx: AnalyzerContext): voi
     for (const element of param.name.elements) {
       if (ts.isBindingElement(element) && ts.isIdentifier(element.name)) {
         const localName = element.name.text
-        const defaultValue = element.initializer ? ctx.getJS(element.initializer) : undefined
 
         // Handle rest props: { ...props }
         if (element.dotDotDotToken) {
@@ -3466,22 +3538,13 @@ function extractProps(param: ts.ParameterDeclaration, ctx: AnalyzerContext): voi
         const member = memberTypes?.get(sourcePropName)
         const resolvedType: TypeInfo = member?.type ?? { kind: 'unknown', raw: 'unknown' }
 
-        const defaultContainsArrow = element.initializer ? nodeContainsArrow(element.initializer) : false
-        // Structured mirror of `defaultValue`, from the binding element's OWN
-        // `initializer` node — `tsNodeToParsedExpr` converts the already-parsed
-        // AST directly, no re-parse of the `defaultValue` text (same convention
-        // as `SignalInfo.parsed`). An unsupported shape leaves `parsed` unset;
-        // consumers fall back to `defaultValue` text.
-        const parsedDefault = element.initializer ? tsNodeToParsedExpr(element.initializer) : undefined
         ctx.propsParams.push({
           name: localName,
           type: resolvedType,
           // The type's `?` and a destructure default (`{ x = 1 }`) both mean
           // the caller may omit the prop.
           optional: !!member?.optional || !!element.initializer,
-          defaultValue,
-          ...(parsedDefault && parsedDefault.kind !== 'unsupported' && { parsed: parsedDefault }),
-          defaultContainsArrow: defaultContainsArrow || undefined,
+          ...bindingElementDefaultFields(element.initializer, ctx),
           // Only aliased bindings carry the source key — see ParamInfo.sourceName.
           ...(sourcePropName !== localName && { sourceName: sourcePropName }),
         })

--- a/packages/jsx/src/jsx-to-ir.ts
+++ b/packages/jsx/src/jsx-to-ir.ts
@@ -51,7 +51,7 @@ import {
   collectAstPropRefs,
   rewriteScopedValueRefs,
 } from './prop-rewrite.ts'
-import { boundPropLocalNames, buildPropAliasMap, resolveAliasOrigin, resolveRestSpreadOriginCore, livePropReadExpr, resolveBodyPropAliases } from './props-binding.ts'
+import { boundPropLocalNames, buildPropAliasMap, resolveAliasOrigin, resolveRestSpreadOriginCore, livePropReadExpr } from './props-binding.ts'
 import { PROPS_PARAM } from './ir-to-client-js/utils.ts'
 import { resolveFreeRefs, isNameBound as isNameBoundInEnv, type BindingEnvironment } from './free-refs.ts'
 import { computeFileScope } from './ir-to-client-js/component-scope.ts'
@@ -137,12 +137,11 @@ interface TransformContext {
    * `data-label={label}` with `label = 'none'`: correct once the caller
    * sends a value, but the attribute was omitted entirely on the first
    * render, where `_p.label` is `undefined`. Covers PARAMETER destructuring
-   * directly (`propsParams` there already carries `defaultValue`) and, via
-   * an overlay in `getDestructuredPropNames`, an UNRENAMED BODY destructure
-   * default too (`function Foo(props) { const { label = 'none' } = props }`)
-   * — `propsParams` in that mode is type-member info with no default of its
-   * own, so the overlay borrows one from `resolveBodyPropAliases` when the
-   * alias's key matches the type-member name (#2934).
+   * and an UNRENAMED BODY destructure default alike (`function Foo(props) {
+   * const { label = 'none' } = props }`) — both populate `defaultValue`
+   * directly on `propsParams` (the parameter form in `extractProps`, the
+   * body form via `collectConstant`'s overlay, #2943), so this map is a
+   * plain re-keying of `eligible`, no second default-resolution needed.
    */
   _destructuredPropInfoByName?: ReadonlyMap<string, ParamInfo> | null
   /**
@@ -703,23 +702,13 @@ function getDestructuredPropNames(ctx: TransformContext): Set<string> | null {
     const names = eligible.map(p => p.name)
     ctx._destructuredPropNames = names.length > 0 ? new Set(names) : null
     ctx._destructuredPropAliases = buildPropAliasMap(eligible) ?? null
-    // #2934: `eligible`'s `ParamInfo`s are type-member info in props-object
-    // mode (no `defaultValue` of its own) — overlay an UNRENAMED body
-    // destructure's default from `resolveBodyPropAliases` onto it. Guarded
-    // on `alias.key === p.name` so a RENAMED body default (`{ label: text =
-    // 'none' }`, whose bare-identifier bookkeeping above is keyed by the
-    // type member's name `label`, not the local `text`) is deliberately
-    // left alone rather than overlaying a default under the wrong name.
-    const bodyAliases = ctx.analyzer.propsObjectName
-      ? resolveBodyPropAliases(ctx.analyzer.localConstants, ctx.analyzer.propsObjectName)
-      : null
+    // #2943: `eligible`'s `ParamInfo`s already carry a body-destructured
+    // default when the alias is unrenamed — the analyzer overlays it onto
+    // `propsParams` directly at the binding's own declaration
+    // (`collectConstant`, `analyzer.ts`), so no separate overlay is needed
+    // here (there used to be one; see git history at #2934/#2943 for why).
     const infoByName = new Map<string, ParamInfo>()
-    for (const p of eligible) {
-      const alias = bodyAliases?.get(p.name)
-      infoByName.set(p.name, alias?.hasDefault && alias.key === p.name
-        ? { ...p, defaultValue: alias.defaultValue, defaultContainsArrow: alias.defaultContainsArrow }
-        : p)
-    }
+    for (const p of eligible) infoByName.set(p.name, p)
     ctx._destructuredPropInfoByName = infoByName.size > 0 ? infoByName : null
   }
   return ctx._destructuredPropNames ?? null

--- a/packages/jsx/src/props-binding.ts
+++ b/packages/jsx/src/props-binding.ts
@@ -132,11 +132,14 @@ export interface BodyPropAlias {
    *  explicit `props.x ?? d` alias) — `resolveBodyDestructuredPropAliases`
    *  excludes these; `resolveBodyAliasReads` handles them itself. */
   hasDefault: boolean
-  /** The `??` right-hand side's source text, present iff `hasDefault` —
-   *  mirrors `ParamInfo.defaultValue`. */
-  defaultValue?: string
   /** When true, the default value contains an arrow function or function
-   *  expression — mirrors `ParamInfo.defaultContainsArrow`. */
+   *  expression — mirrors `ParamInfo.defaultContainsArrow`. `hasDefault`'s
+   *  own source text is NOT carried here (unlike `defaultContainsArrow`):
+   *  `rewriteBodyAliasReads` re-derives it from the emitted init body's own
+   *  declaration rather than from this alias (see its docstring), and the
+   *  only OTHER consumer that once read a `defaultValue` field here — the
+   *  `jsx-to-ir.ts` CSR-template overlay — is gone since #2943 folded the
+   *  default straight onto `ParamInfo.defaultValue` at the analyzer level. */
   defaultContainsArrow?: boolean
 }
 
@@ -197,7 +200,6 @@ export function resolveBodyPropAliases(
     aliases.set(c.name, {
       key: read.key,
       hasDefault,
-      defaultValue: read.fallback?.getText(sourceFile),
       defaultContainsArrow: hasDefault ? c.containsArrow : undefined,
     })
   }

--- a/packages/jsx/src/ssr-defaults.ts
+++ b/packages/jsx/src/ssr-defaults.ts
@@ -184,10 +184,15 @@ export function extractSsrDefaults(metadata: IRMetadata): Record<string, SsrDefa
   //     adapters flatten `props.X` to the same bare scalar (`$X` — see
   //     the Mojo emitter's `member()`), NOT a `$props->{X}` hash read,
   //     so an unseeded prop the caller forgets to pass is a strict-mode
-  //     compile error, not a soft `undef` (#2126). Seed every declared
-  //     prop with a `null` fallback (→ undef; the template-side `// …`
-  //     recompute supplies the real default, and a caller-passed prop
-  //     wins via `propName`).
+  //     compile error, not a soft `undef` (#2126). A BODY-destructured
+  //     default (`const { label = 'none' } = props`, #2943) reaches this
+  //     same `p.defaultValue` too — the analyzer overlays it onto
+  //     `propsParams` at the binding's own declaration (`collectConstant`,
+  //     `analyzer.ts`) — so it needs no separate branch here: any prop
+  //     with a static default, from either destructuring form, seeds the
+  //     evaluated value; one with none seeds `null` (→ undef; the
+  //     template-side `// …` recompute supplies the real default, and a
+  //     caller-passed prop wins via `propName`).
   for (const p of metadata.propsParams) {
     if (p.isRest) continue
     // `propName` is the CALLER-facing key (`$props->{propName}` in the Perl
@@ -195,7 +200,7 @@ export function extractSsrDefaults(metadata: IRMetadata): Record<string, SsrDefa
     // `n`, not the local binding `count` the template variable is keyed by.
     // `sourceName ?? name` is an identity for every un-aliased prop.
     const callerPropName = p.sourceName ?? p.name
-    if (metadata.propsObjectName === null && p.defaultValue !== undefined) {
+    if (p.defaultValue !== undefined) {
       const value = tryStaticEval(p.defaultValue, { bindings: {}, propsLike })
       out[p.name] = { propName: callerPropName, value: resultToJsonable(value) }
     } else {

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,42 +1814,8 @@
   },
   "fixtureDivergences": {
     "note": "Render-conformance section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. This answers, per fixture and per adapter, whether the construct WORKS — not just whether it compiles. A construct works either as written (✓) or with a documented `/* @client */` comment (✓†, a verified, supported escape — most refusals have one). Fixtures absent from the table below work on every adapter — most as written, some via that documented escape; the headline says how many of each. Listed fixtures need attention somewhere: a bare diagnostic code is still-open debt with no escape yet, a code led by ✗ owes no escape at all (by design), and ≠ means the fixture compiles clean but its rendered output diverges from the reference.",
-    "totalFixtures": 412,
+    "totalFixtures": 413,
     "fixtures": {
-      "body-destructured-props-live": {
-        "blade": {
-          "kind": "render",
-          "reason": "body-destructured prop default omits the attribute instead of rendering the default on SSR (https://github.com/piconic-ai/barefootjs/issues/2943)"
-        },
-        "erb": {
-          "kind": "render",
-          "reason": "body-destructured prop default omits the attribute instead of rendering the default on SSR (https://github.com/piconic-ai/barefootjs/issues/2943)"
-        },
-        "go-template": {
-          "kind": "render",
-          "reason": "body-destructured prop default omits the attribute instead of rendering the default on SSR (https://github.com/piconic-ai/barefootjs/issues/2943)"
-        },
-        "jinja": {
-          "kind": "render",
-          "reason": "body-destructured prop default omits the attribute instead of rendering the default on SSR (https://github.com/piconic-ai/barefootjs/issues/2943)"
-        },
-        "minijinja": {
-          "kind": "render",
-          "reason": "body-destructured prop default omits the attribute instead of rendering the default on SSR (https://github.com/piconic-ai/barefootjs/issues/2943)"
-        },
-        "mojolicious": {
-          "kind": "render",
-          "reason": "body-destructured prop default omits the attribute instead of rendering the default on SSR (https://github.com/piconic-ai/barefootjs/issues/2943)"
-        },
-        "twig": {
-          "kind": "render",
-          "reason": "body-destructured prop default omits the attribute instead of rendering the default on SSR (https://github.com/piconic-ai/barefootjs/issues/2943)"
-        },
-        "xslate": {
-          "kind": "render",
-          "reason": "body-destructured prop default omits the attribute instead of rendering the default on SSR (https://github.com/piconic-ai/barefootjs/issues/2943)"
-        }
-      },
       "component-prop-bare-getter": {
         "go-template": {
           "kind": "render",
@@ -3660,10 +3626,6 @@
       }
     },
     "docs": {
-      "body-destructured-props-live": {
-        "description": "A body-destructured-props child stays fully reactive across text/memo/effect/handler/attribute…",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/body-destructured-props-live.ts"
-      },
       "component-prop-bare-getter": {
         "description": "A signal getter passed directly (unwrapped) to a component prop compiles, matching the…",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/component-prop-bare-getter.ts"

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-conformance section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. This answers, per fixture and per adapter, whether the construct WORKS — not just whether it compiles. A construct works either as written (✓) or with a documented `/* @client */` comment (✓†, a verified, supported escape — most refusals have one). Fixtures absent from the table below work on every adapter — most as written, some via that documented escape; the headline says how many of each. Listed fixtures need attention somewhere: a bare diagnostic code is still-open debt with no escape yet, a code led by ✗ owes no escape at all (by design), and ≠ means the fixture compiles clean but its rendered output diverges from the reference.",
-    "totalFixtures": 413,
+    "totalFixtures": 414,
     "fixtures": {
       "component-prop-bare-getter": {
         "go-template": {

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -1063,13 +1063,9 @@
           "total": 106
         },
         "blade": {
-          "pass": 96,
+          "pass": 97,
           "total": 106,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -1115,13 +1111,9 @@
           ]
         },
         "erb": {
-          "pass": 97,
+          "pass": 98,
           "total": 106,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -1161,13 +1153,9 @@
           ]
         },
         "go-template": {
-          "pass": 96,
+          "pass": 97,
           "total": 106,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -1213,13 +1201,9 @@
           ]
         },
         "jinja": {
-          "pass": 96,
+          "pass": 97,
           "total": 106,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -1265,13 +1249,9 @@
           ]
         },
         "minijinja": {
-          "pass": 96,
+          "pass": 97,
           "total": 106,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -1317,13 +1297,9 @@
           ]
         },
         "mojolicious": {
-          "pass": 97,
+          "pass": 98,
           "total": 106,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -1363,13 +1339,9 @@
           ]
         },
         "twig": {
-          "pass": 96,
+          "pass": 97,
           "total": 106,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -1415,13 +1387,9 @@
           ]
         },
         "xslate": {
-          "pass": 96,
+          "pass": 97,
           "total": 106,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -1499,13 +1467,9 @@
           ]
         },
         "blade": {
-          "pass": 260,
+          "pass": 261,
           "total": 277,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -1583,13 +1547,9 @@
           ]
         },
         "erb": {
-          "pass": 261,
+          "pass": 262,
           "total": 277,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -1661,13 +1621,9 @@
           ]
         },
         "go-template": {
-          "pass": 257,
+          "pass": 258,
           "total": 277,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "component-prop-bare-getter",
               "issues": []
@@ -1761,13 +1717,9 @@
           ]
         },
         "jinja": {
-          "pass": 260,
+          "pass": 261,
           "total": 277,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -1845,13 +1797,9 @@
           ]
         },
         "minijinja": {
-          "pass": 260,
+          "pass": 261,
           "total": 277,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -1929,13 +1877,9 @@
           ]
         },
         "mojolicious": {
-          "pass": 261,
+          "pass": 262,
           "total": 277,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -2007,13 +1951,9 @@
           ]
         },
         "twig": {
-          "pass": 260,
+          "pass": 261,
           "total": 277,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -2091,13 +2031,9 @@
           ]
         },
         "xslate": {
-          "pass": 260,
+          "pass": 261,
           "total": 277,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -2195,13 +2131,9 @@
           "total": 33
         },
         "blade": {
-          "pass": 30,
+          "pass": 31,
           "total": 33,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "flatmap-typeof-projection",
               "issues": []
@@ -2213,13 +2145,9 @@
           ]
         },
         "erb": {
-          "pass": 30,
+          "pass": 31,
           "total": 33,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "flatmap-typeof-projection",
               "issues": []
@@ -2231,13 +2159,9 @@
           ]
         },
         "go-template": {
-          "pass": 30,
+          "pass": 31,
           "total": 33,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "flatmap-typeof-projection",
               "issues": []
@@ -2249,13 +2173,9 @@
           ]
         },
         "jinja": {
-          "pass": 30,
+          "pass": 31,
           "total": 33,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "flatmap-typeof-projection",
               "issues": []
@@ -2267,13 +2187,9 @@
           ]
         },
         "minijinja": {
-          "pass": 30,
+          "pass": 31,
           "total": 33,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "flatmap-typeof-projection",
               "issues": []
@@ -2285,13 +2201,9 @@
           ]
         },
         "mojolicious": {
-          "pass": 30,
+          "pass": 31,
           "total": 33,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "flatmap-typeof-projection",
               "issues": []
@@ -2303,13 +2215,9 @@
           ]
         },
         "twig": {
-          "pass": 30,
+          "pass": 31,
           "total": 33,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "flatmap-typeof-projection",
               "issues": []
@@ -2321,13 +2229,9 @@
           ]
         },
         "xslate": {
-          "pass": 30,
+          "pass": 31,
           "total": 33,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "flatmap-typeof-projection",
               "issues": []
@@ -2352,11 +2256,11 @@
       }
     },
     "identifier": {
-      "total": 391,
+      "total": 392,
       "cells": {
         "hono": {
-          "pass": 387,
-          "total": 391,
+          "pass": 388,
+          "total": 392,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2379,13 +2283,9 @@
           ]
         },
         "blade": {
-          "pass": 370,
-          "total": 391,
+          "pass": 372,
+          "total": 392,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -2479,13 +2379,9 @@
           ]
         },
         "erb": {
-          "pass": 371,
-          "total": 391,
+          "pass": 373,
+          "total": 392,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -2573,13 +2469,9 @@
           ]
         },
         "go-template": {
-          "pass": 367,
-          "total": 391,
+          "pass": 369,
+          "total": 392,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "component-prop-bare-getter",
               "issues": []
@@ -2689,13 +2581,9 @@
           ]
         },
         "jinja": {
-          "pass": 370,
-          "total": 391,
+          "pass": 372,
+          "total": 392,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -2789,13 +2677,9 @@
           ]
         },
         "minijinja": {
-          "pass": 370,
-          "total": 391,
+          "pass": 372,
+          "total": 392,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -2889,13 +2773,9 @@
           ]
         },
         "mojolicious": {
-          "pass": 369,
-          "total": 391,
+          "pass": 371,
+          "total": 392,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -2995,13 +2875,9 @@
           ]
         },
         "twig": {
-          "pass": 370,
-          "total": 391,
+          "pass": 372,
+          "total": 392,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -3095,13 +2971,9 @@
           ]
         },
         "xslate": {
-          "pass": 368,
-          "total": 391,
+          "pass": 370,
+          "total": 392,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -3272,11 +3144,11 @@
       }
     },
     "literal": {
-      "total": 313,
+      "total": 314,
       "cells": {
         "hono": {
-          "pass": 312,
-          "total": 313,
+          "pass": 313,
+          "total": 314,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -3285,13 +3157,9 @@
           ]
         },
         "blade": {
-          "pass": 300,
-          "total": 313,
+          "pass": 302,
+          "total": 314,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -3345,13 +3213,9 @@
           ]
         },
         "erb": {
-          "pass": 300,
-          "total": 313,
+          "pass": 302,
+          "total": 314,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -3405,13 +3269,9 @@
           ]
         },
         "go-template": {
-          "pass": 297,
-          "total": 313,
+          "pass": 299,
+          "total": 314,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "component-prop-bare-getter",
               "issues": []
@@ -3481,13 +3341,9 @@
           ]
         },
         "jinja": {
-          "pass": 300,
-          "total": 313,
+          "pass": 302,
+          "total": 314,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -3541,13 +3397,9 @@
           ]
         },
         "minijinja": {
-          "pass": 300,
-          "total": 313,
+          "pass": 302,
+          "total": 314,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -3601,13 +3453,9 @@
           ]
         },
         "mojolicious": {
-          "pass": 298,
-          "total": 313,
+          "pass": 300,
+          "total": 314,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -3673,13 +3521,9 @@
           ]
         },
         "twig": {
-          "pass": 300,
-          "total": 313,
+          "pass": 302,
+          "total": 314,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -3733,13 +3577,9 @@
           ]
         },
         "xslate": {
-          "pass": 298,
-          "total": 313,
+          "pass": 300,
+          "total": 314,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -3818,20 +3658,16 @@
       }
     },
     "logical": {
-      "total": 50,
+      "total": 51,
       "cells": {
         "hono": {
-          "pass": 50,
-          "total": 50
+          "pass": 51,
+          "total": 51
         },
         "blade": {
-          "pass": 47,
-          "total": 50,
+          "pass": 49,
+          "total": 51,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "static-array-from-props",
               "issues": [
@@ -3845,13 +3681,9 @@
           ]
         },
         "erb": {
-          "pass": 47,
-          "total": 50,
+          "pass": 49,
+          "total": 51,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "static-array-from-props",
               "issues": [
@@ -3865,13 +3697,9 @@
           ]
         },
         "go-template": {
-          "pass": 47,
-          "total": 50,
+          "pass": 49,
+          "total": 51,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "static-array-from-props",
               "issues": [
@@ -3885,13 +3713,9 @@
           ]
         },
         "jinja": {
-          "pass": 47,
-          "total": 50,
+          "pass": 49,
+          "total": 51,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "static-array-from-props",
               "issues": [
@@ -3905,13 +3729,9 @@
           ]
         },
         "minijinja": {
-          "pass": 47,
-          "total": 50,
+          "pass": 49,
+          "total": 51,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "static-array-from-props",
               "issues": [
@@ -3925,13 +3745,9 @@
           ]
         },
         "mojolicious": {
-          "pass": 47,
-          "total": 50,
+          "pass": 49,
+          "total": 51,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "static-array-from-props",
               "issues": [
@@ -3945,13 +3761,9 @@
           ]
         },
         "twig": {
-          "pass": 47,
-          "total": 50,
+          "pass": 49,
+          "total": 51,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "static-array-from-props",
               "issues": [
@@ -3965,13 +3777,9 @@
           ]
         },
         "xslate": {
-          "pass": 47,
-          "total": 50,
+          "pass": 49,
+          "total": 51,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "static-array-from-props",
               "issues": [
@@ -3998,11 +3806,11 @@
       }
     },
     "member": {
-      "total": 231,
+      "total": 232,
       "cells": {
         "hono": {
-          "pass": 228,
-          "total": 231,
+          "pass": 229,
+          "total": 232,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4021,13 +3829,9 @@
           ]
         },
         "blade": {
-          "pass": 211,
-          "total": 231,
+          "pass": 213,
+          "total": 232,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -4117,13 +3921,9 @@
           ]
         },
         "erb": {
-          "pass": 212,
-          "total": 231,
+          "pass": 214,
+          "total": 232,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -4207,13 +4007,9 @@
           ]
         },
         "go-template": {
-          "pass": 208,
-          "total": 231,
+          "pass": 210,
+          "total": 232,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "component-prop-bare-getter",
               "issues": []
@@ -4319,13 +4115,9 @@
           ]
         },
         "jinja": {
-          "pass": 211,
-          "total": 231,
+          "pass": 213,
+          "total": 232,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -4415,13 +4207,9 @@
           ]
         },
         "minijinja": {
-          "pass": 211,
-          "total": 231,
+          "pass": 213,
+          "total": 232,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -4511,13 +4299,9 @@
           ]
         },
         "mojolicious": {
-          "pass": 210,
-          "total": 231,
+          "pass": 212,
+          "total": 232,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -4613,13 +4397,9 @@
           ]
         },
         "twig": {
-          "pass": 211,
-          "total": 231,
+          "pass": 213,
+          "total": 232,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -4709,13 +4489,9 @@
           ]
         },
         "xslate": {
-          "pass": 209,
-          "total": 231,
+          "pass": 211,
+          "total": 232,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -7341,84 +7117,36 @@
           "total": 14
         },
         "blade": {
-          "pass": 13,
-          "total": 14,
-          "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            }
-          ]
+          "pass": 14,
+          "total": 14
         },
         "erb": {
-          "pass": 13,
-          "total": 14,
-          "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            }
-          ]
+          "pass": 14,
+          "total": 14
         },
         "go-template": {
-          "pass": 13,
-          "total": 14,
-          "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            }
-          ]
+          "pass": 14,
+          "total": 14
         },
         "jinja": {
-          "pass": 13,
-          "total": 14,
-          "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            }
-          ]
+          "pass": 14,
+          "total": 14
         },
         "minijinja": {
-          "pass": 13,
-          "total": 14,
-          "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            }
-          ]
+          "pass": 14,
+          "total": 14
         },
         "mojolicious": {
-          "pass": 13,
-          "total": 14,
-          "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            }
-          ]
+          "pass": 14,
+          "total": 14
         },
         "twig": {
-          "pass": 13,
-          "total": 14,
-          "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            }
-          ]
+          "pass": 14,
+          "total": 14
         },
         "xslate": {
-          "pass": 13,
-          "total": 14,
-          "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            }
-          ]
+          "pass": 14,
+          "total": 14
         }
       },
       "source": {
@@ -8167,13 +7895,9 @@
           ]
         },
         "blade": {
-          "pass": 68,
+          "pass": 69,
           "total": 71,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "jsx-element-prop-ternary",
               "issues": []
@@ -8185,13 +7909,9 @@
           ]
         },
         "erb": {
-          "pass": 68,
+          "pass": 69,
           "total": 71,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "jsx-element-prop-ternary",
               "issues": []
@@ -8203,13 +7923,9 @@
           ]
         },
         "go-template": {
-          "pass": 67,
+          "pass": 68,
           "total": 71,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "jsx-element-prop-ternary",
               "issues": []
@@ -8227,13 +7943,9 @@
           ]
         },
         "jinja": {
-          "pass": 68,
+          "pass": 69,
           "total": 71,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "jsx-element-prop-ternary",
               "issues": []
@@ -8245,13 +7957,9 @@
           ]
         },
         "minijinja": {
-          "pass": 68,
+          "pass": 69,
           "total": 71,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "jsx-element-prop-ternary",
               "issues": []
@@ -8263,13 +7971,9 @@
           ]
         },
         "mojolicious": {
-          "pass": 66,
+          "pass": 67,
           "total": 71,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "jsx-element-prop-ternary",
               "issues": []
@@ -8293,13 +7997,9 @@
           ]
         },
         "twig": {
-          "pass": 68,
+          "pass": 69,
           "total": 71,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "jsx-element-prop-ternary",
               "issues": []
@@ -8311,13 +8011,9 @@
           ]
         },
         "xslate": {
-          "pass": 66,
+          "pass": 67,
           "total": 71,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "jsx-element-prop-ternary",
               "issues": []
@@ -8428,13 +8124,9 @@
           "total": 143
         },
         "blade": {
-          "pass": 137,
+          "pass": 138,
           "total": 143,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "fill-unsupported",
               "issues": []
@@ -8458,13 +8150,9 @@
           ]
         },
         "erb": {
-          "pass": 137,
+          "pass": 138,
           "total": 143,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "fill-unsupported",
               "issues": []
@@ -8488,13 +8176,9 @@
           ]
         },
         "go-template": {
-          "pass": 135,
+          "pass": 136,
           "total": 143,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "component-prop-bare-getter",
               "issues": []
@@ -8528,13 +8212,9 @@
           ]
         },
         "jinja": {
-          "pass": 137,
+          "pass": 138,
           "total": 143,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "fill-unsupported",
               "issues": []
@@ -8558,13 +8238,9 @@
           ]
         },
         "minijinja": {
-          "pass": 137,
+          "pass": 138,
           "total": 143,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "fill-unsupported",
               "issues": []
@@ -8588,13 +8264,9 @@
           ]
         },
         "mojolicious": {
-          "pass": 135,
+          "pass": 136,
           "total": 143,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "fill-unsupported",
               "issues": []
@@ -8630,13 +8302,9 @@
           ]
         },
         "twig": {
-          "pass": 137,
+          "pass": 138,
           "total": 143,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "fill-unsupported",
               "issues": []
@@ -8660,13 +8328,9 @@
           ]
         },
         "xslate": {
-          "pass": 135,
+          "pass": 136,
           "total": 143,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "fill-unsupported",
               "issues": []
@@ -8715,20 +8379,16 @@
       }
     },
     "literal:string": {
-      "total": 214,
+      "total": 215,
       "cells": {
         "hono": {
-          "pass": 214,
-          "total": 214
+          "pass": 215,
+          "total": 215
         },
         "blade": {
-          "pass": 205,
-          "total": 214,
+          "pass": 207,
+          "total": 215,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -8766,13 +8426,9 @@
           ]
         },
         "erb": {
-          "pass": 205,
-          "total": 214,
+          "pass": 207,
+          "total": 215,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -8810,13 +8466,9 @@
           ]
         },
         "go-template": {
-          "pass": 204,
-          "total": 214,
+          "pass": 206,
+          "total": 215,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -8860,13 +8512,9 @@
           ]
         },
         "jinja": {
-          "pass": 205,
-          "total": 214,
+          "pass": 207,
+          "total": 215,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -8904,13 +8552,9 @@
           ]
         },
         "minijinja": {
-          "pass": 205,
-          "total": 214,
+          "pass": 207,
+          "total": 215,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -8948,13 +8592,9 @@
           ]
         },
         "mojolicious": {
-          "pass": 203,
-          "total": 214,
+          "pass": 205,
+          "total": 215,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -9004,13 +8644,9 @@
           ]
         },
         "twig": {
-          "pass": 205,
-          "total": 214,
+          "pass": 207,
+          "total": 215,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -9048,13 +8684,9 @@
           ]
         },
         "xslate": {
-          "pass": 203,
-          "total": 214,
+          "pass": 205,
+          "total": 215,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -9169,20 +8801,16 @@
       }
     },
     "logical:??": {
-      "total": 42,
+      "total": 43,
       "cells": {
         "hono": {
-          "pass": 42,
-          "total": 42
+          "pass": 43,
+          "total": 43
         },
         "blade": {
-          "pass": 39,
-          "total": 42,
+          "pass": 41,
+          "total": 43,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "static-array-from-props",
               "issues": [
@@ -9196,13 +8824,9 @@
           ]
         },
         "erb": {
-          "pass": 39,
-          "total": 42,
+          "pass": 41,
+          "total": 43,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "static-array-from-props",
               "issues": [
@@ -9216,13 +8840,9 @@
           ]
         },
         "go-template": {
-          "pass": 39,
-          "total": 42,
+          "pass": 41,
+          "total": 43,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "static-array-from-props",
               "issues": [
@@ -9236,13 +8856,9 @@
           ]
         },
         "jinja": {
-          "pass": 39,
-          "total": 42,
+          "pass": 41,
+          "total": 43,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "static-array-from-props",
               "issues": [
@@ -9256,13 +8872,9 @@
           ]
         },
         "minijinja": {
-          "pass": 39,
-          "total": 42,
+          "pass": 41,
+          "total": 43,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "static-array-from-props",
               "issues": [
@@ -9276,13 +8888,9 @@
           ]
         },
         "mojolicious": {
-          "pass": 39,
-          "total": 42,
+          "pass": 41,
+          "total": 43,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "static-array-from-props",
               "issues": [
@@ -9296,13 +8904,9 @@
           ]
         },
         "twig": {
-          "pass": 39,
-          "total": 42,
+          "pass": 41,
+          "total": 43,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "static-array-from-props",
               "issues": [
@@ -9316,13 +8920,9 @@
           ]
         },
         "xslate": {
-          "pass": 39,
-          "total": 42,
+          "pass": 41,
+          "total": 43,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "static-array-from-props",
               "issues": [
@@ -9342,10 +8942,9 @@
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/src/coverage-map.ts#L152"
       },
       "example": {
-        "fixture": "nullish-coalescing-destructured",
-        "description": "Nullish coalescing over destructured optional props seeds SSR correctly",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/nullish-coalescing-destructured.ts",
-        "code": "size ?? 1"
+        "fixture": "body-destructured-prop-default-renamed",
+        "description": "A renamed body-destructured prop default renders the default on SSR (#2943)",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/body-destructured-prop-default-renamed.ts"
       }
     },
     "logical:||": {

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -1063,13 +1063,9 @@
           "total": 106
         },
         "blade": {
-          "pass": 96,
+          "pass": 97,
           "total": 106,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -1115,13 +1111,9 @@
           ]
         },
         "erb": {
-          "pass": 97,
+          "pass": 98,
           "total": 106,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -1161,13 +1153,9 @@
           ]
         },
         "go-template": {
-          "pass": 96,
+          "pass": 97,
           "total": 106,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -1213,13 +1201,9 @@
           ]
         },
         "jinja": {
-          "pass": 96,
+          "pass": 97,
           "total": 106,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -1265,13 +1249,9 @@
           ]
         },
         "minijinja": {
-          "pass": 96,
+          "pass": 97,
           "total": 106,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -1317,13 +1297,9 @@
           ]
         },
         "mojolicious": {
-          "pass": 97,
+          "pass": 98,
           "total": 106,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -1363,13 +1339,9 @@
           ]
         },
         "twig": {
-          "pass": 96,
+          "pass": 97,
           "total": 106,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -1415,13 +1387,9 @@
           ]
         },
         "xslate": {
-          "pass": 96,
+          "pass": 97,
           "total": 106,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -1499,13 +1467,9 @@
           ]
         },
         "blade": {
-          "pass": 260,
+          "pass": 261,
           "total": 277,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -1583,13 +1547,9 @@
           ]
         },
         "erb": {
-          "pass": 261,
+          "pass": 262,
           "total": 277,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -1661,13 +1621,9 @@
           ]
         },
         "go-template": {
-          "pass": 257,
+          "pass": 258,
           "total": 277,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "component-prop-bare-getter",
               "issues": []
@@ -1761,13 +1717,9 @@
           ]
         },
         "jinja": {
-          "pass": 260,
+          "pass": 261,
           "total": 277,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -1845,13 +1797,9 @@
           ]
         },
         "minijinja": {
-          "pass": 260,
+          "pass": 261,
           "total": 277,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -1929,13 +1877,9 @@
           ]
         },
         "mojolicious": {
-          "pass": 261,
+          "pass": 262,
           "total": 277,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -2007,13 +1951,9 @@
           ]
         },
         "twig": {
-          "pass": 260,
+          "pass": 261,
           "total": 277,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -2091,13 +2031,9 @@
           ]
         },
         "xslate": {
-          "pass": 260,
+          "pass": 261,
           "total": 277,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -2195,13 +2131,9 @@
           "total": 33
         },
         "blade": {
-          "pass": 30,
+          "pass": 31,
           "total": 33,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "flatmap-typeof-projection",
               "issues": []
@@ -2213,13 +2145,9 @@
           ]
         },
         "erb": {
-          "pass": 30,
+          "pass": 31,
           "total": 33,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "flatmap-typeof-projection",
               "issues": []
@@ -2231,13 +2159,9 @@
           ]
         },
         "go-template": {
-          "pass": 30,
+          "pass": 31,
           "total": 33,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "flatmap-typeof-projection",
               "issues": []
@@ -2249,13 +2173,9 @@
           ]
         },
         "jinja": {
-          "pass": 30,
+          "pass": 31,
           "total": 33,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "flatmap-typeof-projection",
               "issues": []
@@ -2267,13 +2187,9 @@
           ]
         },
         "minijinja": {
-          "pass": 30,
+          "pass": 31,
           "total": 33,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "flatmap-typeof-projection",
               "issues": []
@@ -2285,13 +2201,9 @@
           ]
         },
         "mojolicious": {
-          "pass": 30,
+          "pass": 31,
           "total": 33,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "flatmap-typeof-projection",
               "issues": []
@@ -2303,13 +2215,9 @@
           ]
         },
         "twig": {
-          "pass": 30,
+          "pass": 31,
           "total": 33,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "flatmap-typeof-projection",
               "issues": []
@@ -2321,13 +2229,9 @@
           ]
         },
         "xslate": {
-          "pass": 30,
+          "pass": 31,
           "total": 33,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "flatmap-typeof-projection",
               "issues": []
@@ -2352,11 +2256,11 @@
       }
     },
     "identifier": {
-      "total": 390,
+      "total": 391,
       "cells": {
         "hono": {
-          "pass": 386,
-          "total": 390,
+          "pass": 387,
+          "total": 391,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2379,13 +2283,9 @@
           ]
         },
         "blade": {
-          "pass": 369,
-          "total": 390,
+          "pass": 371,
+          "total": 391,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -2479,13 +2379,9 @@
           ]
         },
         "erb": {
-          "pass": 370,
-          "total": 390,
+          "pass": 372,
+          "total": 391,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -2573,13 +2469,9 @@
           ]
         },
         "go-template": {
-          "pass": 366,
-          "total": 390,
+          "pass": 368,
+          "total": 391,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "component-prop-bare-getter",
               "issues": []
@@ -2689,13 +2581,9 @@
           ]
         },
         "jinja": {
-          "pass": 369,
-          "total": 390,
+          "pass": 371,
+          "total": 391,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -2789,13 +2677,9 @@
           ]
         },
         "minijinja": {
-          "pass": 369,
-          "total": 390,
+          "pass": 371,
+          "total": 391,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -2889,13 +2773,9 @@
           ]
         },
         "mojolicious": {
-          "pass": 368,
-          "total": 390,
+          "pass": 370,
+          "total": 391,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -2995,13 +2875,9 @@
           ]
         },
         "twig": {
-          "pass": 369,
-          "total": 390,
+          "pass": 371,
+          "total": 391,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -3095,13 +2971,9 @@
           ]
         },
         "xslate": {
-          "pass": 367,
-          "total": 390,
+          "pass": 369,
+          "total": 391,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -3272,11 +3144,11 @@
       }
     },
     "literal": {
-      "total": 312,
+      "total": 313,
       "cells": {
         "hono": {
-          "pass": 311,
-          "total": 312,
+          "pass": 312,
+          "total": 313,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -3285,13 +3157,9 @@
           ]
         },
         "blade": {
-          "pass": 299,
-          "total": 312,
+          "pass": 301,
+          "total": 313,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -3345,13 +3213,9 @@
           ]
         },
         "erb": {
-          "pass": 299,
-          "total": 312,
+          "pass": 301,
+          "total": 313,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -3405,13 +3269,9 @@
           ]
         },
         "go-template": {
-          "pass": 296,
-          "total": 312,
+          "pass": 298,
+          "total": 313,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "component-prop-bare-getter",
               "issues": []
@@ -3481,13 +3341,9 @@
           ]
         },
         "jinja": {
-          "pass": 299,
-          "total": 312,
+          "pass": 301,
+          "total": 313,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -3541,13 +3397,9 @@
           ]
         },
         "minijinja": {
-          "pass": 299,
-          "total": 312,
+          "pass": 301,
+          "total": 313,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -3601,13 +3453,9 @@
           ]
         },
         "mojolicious": {
-          "pass": 297,
-          "total": 312,
+          "pass": 299,
+          "total": 313,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -3673,13 +3521,9 @@
           ]
         },
         "twig": {
-          "pass": 299,
-          "total": 312,
+          "pass": 301,
+          "total": 313,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -3733,13 +3577,9 @@
           ]
         },
         "xslate": {
-          "pass": 297,
-          "total": 312,
+          "pass": 299,
+          "total": 313,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -3818,20 +3658,16 @@
       }
     },
     "logical": {
-      "total": 50,
+      "total": 51,
       "cells": {
         "hono": {
-          "pass": 50,
-          "total": 50
+          "pass": 51,
+          "total": 51
         },
         "blade": {
-          "pass": 47,
-          "total": 50,
+          "pass": 49,
+          "total": 51,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "static-array-from-props",
               "issues": [
@@ -3845,13 +3681,9 @@
           ]
         },
         "erb": {
-          "pass": 47,
-          "total": 50,
+          "pass": 49,
+          "total": 51,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "static-array-from-props",
               "issues": [
@@ -3865,13 +3697,9 @@
           ]
         },
         "go-template": {
-          "pass": 47,
-          "total": 50,
+          "pass": 49,
+          "total": 51,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "static-array-from-props",
               "issues": [
@@ -3885,13 +3713,9 @@
           ]
         },
         "jinja": {
-          "pass": 47,
-          "total": 50,
+          "pass": 49,
+          "total": 51,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "static-array-from-props",
               "issues": [
@@ -3905,13 +3729,9 @@
           ]
         },
         "minijinja": {
-          "pass": 47,
-          "total": 50,
+          "pass": 49,
+          "total": 51,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "static-array-from-props",
               "issues": [
@@ -3925,13 +3745,9 @@
           ]
         },
         "mojolicious": {
-          "pass": 47,
-          "total": 50,
+          "pass": 49,
+          "total": 51,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "static-array-from-props",
               "issues": [
@@ -3945,13 +3761,9 @@
           ]
         },
         "twig": {
-          "pass": 47,
-          "total": 50,
+          "pass": 49,
+          "total": 51,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "static-array-from-props",
               "issues": [
@@ -3965,13 +3777,9 @@
           ]
         },
         "xslate": {
-          "pass": 47,
-          "total": 50,
+          "pass": 49,
+          "total": 51,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "static-array-from-props",
               "issues": [
@@ -3998,11 +3806,11 @@
       }
     },
     "member": {
-      "total": 231,
+      "total": 232,
       "cells": {
         "hono": {
-          "pass": 228,
-          "total": 231,
+          "pass": 229,
+          "total": 232,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4021,13 +3829,9 @@
           ]
         },
         "blade": {
-          "pass": 211,
-          "total": 231,
+          "pass": 213,
+          "total": 232,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -4117,13 +3921,9 @@
           ]
         },
         "erb": {
-          "pass": 212,
-          "total": 231,
+          "pass": 214,
+          "total": 232,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -4207,13 +4007,9 @@
           ]
         },
         "go-template": {
-          "pass": 208,
-          "total": 231,
+          "pass": 210,
+          "total": 232,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "component-prop-bare-getter",
               "issues": []
@@ -4319,13 +4115,9 @@
           ]
         },
         "jinja": {
-          "pass": 211,
-          "total": 231,
+          "pass": 213,
+          "total": 232,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -4415,13 +4207,9 @@
           ]
         },
         "minijinja": {
-          "pass": 211,
-          "total": 231,
+          "pass": 213,
+          "total": 232,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -4511,13 +4299,9 @@
           ]
         },
         "mojolicious": {
-          "pass": 210,
-          "total": 231,
+          "pass": 212,
+          "total": 232,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -4613,13 +4397,9 @@
           ]
         },
         "twig": {
-          "pass": 211,
-          "total": 231,
+          "pass": 213,
+          "total": 232,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -4709,13 +4489,9 @@
           ]
         },
         "xslate": {
-          "pass": 209,
-          "total": 231,
+          "pass": 211,
+          "total": 232,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "date-method-uncatalogued",
               "issues": [
@@ -7341,84 +7117,36 @@
           "total": 14
         },
         "blade": {
-          "pass": 13,
-          "total": 14,
-          "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            }
-          ]
+          "pass": 14,
+          "total": 14
         },
         "erb": {
-          "pass": 13,
-          "total": 14,
-          "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            }
-          ]
+          "pass": 14,
+          "total": 14
         },
         "go-template": {
-          "pass": 13,
-          "total": 14,
-          "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            }
-          ]
+          "pass": 14,
+          "total": 14
         },
         "jinja": {
-          "pass": 13,
-          "total": 14,
-          "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            }
-          ]
+          "pass": 14,
+          "total": 14
         },
         "minijinja": {
-          "pass": 13,
-          "total": 14,
-          "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            }
-          ]
+          "pass": 14,
+          "total": 14
         },
         "mojolicious": {
-          "pass": 13,
-          "total": 14,
-          "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            }
-          ]
+          "pass": 14,
+          "total": 14
         },
         "twig": {
-          "pass": 13,
-          "total": 14,
-          "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            }
-          ]
+          "pass": 14,
+          "total": 14
         },
         "xslate": {
-          "pass": 13,
-          "total": 14,
-          "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            }
-          ]
+          "pass": 14,
+          "total": 14
         }
       },
       "source": {
@@ -8167,13 +7895,9 @@
           ]
         },
         "blade": {
-          "pass": 68,
+          "pass": 69,
           "total": 71,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "jsx-element-prop-ternary",
               "issues": []
@@ -8185,13 +7909,9 @@
           ]
         },
         "erb": {
-          "pass": 68,
+          "pass": 69,
           "total": 71,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "jsx-element-prop-ternary",
               "issues": []
@@ -8203,13 +7923,9 @@
           ]
         },
         "go-template": {
-          "pass": 67,
+          "pass": 68,
           "total": 71,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "jsx-element-prop-ternary",
               "issues": []
@@ -8227,13 +7943,9 @@
           ]
         },
         "jinja": {
-          "pass": 68,
+          "pass": 69,
           "total": 71,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "jsx-element-prop-ternary",
               "issues": []
@@ -8245,13 +7957,9 @@
           ]
         },
         "minijinja": {
-          "pass": 68,
+          "pass": 69,
           "total": 71,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "jsx-element-prop-ternary",
               "issues": []
@@ -8263,13 +7971,9 @@
           ]
         },
         "mojolicious": {
-          "pass": 66,
+          "pass": 67,
           "total": 71,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "jsx-element-prop-ternary",
               "issues": []
@@ -8293,13 +7997,9 @@
           ]
         },
         "twig": {
-          "pass": 68,
+          "pass": 69,
           "total": 71,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "jsx-element-prop-ternary",
               "issues": []
@@ -8311,13 +8011,9 @@
           ]
         },
         "xslate": {
-          "pass": 66,
+          "pass": 67,
           "total": 71,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "jsx-element-prop-ternary",
               "issues": []
@@ -8428,13 +8124,9 @@
           "total": 143
         },
         "blade": {
-          "pass": 137,
+          "pass": 138,
           "total": 143,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "fill-unsupported",
               "issues": []
@@ -8458,13 +8150,9 @@
           ]
         },
         "erb": {
-          "pass": 137,
+          "pass": 138,
           "total": 143,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "fill-unsupported",
               "issues": []
@@ -8488,13 +8176,9 @@
           ]
         },
         "go-template": {
-          "pass": 135,
+          "pass": 136,
           "total": 143,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "component-prop-bare-getter",
               "issues": []
@@ -8528,13 +8212,9 @@
           ]
         },
         "jinja": {
-          "pass": 137,
+          "pass": 138,
           "total": 143,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "fill-unsupported",
               "issues": []
@@ -8558,13 +8238,9 @@
           ]
         },
         "minijinja": {
-          "pass": 137,
+          "pass": 138,
           "total": 143,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "fill-unsupported",
               "issues": []
@@ -8588,13 +8264,9 @@
           ]
         },
         "mojolicious": {
-          "pass": 135,
+          "pass": 136,
           "total": 143,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "fill-unsupported",
               "issues": []
@@ -8630,13 +8302,9 @@
           ]
         },
         "twig": {
-          "pass": 137,
+          "pass": 138,
           "total": 143,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "fill-unsupported",
               "issues": []
@@ -8660,13 +8328,9 @@
           ]
         },
         "xslate": {
-          "pass": 135,
+          "pass": 136,
           "total": 143,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "fill-unsupported",
               "issues": []
@@ -8715,20 +8379,16 @@
       }
     },
     "literal:string": {
-      "total": 213,
+      "total": 214,
       "cells": {
         "hono": {
-          "pass": 213,
-          "total": 213
+          "pass": 214,
+          "total": 214
         },
         "blade": {
-          "pass": 204,
-          "total": 213,
+          "pass": 206,
+          "total": 214,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -8766,13 +8426,9 @@
           ]
         },
         "erb": {
-          "pass": 204,
-          "total": 213,
+          "pass": 206,
+          "total": 214,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -8810,13 +8466,9 @@
           ]
         },
         "go-template": {
-          "pass": 203,
-          "total": 213,
+          "pass": 205,
+          "total": 214,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -8860,13 +8512,9 @@
           ]
         },
         "jinja": {
-          "pass": 204,
-          "total": 213,
+          "pass": 206,
+          "total": 214,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -8904,13 +8552,9 @@
           ]
         },
         "minijinja": {
-          "pass": 204,
-          "total": 213,
+          "pass": 206,
+          "total": 214,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -8948,13 +8592,9 @@
           ]
         },
         "mojolicious": {
-          "pass": 202,
-          "total": 213,
+          "pass": 204,
+          "total": 214,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -9004,13 +8644,9 @@
           ]
         },
         "twig": {
-          "pass": 204,
-          "total": 213,
+          "pass": 206,
+          "total": 214,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -9048,13 +8684,9 @@
           ]
         },
         "xslate": {
-          "pass": 202,
-          "total": 213,
+          "pass": 204,
+          "total": 214,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "every-typeof-predicate",
               "issues": []
@@ -9169,20 +8801,16 @@
       }
     },
     "logical:??": {
-      "total": 42,
+      "total": 43,
       "cells": {
         "hono": {
-          "pass": 42,
-          "total": 42
+          "pass": 43,
+          "total": 43
         },
         "blade": {
-          "pass": 39,
-          "total": 42,
+          "pass": 41,
+          "total": 43,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "static-array-from-props",
               "issues": [
@@ -9196,13 +8824,9 @@
           ]
         },
         "erb": {
-          "pass": 39,
-          "total": 42,
+          "pass": 41,
+          "total": 43,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "static-array-from-props",
               "issues": [
@@ -9216,13 +8840,9 @@
           ]
         },
         "go-template": {
-          "pass": 39,
-          "total": 42,
+          "pass": 41,
+          "total": 43,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "static-array-from-props",
               "issues": [
@@ -9236,13 +8856,9 @@
           ]
         },
         "jinja": {
-          "pass": 39,
-          "total": 42,
+          "pass": 41,
+          "total": 43,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "static-array-from-props",
               "issues": [
@@ -9256,13 +8872,9 @@
           ]
         },
         "minijinja": {
-          "pass": 39,
-          "total": 42,
+          "pass": 41,
+          "total": 43,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "static-array-from-props",
               "issues": [
@@ -9276,13 +8888,9 @@
           ]
         },
         "mojolicious": {
-          "pass": 39,
-          "total": 42,
+          "pass": 41,
+          "total": 43,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "static-array-from-props",
               "issues": [
@@ -9296,13 +8904,9 @@
           ]
         },
         "twig": {
-          "pass": 39,
-          "total": 42,
+          "pass": 41,
+          "total": 43,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "static-array-from-props",
               "issues": [
@@ -9316,13 +8920,9 @@
           ]
         },
         "xslate": {
-          "pass": 39,
-          "total": 42,
+          "pass": 41,
+          "total": 43,
           "gaps": [
-            {
-              "fixture": "body-destructured-props-live",
-              "issues": []
-            },
             {
               "fixture": "static-array-from-props",
               "issues": [
@@ -9342,10 +8942,9 @@
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/src/coverage-map.ts#L152"
       },
       "example": {
-        "fixture": "nullish-coalescing-destructured",
-        "description": "Nullish coalescing over destructured optional props seeds SSR correctly",
-        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/nullish-coalescing-destructured.ts",
-        "code": "size ?? 1"
+        "fixture": "body-destructured-prop-default-renamed",
+        "description": "A renamed body-destructured prop default renders the default on SSR (#2943)",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/body-destructured-prop-default-renamed.ts"
       }
     },
     "logical:||": {


### PR DESCRIPTION
## Summary

Fixes #2943: a BODY-destructured prop's default (`function Foo(props: Props) { const { label = 'none' } = props; ... }`, renamed or not) never reached `ParamInfo.defaultValue` — `extractPropsFromTypeMembers` built `propsParams` purely from the TYPE annotation, with no notion of a body destructure's own default. Every non-Hono template adapter's presence-guard classification (`collectNullableOptionalProps` and its per-language equivalents) then treated the prop as defaultless and **omitted the attribute entirely** when the caller didn't pass it, instead of falling back to the default the way Hono's real JS destructuring naturally does.

A **renamed** default (`const { label: text = 'none' } = props`) was worse: it had no `propsParams` entry at all, so Jinja/Xslate/ERB/Blade/Twig/Rust read an undefined template variable unconditionally, Mojolicious fataled under Perl strict mode, and Go's Input struct had no field mapping for it — a `go run` **compile error**, not a soft divergence.

This was discovered and pinned as a `known-limitation` (`renderDivergences` on all 8 non-Hono adapters) during #2934's PR (#2941), with Fable's design consult recommending the fix be scoped out to a follow-up rather than expand that PR. This PR is that follow-up, again designed with Fable.

## Root cause & fix

The analyzer now overlays a body-destructure default directly onto `ir.metadata.propsParams` (`collectConstant`'s body-destructure branch, `analyzer.ts`), sharing a `bindingElementDefaultFields` helper with the parameter-destructured path (`extractProps`) so "what does this default look like structurally" has one implementation, not two:

- **Unrenamed** (`const { label = 'none' } = props`): overlays `defaultValue`/`parsed`/`optional: true` onto the existing type-member `label` entry.
- **Renamed** (`const { label: text = 'none' } = props`): ADDS a second entry (`text`, `sourceName: 'label'`) rather than replacing — `label` itself stays a real, separately-classified binding, since a bare `props.label` read elsewhere still needs its own presence guard / stash entry.

This is the SAME shared `ParamInfo` every consumer already reads for a parameter-destructured default (SSR presence-guard classification, `extractSsrDefaults`'s stash seed, the CSR-fresh-mount `template:` lambda) — so `ssr-defaults.ts`'s `extractSsrDefaults` needed only its `propsObjectName === null` gate lifted to a plain `p.defaultValue !== undefined` check, and the narrower `jsx-to-ir.ts` workaround from #2934/#2941 (`_destructuredPropInfoByName`'s overlay, which only ever fixed the CSR lambda for the unrenamed case) is now redundant and removed.

## Two adapter-specific fixes for the renamed+default shape

- **Hono** (`hono-adapter.ts`): the hydration-payload serialization loop read `props[name]` (the local binding) instead of `props[sourceName ?? name]` (the real property) — for a renamed synthesized entry these differ, so the old code silently wrote `undefined` over the caller's actual value in `bf-p`. Fixed; verified the generated code now writes the correct caller-facing key.
- **Go** (`go-template-adapter.ts`): the generated Input struct emits one field per `propsParams` entry keyed by caller-facing name — `label` and `text` now share one name, so the naive loop double-declared the field (`go build` error). Fixed with a de-dup pass. A further wrinkle: when the SAME underlying prop is ALSO read bare elsewhere in the component (independently flipping that shared field to a nillable `interface{}`), the naive string-typed default-application wrapper wouldn't compile either — fixed with a type-aware nil-check + assertion. Verified end-to-end with a real `go run` compile+render for all three shapes (unrenamed, renamed, and the mixed raw+renamed edge case).

## Tests

- New `packages/jsx/src/__tests__/body-destructured-prop-default-propsparams.test.ts`: pins the exact `propsParams` shape for unrenamed/renamed/untyped/arrow-default/defaultless-rename/`let` cases.
- New `ssr-defaults.test.ts` cases: unrenamed default seeds the evaluated value (not `null`), renamed default seeds both entries correctly and `deriveStashFromDefaults` resolves the caller override.
- Updated `body-destructured-props-live.test.ts`'s CSR-lambda test's docstring (mechanism changed, output unchanged) and added a renamed+default CSR case.
- New shared fixture `body-destructured-prop-default-renamed` (all 9 adapters, including a caller-value-wins data point) — graduates the `body-destructured-props-live` `renderDivergences` pins on all 8 non-Hono adapters.

## Out of scope (unaffected)

#2940 (a body-destructured prop's arrow-function default emits invalid JS in the init body, `_p.x ?? (v) => ...`) is a different, pre-existing bug in the analyzer's `value` text construction for the `ConstantInfo`/init-body path — untouched by this fix, still pinned separately. (Verified: this fix DOES now make an arrow default's `defaultContainsArrow`/`parsed` flow correctly through `propsParams` for the CSR template lambda and SSR classification, just not the separately-broken init-body text.)

## Verification

- [x] New analyzer unit tests (`body-destructured-prop-default-propsparams.test.ts`) — all pass, including a manual before/after revert confirming they fail without the fix.
- [x] `ssr-defaults.test.ts`: 46/46 pass.
- [x] `body-destructured-props-live.test.ts`: 9/9 pass (updated + new case).
- [x] Full `packages/jsx/src/__tests__` suite, `packages/adapter-tests/src/__tests__/csr-conformance.test.ts` (384/384, including the new fixture), `ui/components` (1240/1240), `packages/adapter-hono/src/__tests__`, `packages/adapter-go-template/src/__tests__`, `packages/adapter-jinja/src/__tests__` — all green (isolated flaky timeouts on two unrelated pre-existing type-check tests confirmed present on unmodified `main` too, via git stash).
- [x] Manual end-to-end verification: real `go run` compile+render for unrenamed/renamed/mixed-usage shapes; compiled Jinja/Mojolicious templates inspected directly for unconditional (non-guarded) attribute emission; Hono's generated hydration code inspected for the corrected `bf-p` key.
- [x] `bun run compat:lock` / `bun run support-matrix:lock`: only the expected diff (8 adapters' `body-destructured-props-live` divergence removed, new fixture added cleanly with zero new divergences anywhere).
- [x] `packages/adapter-tests/scripts/generate-expected-html.ts` run locally, `git status --short` clean afterward (only the new fixture's `expectedHtml`, auto-generated from Hono).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017AEkVQuwMv4vULJ7Ziw9CF

---
_Generated by [Claude Code](https://claude.ai/code/session_017AEkVQuwMv4vULJ7Ziw9CF)_