### PR TITLE
fix(jsx): module-scope const array `.map()`'d directly renders on every adapter (#2946)

### DIFF
--- a/.changeset/module-const-loop-source.md
+++ b/.changeset/module-const-loop-source.md
@@ -1,0 +1,19 @@
+---
+"@barefootjs/jsx": patch
+"@barefootjs/erb": patch
+"@barefootjs/jinja": patch
+"@barefootjs/twig": patch
+"@barefootjs/blade": patch
+"@barefootjs/xslate": patch
+"@barefootjs/rust": patch
+"@barefootjs/mojolicious": patch
+"@barefootjs/go-template": patch
+---
+
+Fixes #2946: a `'use client'` component that declares a static array at MODULE scope and `.map()`s it directly — no `createSignal` wrapper in between — now renders its rows correctly on every adapter. Previously ERB, Jinja, Twig, Blade, Xslate, Rust (minijinja), and Mojolicious silently rendered the loop body empty, and Go template raised an execution-time `can't evaluate field ... in type ...Props` error; only Hono (the reference adapter) rendered correctly.
+
+Root cause: `resolveStaticLoopSource` (`packages/jsx/src/static-literal.ts`) — the one shared resolver every adapter's `renderLoop` consults to inline a `.map()` loop's array source as a native literal — deliberately excluded module-scope consts, on the theory that a separate seeding path (`ssr-defaults.ts` / Go's `convertInitialValue`) already handled them. That path only ever sees a module const through a `createSignal(...)` argument, never a bare `.map()` with no signal in between, so a directly-mapped module array was left completely unresolved.
+
+Fixed at the source: `resolveStaticLoopSource` now resolves a bare identifier bound to a local const's static initializer regardless of whether it's declared at module or function scope — the only remaining exclusions are a name shadowed by the enclosing loop scope, a non-literal (runtime-computed) initializer, and a const flagged `mutatedAfterDeclaration` (#2910 — its initializer would otherwise bake a stale snapshot). Each adapter's own "unresolvable local const" BF101 diagnostic is widened the same way, so a module-scope const computed via a function call (e.g. `const items = buildItems()`) now refuses loudly and uniformly instead of only being caught when declared inside the component.
+
+Adds `module-const-loop-source` (plain-element loop body) and `module-const-loop-source-child-component` (child-component loop body, exercising Go's per-item bake path) as new passing fixtures across all 9 adapters, plus `module-const-loop-source-computed` (BF101-pinned on the 8 non-Hono adapters) with its `/* @client */` escape twin `module-const-loop-source-computed-client`.

--- a/packages/adapter-blade/src/adapter/blade-adapter.ts
+++ b/packages/adapter-blade/src/adapter/blade-adapter.ts
@@ -951,17 +951,11 @@ export class BladeAdapter extends BaseAdapter implements IRNodeEmitter<BladeRend
       })
     }
 
-    // A `.map()` loop whose array is a bare identifier bound to a
-    // FUNCTION-scope local const with a non-statically-evaluable initializer
-    // that reads props/signals (e.g. `const entries =
-    // Object.entries(props.x ?? {}).filter(...)`) can't render correctly.
-    // Module-scope consts (`isModule`, e.g. `const payments = [...]` at the
-    // top of the file) are a DIFFERENT, already-working case — the shared
-    // `ssr-defaults.ts` statically evaluates those and seeds them straight
-    // into the render context, so a bare `payments` reference resolves for
-    // free (data-table demo). Function-scope locals get no such seeding
-    // (`ssr-defaults.ts`: "component-scope locals can depend on
-    // signals/props and are evaluated lazily elsewhere") — and this
+    // A `.map()` loop whose array is a bare identifier bound to a local
+    // const (module- or function-scope, #2946) with a non-statically-
+    // evaluable initializer that reads props/signals/a function call (e.g.
+    // `const entries = Object.entries(props.x ?? {}).filter(...)`) can't
+    // render correctly. Locals get no per-render stash slot — this
     // adapter's only "elsewhere" is inlining a const's value at its use
     // site (`_resolveLiteralConst`'s numeric/single-quoted-string fast
     // path, or a static-record-literal lookup), never binding one as a
@@ -974,22 +968,21 @@ export class BladeAdapter extends BaseAdapter implements IRNodeEmitter<BladeRend
     // corpus only because the widened destructure gate (#2087 Phase A/B)
     // no longer refuses this fixture's `([emoji, users]) => ...` param
     // first. Same policy and shape as the Jinja / ERB adapters' check.
-    // #2208: a loop source that is a fully-static array literal — either
-    // inline (`[{ label: 'Alpha' }, ...].map(...)`) or a bare identifier
-    // bound to a FUNCTION-scope local const whose initializer has no
-    // prop/signal/function-call dependency — inlines as a native PHP
-    // array literal below, the same way a module-scope const's value is
-    // already seeded. A runtime-computed local (#2069, e.g.
-    // `Object.entries(props.tags).filter(...)`) still refuses below.
-    // `isNameShadowed` guards a DIFFERENT, enclosing loop's own callback
-    // param shadowing this identifier (fable review) — never resolve the
-    // static const in that case. `rawArray` then falls through to the
-    // bare identifier expression below, same as before #2208 — which
-    // still trips the pre-existing BF101 gate for an unresolvable local
-    // const reference (a loud, conservative refusal, not a silent wrong
-    // value). Canonical, position-accurate predicate (#2482 Stage 2) — the
-    // enclosing loop scope's own membership, not a coarse whole-component
-    // union.
+    // #2208/#2946: a loop source that is a fully-static array literal —
+    // either inline (`[{ label: 'Alpha' }, ...].map(...)`) or a bare
+    // identifier bound to a local const (module- or function-scope) whose
+    // initializer has no prop/signal/function-call dependency — inlines as
+    // a native PHP array literal below. A runtime-computed local (#2069,
+    // e.g. `Object.entries(props.tags).filter(...)`) still refuses below,
+    // whichever scope it's declared in. `isNameShadowed` guards a
+    // DIFFERENT, enclosing loop's own callback param shadowing this
+    // identifier (fable review) — never resolve the static const in that
+    // case. `rawArray` then falls through to the bare identifier expression
+    // below, same as before #2208 — which still trips the pre-existing
+    // BF101 gate for an unresolvable local const reference (a loud,
+    // conservative refusal, not a silent wrong value). Canonical,
+    // position-accurate predicate (#2482 Stage 2) — the enclosing loop
+    // scope's own membership, not a coarse whole-component union.
     const staticItems = resolveStaticLoopSource(loop.arrayParsed, this.localConstants, {
       isNameShadowed: this.scope.asShadowPredicate(),
     })
@@ -998,11 +991,11 @@ export class BladeAdapter extends BaseAdapter implements IRNodeEmitter<BladeRend
     const arrayName = loop.array.trim()
     if (staticArray === null && /^[A-Za-z_$][\w$]*$/.test(arrayName)) {
       const arrayConst = (this.localConstants ?? []).find(c => c.name === arrayName)
-      if (arrayConst && !arrayConst.isModule && this._resolveLiteralConst(arrayName) === null) {
+      if (arrayConst && this._resolveLiteralConst(arrayName) === null) {
         this.errors.push({
           code: 'BF101',
           severity: 'error',
-          message: `Loop array \`${arrayName}\` is a local computed value (\`${arrayConst.value}\`) that the Blade adapter cannot bind as a template variable — only numeric/string-literal locals inline at their use site.`,
+          message: `Loop array \`${arrayName}\` is a const (module- or function-scope) computed value (\`${arrayConst.value}\`) that the Blade adapter cannot bind as a template variable — only numeric/string-literal locals inline at their use site.`,
           loc: loop.loc ?? { file: this.componentName + '.tsx', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
           suggestion: {
             message:

--- a/packages/adapter-blade/src/conformance-pins.ts
+++ b/packages/adapter-blade/src/conformance-pins.ts
@@ -47,6 +47,17 @@ export const conformancePins: ConformancePins = {
       issue: 'https://github.com/piconic-ai/barefootjs/issues/2321',
     },
   ],
+  // #2946: the module-scope const is computed via a function call, not a
+  // static literal — genuinely unresolvable at SSR render time, same
+  // policy as an unresolvable FUNCTION-scope const above. Escape twin:
+  // `module-const-loop-source-computed-client`.
+  'module-const-loop-source-computed': [
+    {
+      code: 'BF101',
+      severity: 'error',
+      issue: 'https://github.com/piconic-ai/barefootjs/issues/2946',
+    },
+  ],
   // No inline nested-callback form exists in the evaluator-JSON `*_eval`
   // mechanism (this adapter's only higher-order lowering path — see
   // blade-adapter.ts's header, divergence 3): loud BF101 instead of the

--- a/packages/adapter-erb/src/adapter/erb-adapter.ts
+++ b/packages/adapter-erb/src/adapter/erb-adapter.ts
@@ -948,9 +948,9 @@ export class ErbAdapter extends BaseAdapter implements IRNodeEmitter<ErbRenderCt
       })
     }
 
-    // Loop array is a bare identifier naming a component-scope (non-module)
-    // `const` the adapter has no way to compute at SSR render time. Only a
-    // pure-literal const (`resolveLiteralConst`) or a module-scope
+    // Loop array is a bare identifier naming a local const (module- or
+    // component-scope, #2946) the adapter has no way to compute at SSR
+    // render time. Only a pure-literal const (`resolveLiteralConst`) or a
     // pure-string const (`resolveModuleStringConst`) is ever inlined —
     // anything else (`const entries = Object.entries(props.x).filter(...)`)
     // falls through to the generic `v[:entries]` vars-Hash read, which is
@@ -964,17 +964,16 @@ export class ErbAdapter extends BaseAdapter implements IRNodeEmitter<ErbRenderCt
     // reproduces identically with a non-destructured param, so it is NOT a
     // destructure-lowering limitation. Surface BF101 honestly instead of
     // emitting a loop bound that silently crashes / renders empty.
-    // #2208: a loop source that is a fully-static array literal — either
-    // inline (`[{ label: 'Alpha' }, ...].map(...)`) or a bare identifier
-    // bound to a FUNCTION-scope local const whose initializer has no
-    // prop/signal/function-call dependency — inlines as a native Ruby
-    // array/hash literal below, the same way a module-scope const's value
-    // is already seeded. Previously the INLINE shape wasn't gated here at
-    // all (this check only ever inspected an `identifier` array source) —
-    // it still ended up refusing via `convertExpressionToRuby`'s generic
-    // `unsupported` object-literal path (BF101, "Expression not
-    // supported"), which is what this loop-specific check now also does
-    // deliberately, up front, for both shapes.
+    // #2208/#2946: a loop source that is a fully-static array literal —
+    // either inline (`[{ label: 'Alpha' }, ...].map(...)`) or a bare
+    // identifier bound to a local const (module- or function-scope) whose
+    // initializer has no prop/signal/function-call dependency — inlines as
+    // a native Ruby array/hash literal below. Previously the INLINE shape
+    // wasn't gated here at all (this check only ever inspected an
+    // `identifier` array source) — it still ended up refusing via
+    // `convertExpressionToRuby`'s generic `unsupported` object-literal path
+    // (BF101, "Expression not supported"), which is what this loop-specific
+    // check now also does deliberately, up front, for both shapes.
     // Canonical, position-accurate predicate (#2482 Stage 2) — the
     // enclosing loop scope's own membership.
     const staticItems = resolveStaticLoopSource(loop.arrayParsed, this.localConstants, {
@@ -988,10 +987,10 @@ export class ErbAdapter extends BaseAdapter implements IRNodeEmitter<ErbRenderCt
         !this.scope.isBound(arrayName) &&
         this.resolveModuleStringConst(arrayName) === null &&
         this.resolveLiteralConst(arrayName) === null &&
-        this.localConstants.some(c => c.name === arrayName && !c.isModule)
+        this.localConstants.some(c => c.name === arrayName)
       if (isUnresolvableLocalConst) {
         this._recordExprBF101(
-          `Loop array \`${arrayName}\` is a component-scope const computed from a runtime expression the ERB adapter cannot evaluate at SSR render time.`,
+          `Loop array \`${arrayName}\` is a const (module- or component-scope) computed from a runtime expression the ERB adapter cannot evaluate at SSR render time.`,
           `Options:\n1. Inline the array expression directly in the .map() call instead of a preceding const.\n2. Mark the loop position as @client-only so the array materialises on the client.\n3. Precompute the value server-side and pass it in as a prop.`,
           [{ kind: 'prop-precompute' }, { kind: 'client-directive' }],
         )

--- a/packages/adapter-erb/src/conformance-pins.ts
+++ b/packages/adapter-erb/src/conformance-pins.ts
@@ -47,6 +47,17 @@ export const conformancePins: ConformancePins = {
       issue: 'https://github.com/piconic-ai/barefootjs/issues/2321',
     },
   ],
+  // #2946: the module-scope const is computed via a function call, not a
+  // static literal — genuinely unresolvable at SSR render time, same
+  // policy as an unresolvable FUNCTION-scope const above. Escape twin:
+  // `module-const-loop-source-computed-client`.
+  'module-const-loop-source-computed': [
+    {
+      code: 'BF101',
+      severity: 'error',
+      issue: 'https://github.com/piconic-ai/barefootjs/issues/2946',
+    },
+  ],
   // Only the `.find` variant is pinned — `find*` returns an element, not a
   // boolean, so there is no inline predicate form; the nested-`.some` sibling
   // lowers to a real inline Ruby block and must render to Hono parity instead.

--- a/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
+++ b/packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts
@@ -5586,9 +5586,15 @@ export function List(props: Props) {
     // which a misclassified `isPropDerived: true` hides from JSON entirely.
     expect(collidingTypes).toContain('Items []ItemProps `json:"items"`')
     expect(collidingTypes).not.toContain('Items []ItemProps `json:"-"`')
-    const itemsFieldLine = (src: string) => src.split('\n').find(l => l.includes('[]ItemInput')) ?? ''
-    expect(itemsFieldLine(collidingTypes)).not.toBe('')
-    expect(itemsFieldLine(collidingTypes)).toBe(itemsFieldLine(controlTypes))
+    // #2946: `base` is a module-scope static array, so the loop is now baked
+    // (`analyzeBakeableStaticChildLoop`) — each item's props are computed
+    // directly in `NewListProps`, and the Input struct carries no
+    // `[]ItemInput` field for a caller to (redundantly) supply, in either
+    // source. Same shape as the `#2208` static-array-loop-source-baking
+    // describe block below.
+    const inputStruct = (src: string) => src.slice(src.indexOf('ListInput struct'), src.indexOf('ListProps struct'))
+    expect(inputStruct(collidingTypes)).not.toContain('ItemInput')
+    expect(inputStruct(controlTypes)).not.toContain('ItemInput')
   })
 })
 

--- a/packages/adapter-go-template/src/adapter/go-template-adapter.ts
+++ b/packages/adapter-go-template/src/adapter/go-template-adapter.ts
@@ -7606,12 +7606,10 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
       })
     }
 
-    // A loop array that's a bare reference to a FUNCTION-SCOPE local const with
-    // a computed initializer (`const entries = Object.entries(props.x ??
-    // {}).filter(...)`) can't be bound as a Go template value: module-scope
-    // consts (`isModule`) are a different, already-working case (statically
-    // evaluated and seeded into the render context elsewhere), but a
-    // function-scope local only reaches the template at all via
+    // A loop array that's a bare reference to a local const (module- or
+    // function-scope, #2946) with a computed initializer (`const entries =
+    // Object.entries(props.x ?? {}).filter(...)`) can't be bound as a Go
+    // template value: such a local only reaches the template at all via
     // `computeDerivedConstFields`'s STRING-typed derived-const lowering
     // (`isStringExpr`) — an array-typed initializer like this one never
     // qualifies, so `identifier()` would still emit `.Entries` (the naive
@@ -7678,11 +7676,11 @@ export class GoTemplateAdapter extends BaseAdapter implements ParsedExprEmitter,
     // `prop-handling.ts`'s `expandDynamicPropValue`.
     if (bakedChildLoop === null && /^[A-Za-z_$][\w$]*$/.test(arrayName) && !this.scope.isBound(arrayName)) {
       const arrayConst = this.state.localConstants.find(c => c.name === arrayName)
-      if (arrayConst && !arrayConst.isModule && arrayConst.parsed && !this.isStringExpr(arrayConst.parsed, new Set())) {
+      if (arrayConst && arrayConst.parsed && !this.isStringExpr(arrayConst.parsed, new Set())) {
         this.state.errors.push({
           code: 'BF101',
           severity: 'error',
-          message: `Loop array \`${arrayName}\` is a local computed value (\`${arrayConst.value}\`) that the Go template adapter cannot bind as a template variable — only a string-derived local resolves to a generated struct field.`,
+          message: `Loop array \`${arrayName}\` is a const (module- or function-scope) computed value (\`${arrayConst.value}\`) that the Go template adapter cannot bind as a template variable — only a string-derived local resolves to a generated struct field.`,
           loc: loop.loc ?? this.makeLoc(),
           suggestion: {
             message:

--- a/packages/adapter-go-template/src/conformance-pins.ts
+++ b/packages/adapter-go-template/src/conformance-pins.ts
@@ -43,6 +43,17 @@ export const conformancePins: ConformancePins = {
       issue: 'https://github.com/piconic-ai/barefootjs/issues/2321',
     },
   ],
+  // #2946: the module-scope const is computed via a function call, not a
+  // static literal — genuinely unresolvable at SSR render time, same
+  // policy as an unresolvable FUNCTION-scope const above. Escape twin:
+  // `module-const-loop-source-computed-client`.
+  'module-const-loop-source-computed': [
+    {
+      code: 'BF101',
+      severity: 'error',
+      issue: 'https://github.com/piconic-ai/barefootjs/issues/2946',
+    },
+  ],
   // #2038: `renderFilterExpr`'s `call` arm has no faithful Go form for a
   // nested arrow — loud BF101 instead of the old silent drop of the arrow
   // argument.

--- a/packages/adapter-jinja/src/adapter/jinja-adapter.ts
+++ b/packages/adapter-jinja/src/adapter/jinja-adapter.ts
@@ -800,44 +800,33 @@ export class JinjaAdapter extends BaseAdapter implements IRNodeEmitter<JinjaRend
       })
     }
 
-    // A `.map()` loop whose array is a bare identifier bound to a
-    // FUNCTION-scope local const with a non-statically-evaluable initializer
-    // that reads props/signals (e.g. `const entries =
-    // Object.entries(props.x ?? {}).filter(...)`) can't render correctly.
-    // Module-scope consts (`isModule`, e.g. `const payments = [...]` at the
-    // top of the file) are a DIFFERENT, already-working case — the shared
-    // `ssr-defaults.ts` statically evaluates those and seeds them straight
-    // into the render context, so a bare `payments` reference resolves for
-    // free (data-table demo). Function-scope locals get no such seeding
-    // (`ssr-defaults.ts`: "component-scope locals can depend on
-    // signals/props and are evaluated lazily elsewhere") — and this
-    // adapter's only "elsewhere" is inlining a const's value at its use
-    // site (`_resolveLiteralConst`'s numeric/single-quoted-string fast
-    // path, or a static-record-literal lookup), never binding one as a
-    // `{% set %}` template local. Left unchecked, `{% for item in entries
-    // %}` over an unbound name would silently iterate zero times (Jinja's
+    // A `.map()` loop whose array is a bare identifier bound to a local
+    // const (module- or function-scope, #2946) with a non-statically-
+    // evaluable initializer that reads props/signals/a function call (e.g.
+    // `const entries = Object.entries(props.x ?? {}).filter(...)`) can't
+    // render correctly. Left unchecked, `{% for item in entries %}` over an
+    // unbound name would silently iterate zero times (Jinja's
     // `ChainableUndefined` tolerates it rather than raising) instead of
     // failing loudly. Pre-existing, general limitation, orthogonal to
     // #2087's destructure-binding work — newly reachable in this adapter's
     // test corpus only because the widened destructure gate (#2087 Phase
     // A/B) no longer refuses this fixture's `([emoji, users]) => ...`
     // param first.
-    // #2208: a loop source that is a fully-static array literal — either
-    // inline (`[{ label: 'Alpha' }, ...].map(...)`) or a bare identifier
-    // bound to a FUNCTION-scope local const whose initializer has no
-    // prop/signal/function-call dependency — inlines as a native Jinja
-    // list/dict literal below, the same way a module-scope const's value
-    // is already seeded. A runtime-computed local (#2069, e.g.
-    // `Object.entries(props.tags).filter(...)`) still refuses below.
-    // `isNameShadowed` guards a DIFFERENT, enclosing loop's own callback
-    // param shadowing this identifier (fable review) — never resolve the
-    // static const in that case. `rawArray` then falls through to the
-    // bare identifier expression below, same as before #2208 — which
-    // still trips the pre-existing BF101 gate for an unresolvable local
-    // const reference (a loud, conservative refusal, not a silent wrong
-    // value). Canonical, position-accurate predicate (#2482 Stage 2) — the
-    // enclosing loop scope's own membership, not a coarse whole-component
-    // union.
+    // #2208/#2946: a loop source that is a fully-static array literal —
+    // either inline (`[{ label: 'Alpha' }, ...].map(...)`) or a bare
+    // identifier bound to a local const (module- or function-scope) whose
+    // initializer has no prop/signal/function-call dependency — inlines as
+    // a native Jinja list/dict literal below. A runtime-computed local
+    // (#2069, e.g. `Object.entries(props.tags).filter(...)`) still refuses
+    // below, whichever scope it's declared in. `isNameShadowed` guards a
+    // DIFFERENT, enclosing loop's own callback param shadowing this
+    // identifier (fable review) — never resolve the static const in that
+    // case. `rawArray` then falls through to the bare identifier expression
+    // below, same as before #2208 — which still trips the pre-existing
+    // BF101 gate for an unresolvable local const reference (a loud,
+    // conservative refusal, not a silent wrong value). Canonical,
+    // position-accurate predicate (#2482 Stage 2) — the enclosing loop
+    // scope's own membership, not a coarse whole-component union.
     const staticItems = resolveStaticLoopSource(loop.arrayParsed, this.localConstants, {
       isNameShadowed: this.scope.asShadowPredicate(),
     })
@@ -846,11 +835,11 @@ export class JinjaAdapter extends BaseAdapter implements IRNodeEmitter<JinjaRend
     const arrayName = loop.array.trim()
     if (staticArray === null && /^[A-Za-z_$][\w$]*$/.test(arrayName)) {
       const arrayConst = (this.localConstants ?? []).find(c => c.name === arrayName)
-      if (arrayConst && !arrayConst.isModule && this._resolveLiteralConst(arrayName) === null) {
+      if (arrayConst && this._resolveLiteralConst(arrayName) === null) {
         this.errors.push({
           code: 'BF101',
           severity: 'error',
-          message: `Loop array \`${arrayName}\` is a local computed value (\`${arrayConst.value}\`) that the Jinja adapter cannot bind as a template variable — only numeric/string-literal locals inline at their use site.`,
+          message: `Loop array \`${arrayName}\` is a const (module- or function-scope) computed value (\`${arrayConst.value}\`) that the Jinja adapter cannot bind as a template variable — only numeric/string-literal locals inline at their use site.`,
           loc: loop.loc ?? { file: this.componentName + '.tsx', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
           suggestion: {
             message:

--- a/packages/adapter-jinja/src/conformance-pins.ts
+++ b/packages/adapter-jinja/src/conformance-pins.ts
@@ -47,6 +47,17 @@ export const conformancePins: ConformancePins = {
       issue: 'https://github.com/piconic-ai/barefootjs/issues/2321',
     },
   ],
+  // #2946: the module-scope const is computed via a function call, not a
+  // static literal — genuinely unresolvable at SSR render time, same
+  // policy as an unresolvable FUNCTION-scope const above. Escape twin:
+  // `module-const-loop-source-computed-client`.
+  'module-const-loop-source-computed': [
+    {
+      code: 'BF101',
+      severity: 'error',
+      issue: 'https://github.com/piconic-ai/barefootjs/issues/2946',
+    },
+  ],
   // #2038: no inline comprehension-with-nested-callback form via the
   // evaluator-JSON `*_eval` mechanism (`jinja-adapter.ts`'s header,
   // divergence 3) — loud BF101 instead of lossy.

--- a/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
+++ b/packages/adapter-mojolicious/src/adapter/mojo-adapter.ts
@@ -897,13 +897,11 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
       })
     }
 
-    // A `.map()` loop whose array is a bare identifier bound to a
-    // FUNCTION-scope local const with a non-statically-evaluable initializer
-    // that reads props/signals (e.g. `const entries =
-    // Object.entries(props.x ?? {}).filter(...)`) can't render correctly.
-    // Module-scope consts (`isModule`, e.g. `const payments = [...]` at the
-    // top of the file) are a DIFFERENT, already-working case handled
-    // elsewhere. Function-scope locals get no per-render stash slot — this
+    // A `.map()` loop whose array is a bare identifier bound to a local
+    // const (module- or function-scope, #2946) with a non-statically-
+    // evaluable initializer that reads props/signals/a function call (e.g.
+    // `const entries = Object.entries(props.x ?? {}).filter(...)`) can't
+    // render correctly. Locals get no per-render stash slot — this
     // adapter's only "elsewhere" for a local const is inlining its value at
     // the use site (`resolveLiteralConst`'s numeric/single-quoted-string fast
     // path, or a static-record-literal lookup), never binding one as a `my`
@@ -914,17 +912,17 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
     // reachable in this adapter's test corpus only because the widened
     // destructure gate (#2087 Phase A/B) no longer refuses this fixture's
     // `([emoji, users]) => ...` param first.
-    // #2208: a loop source that is a fully-static array literal — either
-    // inline (`[{ label: 'Alpha' }, ...].map(...)`) or a bare identifier
-    // bound to a FUNCTION-scope local const whose initializer has no
-    // prop/signal/function-call dependency — inlines as a native Perl
-    // arrayref/hashref literal below, the same way a module-scope const's
-    // value is already seeded. A runtime-computed local (#2069, e.g.
-    // `Object.entries(props.tags).filter(...)`) still refuses below.
-    // `isNameShadowed` guards a DIFFERENT, enclosing loop's own callback
-    // param shadowing this identifier (fable review) — reuses the same
-    // threaded, position-accurate `this.scope` `resolveModuleStringConst`
-    // already consults for this hazard class (#1749/#2482 Stage 2).
+    // #2208/#2946: a loop source that is a fully-static array literal —
+    // either inline (`[{ label: 'Alpha' }, ...].map(...)`) or a bare
+    // identifier bound to a local const (module- or function-scope) whose
+    // initializer has no prop/signal/function-call dependency — inlines as
+    // a native Perl arrayref/hashref literal below. A runtime-computed
+    // local (#2069, e.g. `Object.entries(props.tags).filter(...)`) still
+    // refuses below, whichever scope it's declared in. `isNameShadowed`
+    // guards a DIFFERENT, enclosing loop's own callback param shadowing
+    // this identifier (fable review) — reuses the same threaded,
+    // position-accurate `this.scope` `resolveModuleStringConst` already
+    // consults for this hazard class (#1749/#2482 Stage 2).
     const staticItems = resolveStaticLoopSource(loop.arrayParsed, this.localConstants, {
       isNameShadowed: this.scope.asShadowPredicate(),
     })
@@ -933,11 +931,11 @@ export class MojoAdapter extends BaseAdapter implements IRNodeEmitter<MojoRender
     const arrayName = loop.array.trim()
     if (staticArray === null && /^[A-Za-z_$][\w$]*$/.test(arrayName)) {
       const arrayConst = (this.localConstants ?? []).find(c => c.name === arrayName)
-      if (arrayConst && !arrayConst.isModule && this.resolveLiteralConst(arrayName) === null) {
+      if (arrayConst && this.resolveLiteralConst(arrayName) === null) {
         this.errors.push({
           code: 'BF101',
           severity: 'error',
-          message: `Loop array \`${arrayName}\` is a local computed value (\`${arrayConst.value}\`) that the Mojo adapter cannot bind as a template variable — only numeric/string-literal locals inline at their use site.`,
+          message: `Loop array \`${arrayName}\` is a const (module- or function-scope) computed value (\`${arrayConst.value}\`) that the Mojo adapter cannot bind as a template variable — only numeric/string-literal locals inline at their use site.`,
           loc: loop.loc ?? { file: this.componentName + '.tsx', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
           suggestion: {
             message:

--- a/packages/adapter-mojolicious/src/conformance-pins.ts
+++ b/packages/adapter-mojolicious/src/conformance-pins.ts
@@ -47,6 +47,17 @@ export const conformancePins: ConformancePins = {
       issue: 'https://github.com/piconic-ai/barefootjs/issues/2321',
     },
   ],
+  // #2946: the module-scope const is computed via a function call, not a
+  // static literal — genuinely unresolvable at SSR render time, same
+  // policy as an unresolvable FUNCTION-scope const above. Escape twin:
+  // `module-const-loop-source-computed-client`.
+  'module-const-loop-source-computed': [
+    {
+      code: 'BF101',
+      severity: 'error',
+      issue: 'https://github.com/piconic-ai/barefootjs/issues/2946',
+    },
+  ],
   // Only `.find` is pinned — `find*` returns an element, not a boolean, so
   // there's no inline predicate form; the nested-`.some` sibling lowers to a
   // real inline Perl `grep` and must render to Hono parity instead.

--- a/packages/adapter-rust/src/adapter/minijinja-adapter.ts
+++ b/packages/adapter-rust/src/adapter/minijinja-adapter.ts
@@ -848,17 +848,11 @@ export class MinijinjaAdapter extends BaseAdapter implements IRNodeEmitter<Jinja
       })
     }
 
-    // A `.map()` loop whose array is a bare identifier bound to a
-    // FUNCTION-scope local const with a non-statically-evaluable initializer
-    // that reads props/signals (e.g. `const entries =
-    // Object.entries(props.x ?? {}).filter(...)`) can't render correctly.
-    // Module-scope consts (`isModule`, e.g. `const payments = [...]` at the
-    // top of the file) are a DIFFERENT, already-working case — the shared
-    // `ssr-defaults.ts` statically evaluates those and seeds them straight
-    // into the render context, so a bare `payments` reference resolves for
-    // free (data-table demo). Function-scope locals get no such seeding
-    // (`ssr-defaults.ts`: "component-scope locals can depend on
-    // signals/props and are evaluated lazily elsewhere") — and this
+    // A `.map()` loop whose array is a bare identifier bound to a local
+    // const (module- or function-scope, #2946) with a non-statically-
+    // evaluable initializer that reads props/signals/a function call (e.g.
+    // `const entries = Object.entries(props.x ?? {}).filter(...)`) can't
+    // render correctly. Locals get no per-render stash slot — this
     // adapter's only "elsewhere" is inlining a const's value at its use
     // site (`_resolveLiteralConst`'s numeric/single-quoted-string fast
     // path, or a static-record-literal lookup), never binding one as a
@@ -871,22 +865,21 @@ export class MinijinjaAdapter extends BaseAdapter implements IRNodeEmitter<Jinja
     // corpus only because the widened destructure gate (#2087 Phase A/B)
     // no longer refuses this fixture's `([emoji, users]) => ...` param
     // first. Mirrors adapter-jinja's identical check.
-    // #2208: a loop source that is a fully-static array literal — either
-    // inline (`[{ label: 'Alpha' }, ...].map(...)`) or a bare identifier
-    // bound to a FUNCTION-scope local const whose initializer has no
-    // prop/signal/function-call dependency — inlines as a native MiniJinja
-    // list/dict literal below, the same way a module-scope const's value
-    // is already seeded. A runtime-computed local (#2069, e.g.
-    // `Object.entries(props.tags).filter(...)`) still refuses below.
-    // `isNameShadowed` guards a DIFFERENT, enclosing loop's own callback
-    // param shadowing this identifier (fable review) — never resolve the
-    // static const in that case. `rawArray` then falls through to the
-    // bare identifier expression below, same as before #2208 — which
-    // still trips the pre-existing BF101 gate for an unresolvable local
-    // const reference (a loud, conservative refusal, not a silent wrong
-    // value). Canonical, position-accurate predicate (#2482 Stage 2) — the
-    // enclosing loop scope's own membership, not a coarse whole-component
-    // union.
+    // #2208/#2946: a loop source that is a fully-static array literal —
+    // either inline (`[{ label: 'Alpha' }, ...].map(...)`) or a bare
+    // identifier bound to a local const (module- or function-scope) whose
+    // initializer has no prop/signal/function-call dependency — inlines as
+    // a native MiniJinja list/dict literal below. A runtime-computed local
+    // (#2069, e.g. `Object.entries(props.tags).filter(...)`) still refuses
+    // below, whichever scope it's declared in. `isNameShadowed` guards a
+    // DIFFERENT, enclosing loop's own callback param shadowing this
+    // identifier (fable review) — never resolve the static const in that
+    // case. `rawArray` then falls through to the bare identifier expression
+    // below, same as before #2208 — which still trips the pre-existing
+    // BF101 gate for an unresolvable local const reference (a loud,
+    // conservative refusal, not a silent wrong value). Canonical,
+    // position-accurate predicate (#2482 Stage 2) — the enclosing loop
+    // scope's own membership, not a coarse whole-component union.
     const staticItems = resolveStaticLoopSource(loop.arrayParsed, this.localConstants, {
       isNameShadowed: this.scope.asShadowPredicate(),
     })
@@ -895,11 +888,11 @@ export class MinijinjaAdapter extends BaseAdapter implements IRNodeEmitter<Jinja
     const arrayName = loop.array.trim()
     if (staticArray === null && /^[A-Za-z_$][\w$]*$/.test(arrayName)) {
       const arrayConst = (this.localConstants ?? []).find(c => c.name === arrayName)
-      if (arrayConst && !arrayConst.isModule && this._resolveLiteralConst(arrayName) === null) {
+      if (arrayConst && this._resolveLiteralConst(arrayName) === null) {
         this.errors.push({
           code: 'BF101',
           severity: 'error',
-          message: `Loop array \`${arrayName}\` is a local computed value (\`${arrayConst.value}\`) that the MiniJinja adapter cannot bind as a template variable — only numeric/string-literal locals inline at their use site.`,
+          message: `Loop array \`${arrayName}\` is a const (module- or function-scope) computed value (\`${arrayConst.value}\`) that the MiniJinja adapter cannot bind as a template variable — only numeric/string-literal locals inline at their use site.`,
           loc: loop.loc ?? { file: this.componentName + '.tsx', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
           suggestion: {
             message:

--- a/packages/adapter-rust/src/conformance-pins.ts
+++ b/packages/adapter-rust/src/conformance-pins.ts
@@ -48,6 +48,17 @@ export const conformancePins: ConformancePins = {
       issue: 'https://github.com/piconic-ai/barefootjs/issues/2321',
     },
   ],
+  // #2946: the module-scope const is computed via a function call, not a
+  // static literal — genuinely unresolvable at SSR render time, same
+  // policy as an unresolvable FUNCTION-scope const above. Escape twin:
+  // `module-const-loop-source-computed-client`.
+  'module-const-loop-source-computed': [
+    {
+      code: 'BF101',
+      severity: 'error',
+      issue: 'https://github.com/piconic-ai/barefootjs/issues/2946',
+    },
+  ],
   // #2038: no inline comprehension-with-nested-callback form via the
   // evaluator-JSON `*_eval` mechanism (`minijinja-adapter.ts`'s header,
   // divergence 3) — loud BF101 instead of lossy.

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -3983,6 +3983,18 @@
         "text"
       ]
     },
+    "module-const-loop-source-computed-precomputed": {
+      "kinds": [
+        "identifier",
+        "member"
+      ],
+      "axes": [],
+      "contexts": [
+        "attribute",
+        "loop",
+        "text"
+      ]
+    },
     "multi-component-module": {
       "kinds": [
         "call",
@@ -6762,11 +6774,11 @@
     "binary": 106,
     "call": 279,
     "conditional": 33,
-    "identifier": 396,
+    "identifier": 397,
     "index-access": 14,
     "literal": 316,
     "logical": 51,
-    "member": 233,
+    "member": 234,
     "object-literal": 93,
     "template-literal": 31,
     "unary": 29,

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -3927,6 +3927,62 @@
         "text"
       ]
     },
+    "module-const-loop-source": {
+      "kinds": [
+        "array-literal",
+        "identifier",
+        "literal"
+      ],
+      "axes": [
+        "literal:string"
+      ],
+      "contexts": [
+        "attribute",
+        "loop",
+        "text"
+      ]
+    },
+    "module-const-loop-source-child-component": {
+      "kinds": [
+        "array-literal",
+        "identifier",
+        "literal",
+        "member",
+        "object-literal"
+      ],
+      "axes": [
+        "literal:string"
+      ],
+      "contexts": [
+        "attribute",
+        "loop",
+        "text"
+      ]
+    },
+    "module-const-loop-source-computed": {
+      "kinds": [
+        "call",
+        "identifier"
+      ],
+      "axes": [],
+      "contexts": [
+        "attribute",
+        "loop",
+        "text"
+      ]
+    },
+    "module-const-loop-source-computed-client": {
+      "kinds": [
+        "call",
+        "identifier"
+      ],
+      "axes": [],
+      "contexts": [
+        "attribute",
+        "loop",
+        "text"
+      ]
+    },
     "multi-component-module": {
       "kinds": [
         "call",
@@ -6700,18 +6756,18 @@
     }
   },
   "kindCounts": {
-    "array-literal": 114,
+    "array-literal": 116,
     "array-method": 71,
     "arrow": 74,
     "binary": 106,
-    "call": 277,
+    "call": 279,
     "conditional": 33,
-    "identifier": 392,
+    "identifier": 396,
     "index-access": 14,
-    "literal": 314,
+    "literal": 316,
     "logical": 51,
-    "member": 232,
-    "object-literal": 92,
+    "member": 233,
+    "object-literal": 93,
     "template-literal": 31,
     "unary": 29,
     "unsupported": 50
@@ -6755,7 +6811,7 @@
     "literal:boolean": 71,
     "literal:null": 26,
     "literal:number": 143,
-    "literal:string": 215,
+    "literal:string": 217,
     "logical:&&": 7,
     "logical:??": 43,
     "logical:||": 16,

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -548,6 +548,7 @@ import { fixture as moduleConstLoopSource } from './module-const-loop-source'
 import { fixture as moduleConstLoopSourceChildComponent } from './module-const-loop-source-child-component'
 import { fixture as moduleConstLoopSourceComputed } from './module-const-loop-source-computed'
 import { fixture as moduleConstLoopSourceComputedClient } from './module-const-loop-source-computed-client'
+import { fixture as moduleConstLoopSourceComputedPrecomputed } from './module-const-loop-source-computed-precomputed'
 import { fixture as loopParamShadowsRecordTemplateSpan } from './loop-param-shadows-record-template-span'
 // #2482 audit follow-ups, adapter-side (pinned known limitations):
 // Go condition-position destructured bindings, Go nested-loop `inLoop`
@@ -1043,6 +1044,7 @@ export const jsxFixtures: JSXFixture[] = [
   moduleConstLoopSourceChildComponent,
   moduleConstLoopSourceComputed,
   moduleConstLoopSourceComputedClient,
+  moduleConstLoopSourceComputedPrecomputed,
   loopParamShadowsRecordTemplateSpan,
   loopDestructuredParamCondition,
   nestedLoopTailContent,

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -542,6 +542,12 @@ import { fixture as moduleConstArraySeed } from './module-const-array-seed'
 // pullfrog review, PR #2881: the no-explicit-generic sibling, exercising
 // resolveModuleConstAsGo's c.type fallback (target.bakeType.kind === 'unknown').
 import { fixture as moduleConstArraySeedNoGeneric } from './module-const-array-seed-no-generic'
+// #2946: a module-scope const array `.map()`'d directly with no signal
+// wrapper — the shape `resolveStaticLoopSource` used to refuse outright.
+import { fixture as moduleConstLoopSource } from './module-const-loop-source'
+import { fixture as moduleConstLoopSourceChildComponent } from './module-const-loop-source-child-component'
+import { fixture as moduleConstLoopSourceComputed } from './module-const-loop-source-computed'
+import { fixture as moduleConstLoopSourceComputedClient } from './module-const-loop-source-computed-client'
 import { fixture as loopParamShadowsRecordTemplateSpan } from './loop-param-shadows-record-template-span'
 // #2482 audit follow-ups, adapter-side (pinned known limitations):
 // Go condition-position destructured bindings, Go nested-loop `inLoop`
@@ -1033,6 +1039,10 @@ export const jsxFixtures: JSXFixture[] = [
   signalObjectSpreadInitClient,
   moduleConstArraySeed,
   moduleConstArraySeedNoGeneric,
+  moduleConstLoopSource,
+  moduleConstLoopSourceChildComponent,
+  moduleConstLoopSourceComputed,
+  moduleConstLoopSourceComputedClient,
   loopParamShadowsRecordTemplateSpan,
   loopDestructuredParamCondition,
   nestedLoopTailContent,

--- a/packages/adapter-tests/fixtures/module-const-loop-source-child-component.ts
+++ b/packages/adapter-tests/fixtures/module-const-loop-source-child-component.ts
@@ -1,0 +1,46 @@
+import { createFixture } from '../src/types'
+
+/**
+ * #2946 sibling: same module-scope static array shape as
+ * `module-const-loop-source`, but the `.map()` body is a sibling CHILD
+ * COMPONENT rather than a plain element. This exercises the Go adapter's
+ * per-item-props BAKING path specifically (`analyzeBakeableStaticChildLoop`
+ * / `getBakedStaticChildLoop`), which is reached through the same
+ * `resolveStaticLoopSource` fix but was otherwise untested for a
+ * module-scope array — see the `#2835` unit test in
+ * `packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts`,
+ * which pinned the pre-fix (unbaked) lowering for this exact shape and had
+ * to be updated alongside the fix.
+ */
+export const fixture = createFixture({
+  id: 'module-const-loop-source-child-component',
+  description: 'A module-scope const array `.map()`\'d over a child component renders on every adapter (#2946)',
+  source: `
+import { ListItem } from './list-item'
+
+const items = [{ label: 'Alpha' }, { label: 'Beta' }]
+
+export function ModuleConstLoopSourceChildComponent() {
+  return (
+    <ul>
+      {items.map(item => (
+        <ListItem key={item.label} label={item.label} className="text-sm" />
+      ))}
+    </ul>
+  )
+}
+`,
+  components: {
+    './list-item.tsx': `
+export function ListItem({ label, className }: { label: string; className?: string }) {
+  return <li className={className}>{label}</li>
+}
+`,
+  },
+  expectedHtml: `
+    <ul bf-s="test" bf="s1">
+      <li bf-s="ListItem_*" bf="s1" class="text-sm" data-key="Alpha"><!--bf:s0-->Alpha<!--/--></li>
+      <li bf-s="ListItem_*" bf="s1" class="text-sm" data-key="Beta"><!--bf:s0-->Beta<!--/--></li>
+    </ul>
+  `,
+})

--- a/packages/adapter-tests/fixtures/module-const-loop-source-computed-client.ts
+++ b/packages/adapter-tests/fixtures/module-const-loop-source-computed-client.ts
@@ -1,0 +1,36 @@
+import { createFixture } from '../src/types'
+
+/**
+ * Escape twin for `module-const-loop-source-computed` (#2946): the same
+ * module-scope computed-const shape, but the loop is marked
+ * `/* @client *\/` so it defers to the browser instead of refusing SSR —
+ * mirrors `client-only-loop`'s bare-loop marker-pair shape. SSR renders the
+ * container with no rows (nothing left to adopt); the client runtime's
+ * `mapArray()` materialises them at hydration time.
+ */
+export const fixture = createFixture({
+  id: 'module-const-loop-source-computed-client',
+  description: 'A /* @client */ loop over a module-scope computed const defers to the browser instead of refusing SSR (#2946)',
+  source: `
+'use client'
+
+function buildItems() {
+  return ['a', 'b', 'c']
+}
+
+const items = buildItems()
+
+export function ModuleConstLoopSourceComputedClient() {
+  return (
+    <div className="container">
+      {/* @client */ items.map(item => (
+        <div key={item} data-item={item}>row {item}</div>
+      ))}
+    </div>
+  )
+}
+`,
+  expectedHtml: `
+    <div bf-s="test" bf="s2" class="container"></div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/module-const-loop-source-computed-precomputed.ts
+++ b/packages/adapter-tests/fixtures/module-const-loop-source-computed-precomputed.ts
@@ -1,0 +1,47 @@
+import { createFixture } from '../src/types'
+
+/**
+ * `prop-precompute` twin of `module-const-loop-source-computed` (#2946) —
+ * the second escape kind the BF101 diagnostic offers alongside
+ * `client-directive`.
+ *
+ * The base refuses on every non-Hono adapter because the loop array is a
+ * module-scope const with a computed initializer (`buildItems()`). This
+ * twin moves the computation out of the component entirely — the caller
+ * passes the already-built array in as a prop, so no adapter is ever asked
+ * to evaluate the function call. Unlike the `-client` twin (SSR renders no
+ * rows), this one renders the full rows on every adapter, same as
+ * `static-array-from-props-precomputed`'s contrast with
+ * `static-array-from-props-client`.
+ */
+export const fixture = createFixture({
+  id: 'module-const-loop-source-computed-precomputed',
+  description: 'prop-precompute twin of module-const-loop-source-computed — computation moved to the caller, full SSR (#2946)',
+  source: `
+'use client'
+
+type Props = {
+  items: string[]
+}
+
+export function ModuleConstLoopSourceComputedPrecomputed(props: Props) {
+  return (
+    <div className="container">
+      {props.items.map(item => (
+        <div key={item} data-item={item}>row {item}</div>
+      ))}
+    </div>
+  )
+}
+`,
+  props: {
+    items: ['a', 'b', 'c'],
+  },
+  expectedHtml: `
+    <div bf-s="test" bf="s2" class="container">
+      <div bf="s1" data-item="a" data-key="a">row <!--bf:s0-->a<!--/--></div>
+      <div bf="s1" data-item="b" data-key="b">row <!--bf:s0-->b<!--/--></div>
+      <div bf="s1" data-item="c" data-key="c">row <!--bf:s0-->c<!--/--></div>
+    </div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/module-const-loop-source-computed.ts
+++ b/packages/adapter-tests/fixtures/module-const-loop-source-computed.ts
@@ -1,0 +1,47 @@
+import { createFixture } from '../src/types'
+
+/**
+ * #2946 companion: a module-scope const whose initializer is NOT a static
+ * literal — it's the result of a function call (`buildItems()`) — mapped
+ * directly with no signal wrapper. Unlike `module-const-loop-source`
+ * (whose array literal is fully known at compile time and now inlines on
+ * every adapter), this shape has no compile-time-known value at all: Hono
+ * renders it fine (real JS runs `buildItems()` at request time), but every
+ * SSR text/struct-template adapter has no way to evaluate an arbitrary
+ * function call, so each refuses loudly with BF101 — same policy as an
+ * unresolvable FUNCTION-scope const (`static-array-from-props`, #2321),
+ * now applied uniformly regardless of which scope the const lives in
+ * (see the `resolveStaticLoopSource` fix in `packages/jsx/src/static-literal.ts`
+ * and each adapter's `renderLoop` guard).
+ */
+export const fixture = createFixture({
+  id: 'module-const-loop-source-computed',
+  description: 'A module-scope const computed via a function call refuses loudly (BF101) on every SSR template adapter (#2946)',
+  escapes: [{ kind: 'client-directive', fixture: 'module-const-loop-source-computed-client' }],
+  source: `
+'use client'
+
+function buildItems() {
+  return ['a', 'b', 'c']
+}
+
+const items = buildItems()
+
+export function ModuleConstLoopSourceComputed() {
+  return (
+    <div className="container">
+      {items.map(item => (
+        <div key={item} data-item={item}>row {item}</div>
+      ))}
+    </div>
+  )
+}
+`,
+  expectedHtml: `
+    <div bf-s="test" bf="s2" class="container">
+      <div bf="s1" data-item="a" data-key="a">row <!--bf:s0-->a<!--/--></div>
+      <div bf="s1" data-item="b" data-key="b">row <!--bf:s0-->b<!--/--></div>
+      <div bf="s1" data-item="c" data-key="c">row <!--bf:s0-->c<!--/--></div>
+    </div>
+  `,
+})

--- a/packages/adapter-tests/fixtures/module-const-loop-source-computed.ts
+++ b/packages/adapter-tests/fixtures/module-const-loop-source-computed.ts
@@ -17,7 +17,10 @@ import { createFixture } from '../src/types'
 export const fixture = createFixture({
   id: 'module-const-loop-source-computed',
   description: 'A module-scope const computed via a function call refuses loudly (BF101) on every SSR template adapter (#2946)',
-  escapes: [{ kind: 'client-directive', fixture: 'module-const-loop-source-computed-client' }],
+  escapes: [
+    { kind: 'prop-precompute', fixture: 'module-const-loop-source-computed-precomputed' },
+    { kind: 'client-directive', fixture: 'module-const-loop-source-computed-client' },
+  ],
   source: `
 'use client'
 

--- a/packages/adapter-tests/fixtures/module-const-loop-source.ts
+++ b/packages/adapter-tests/fixtures/module-const-loop-source.ts
@@ -1,0 +1,49 @@
+import { createFixture } from '../src/types'
+
+/**
+ * #2946: a `'use client'` component that declares a static array-of-objects
+ * const at MODULE scope (outside the component function) and `.map()`s it
+ * directly — no `createSignal` wrapper in between — used to fail to render
+ * its rows on every non-Hono adapter (ERB, Jinja, Twig, Blade, Xslate,
+ * Rust/minijinja, Mojolicious, Go template). Hono (the reference adapter)
+ * always rendered correctly, since plain JS needs no template-variable
+ * indirection for a module-level `const`.
+ *
+ * Root cause: `resolveStaticLoopSource` (`packages/jsx/src/static-literal.ts`)
+ * — the one shared resolver every adapter's `renderLoop` consults to inline
+ * a `.map()` loop's array source as a native literal — deliberately excluded
+ * `isModule` consts on the theory that a separate seeding path
+ * (`ssr-defaults.ts` / Go's `convertInitialValue`) already handled them. That
+ * path only ever sees a module const through a `createSignal(...)`
+ * argument, never a bare `.map()` with no signal in between, so the array
+ * was left completely unresolved: each adapter's fallback for an
+ * unresolvable identifier produced its own distinct failure (a silently
+ * empty loop body on the stash/context-based adapters, a Perl compile error
+ * on Mojolicious, a Go execution-time `can't evaluate field` error).
+ */
+export const fixture = createFixture({
+  id: 'module-const-loop-source',
+  description: 'A module-scope const array `.map()`\'d directly (no signal) renders its rows on every adapter (#2946)',
+  source: `
+'use client'
+
+const items = ['a', 'b', 'c']
+
+export function ModuleConstLoopSource() {
+  return (
+    <div className="container">
+      {items.map(item => (
+        <div key={item} data-item={item}>row {item}</div>
+      ))}
+    </div>
+  )
+}
+`,
+  expectedHtml: `
+    <div bf-s="test" bf="s2" class="container">
+      <div bf="s1" data-item="a" data-key="a">row <!--bf:s0-->a<!--/--></div>
+      <div bf="s1" data-item="b" data-key="b">row <!--bf:s0-->b<!--/--></div>
+      <div bf="s1" data-item="c" data-key="c">row <!--bf:s0-->c<!--/--></div>
+    </div>
+  `,
+})

--- a/packages/adapter-tests/generated-data-points.json
+++ b/packages/adapter-tests/generated-data-points.json
@@ -1927,6 +1927,14 @@
       }
     }
   ],
+  "module-const-loop-source-computed-precomputed": [
+    {
+      "name": "gen:items:empty",
+      "props": {
+        "items": []
+      }
+    }
+  ],
   "nullish-coalescing-destructured": [
     {
       "name": "gen:label:absent",

--- a/packages/adapter-tests/src/csr-skip-set.ts
+++ b/packages/adapter-tests/src/csr-skip-set.ts
@@ -8,6 +8,13 @@ export const CSR_SKIP_FIXTURES: ReadonlySet<string> = new Set([
   // available at CSR template module scope (CSR templates only have access
   // to props and signals); Hono render conformance covers the real-JS runtime.
   'array-map-function-reference',
+  // #2946: same #2073 class — `items` is seeded by a module-scope FUNCTION
+  // call (`buildItems()`), not a static literal, so it can't be inlined into
+  // the CSR template either; only the SSR-side compile refusal (BF101) and
+  // its escape twins are pinned. `module-const-loop-source` and
+  // `module-const-loop-source-child-component` (the fully-static-literal
+  // shapes #2946 actually fixes) are NOT skipped here — those inline fine.
+  'module-const-loop-source-computed',
   // #1247: prop-derived static loops materialize children at init time, not
   // template-eval — CSR shape covered by `static-loop-csr-materialize.test.ts`.
   'static-array-from-props',

--- a/packages/adapter-twig/src/adapter/twig-adapter.ts
+++ b/packages/adapter-twig/src/adapter/twig-adapter.ts
@@ -848,17 +848,11 @@ export class TwigAdapter extends BaseAdapter implements IRNodeEmitter<TwigRender
       })
     }
 
-    // A `.map()` loop whose array is a bare identifier bound to a
-    // FUNCTION-scope local const with a non-statically-evaluable initializer
-    // that reads props/signals (e.g. `const entries =
-    // Object.entries(props.x ?? {}).filter(...)`) can't render correctly.
-    // Module-scope consts (`isModule`, e.g. `const payments = [...]` at the
-    // top of the file) are a DIFFERENT, already-working case — the shared
-    // `ssr-defaults.ts` statically evaluates those and seeds them straight
-    // into the render context, so a bare `payments` reference resolves for
-    // free (data-table demo). Function-scope locals get no such seeding
-    // (`ssr-defaults.ts`: "component-scope locals can depend on
-    // signals/props and are evaluated lazily elsewhere") — and this
+    // A `.map()` loop whose array is a bare identifier bound to a local
+    // const (module- or function-scope, #2946) with a non-statically-
+    // evaluable initializer that reads props/signals/a function call (e.g.
+    // `const entries = Object.entries(props.x ?? {}).filter(...)`) can't
+    // render correctly. Locals get no per-render stash slot — this
     // adapter's only "elsewhere" is inlining a const's value at its use
     // site (`_resolveLiteralConst`'s numeric/single-quoted-string fast
     // path, or a static-record-literal lookup), never binding one as a
@@ -871,22 +865,21 @@ export class TwigAdapter extends BaseAdapter implements IRNodeEmitter<TwigRender
     // (#2087 Phase A/B) no longer refuses this fixture's `([emoji, users])
     // => ...` param first. Same policy and shape as the Jinja / ERB
     // adapters' check.
-    // #2208: a loop source that is a fully-static array literal — either
-    // inline (`[{ label: 'Alpha' }, ...].map(...)`) or a bare identifier
-    // bound to a FUNCTION-scope local const whose initializer has no
-    // prop/signal/function-call dependency — inlines as a native Twig
-    // array/hash literal below, the same way a module-scope const's value
-    // is already seeded. A runtime-computed local (#2069, e.g.
-    // `Object.entries(props.tags).filter(...)`) still refuses below.
-    // `isNameShadowed` guards a DIFFERENT, enclosing loop's own callback
-    // param shadowing this identifier (fable review) — never resolve the
-    // static const in that case. `rawArray` then falls through to the
-    // bare identifier expression below, same as before #2208 — which
-    // still trips the pre-existing BF101 gate for an unresolvable local
-    // const reference (a loud, conservative refusal, not a silent wrong
-    // value). Canonical, position-accurate predicate (#2482 Stage 2) — the
-    // enclosing loop scope's own membership, not a coarse whole-component
-    // union.
+    // #2208/#2946: a loop source that is a fully-static array literal —
+    // either inline (`[{ label: 'Alpha' }, ...].map(...)`) or a bare
+    // identifier bound to a local const (module- or function-scope) whose
+    // initializer has no prop/signal/function-call dependency — inlines as
+    // a native Twig array/hash literal below. A runtime-computed local
+    // (#2069, e.g. `Object.entries(props.tags).filter(...)`) still refuses
+    // below, whichever scope it's declared in. `isNameShadowed` guards a
+    // DIFFERENT, enclosing loop's own callback param shadowing this
+    // identifier (fable review) — never resolve the static const in that
+    // case. `rawArray` then falls through to the bare identifier expression
+    // below, same as before #2208 — which still trips the pre-existing
+    // BF101 gate for an unresolvable local const reference (a loud,
+    // conservative refusal, not a silent wrong value). Canonical,
+    // position-accurate predicate (#2482 Stage 2) — the enclosing loop
+    // scope's own membership, not a coarse whole-component union.
     const staticItems = resolveStaticLoopSource(loop.arrayParsed, this.localConstants, {
       isNameShadowed: this.scope.asShadowPredicate(),
     })
@@ -895,11 +888,11 @@ export class TwigAdapter extends BaseAdapter implements IRNodeEmitter<TwigRender
     const arrayName = loop.array.trim()
     if (staticArray === null && /^[A-Za-z_$][\w$]*$/.test(arrayName)) {
       const arrayConst = (this.localConstants ?? []).find(c => c.name === arrayName)
-      if (arrayConst && !arrayConst.isModule && this._resolveLiteralConst(arrayName) === null) {
+      if (arrayConst && this._resolveLiteralConst(arrayName) === null) {
         this.errors.push({
           code: 'BF101',
           severity: 'error',
-          message: `Loop array \`${arrayName}\` is a local computed value (\`${arrayConst.value}\`) that the Twig adapter cannot bind as a template variable — only numeric/string-literal locals inline at their use site.`,
+          message: `Loop array \`${arrayName}\` is a const (module- or function-scope) computed value (\`${arrayConst.value}\`) that the Twig adapter cannot bind as a template variable — only numeric/string-literal locals inline at their use site.`,
           loc: loop.loc ?? { file: this.componentName + '.tsx', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
           suggestion: {
             message:

--- a/packages/adapter-twig/src/conformance-pins.ts
+++ b/packages/adapter-twig/src/conformance-pins.ts
@@ -47,6 +47,17 @@ export const conformancePins: ConformancePins = {
       issue: 'https://github.com/piconic-ai/barefootjs/issues/2321',
     },
   ],
+  // #2946: the module-scope const is computed via a function call, not a
+  // static literal — genuinely unresolvable at SSR render time, same
+  // policy as an unresolvable FUNCTION-scope const above. Escape twin:
+  // `module-const-loop-source-computed-client`.
+  'module-const-loop-source-computed': [
+    {
+      code: 'BF101',
+      severity: 'error',
+      issue: 'https://github.com/piconic-ai/barefootjs/issues/2946',
+    },
+  ],
   // #2038: no inline comprehension-with-nested-callback form via the
   // evaluator-JSON `*_eval` mechanism (`twig-adapter.ts`'s header,
   // divergence 3) — loud BF101 instead of lossy.

--- a/packages/adapter-xslate/src/adapter/xslate-adapter.ts
+++ b/packages/adapter-xslate/src/adapter/xslate-adapter.ts
@@ -786,13 +786,11 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
       })
     }
 
-    // A `.map()` loop whose array is a bare identifier bound to a
-    // FUNCTION-scope local const with a non-statically-evaluable initializer
-    // that reads props/signals (e.g. `const entries =
-    // Object.entries(props.x ?? {}).filter(...)`) can't render correctly.
-    // Module-scope consts (`isModule`, e.g. `const payments = [...]` at the
-    // top of the file) are a DIFFERENT, already-working case handled
-    // elsewhere. Function-scope locals get no per-render stash slot — this
+    // A `.map()` loop whose array is a bare identifier bound to a local
+    // const (module- or function-scope, #2946) with a non-statically-
+    // evaluable initializer that reads props/signals/a function call (e.g.
+    // `const entries = Object.entries(props.x ?? {}).filter(...)`) can't
+    // render correctly. Locals get no per-render stash slot — this
     // adapter's only "elsewhere" for a local const is inlining its value at
     // the use site (`_resolveLiteralConst`'s numeric/single-quoted-string
     // fast path, or a static-record-literal lookup), never binding one as a
@@ -803,22 +801,21 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
     // this adapter's test corpus only because the widened destructure gate
     // (#2087 Phase A/B) no longer refuses this fixture's `([emoji, users])
     // => ...` param first.
-    // #2208: a loop source that is a fully-static array literal — either
-    // inline (`[{ label: 'Alpha' }, ...].map(...)`) or a bare identifier
-    // bound to a FUNCTION-scope local const whose initializer has no
-    // prop/signal/function-call dependency — inlines as a native Kolon
-    // array/hash literal below, the same way a module-scope const's value
-    // is already seeded. A runtime-computed local (#2069, e.g.
-    // `Object.entries(props.tags).filter(...)`) still refuses below.
-    // `isNameShadowed` guards a DIFFERENT, enclosing loop's own callback
-    // param shadowing this identifier (fable review) — never resolve the
-    // static const in that case. `rawArray` then falls through to the
-    // bare identifier expression below, same as before #2208 — which
-    // still trips the pre-existing BF101 gate for an unresolvable local
-    // const reference (a loud, conservative refusal, not a silent wrong
-    // value). Canonical, position-accurate predicate (#2482 Stage 2) — the
-    // enclosing loop scope's own membership, not a coarse whole-component
-    // union.
+    // #2208/#2946: a loop source that is a fully-static array literal —
+    // either inline (`[{ label: 'Alpha' }, ...].map(...)`) or a bare
+    // identifier bound to a local const (module- or function-scope) whose
+    // initializer has no prop/signal/function-call dependency — inlines as
+    // a native Kolon array/hash literal below. A runtime-computed local
+    // (#2069, e.g. `Object.entries(props.tags).filter(...)`) still refuses
+    // below, whichever scope it's declared in. `isNameShadowed` guards a
+    // DIFFERENT, enclosing loop's own callback param shadowing this
+    // identifier (fable review) — never resolve the static const in that
+    // case. `rawArray` then falls through to the bare identifier expression
+    // below, same as before #2208 — which still trips the pre-existing
+    // BF101 gate for an unresolvable local const reference (a loud,
+    // conservative refusal, not a silent wrong value). Canonical,
+    // position-accurate predicate (#2482 Stage 2) — the enclosing loop
+    // scope's own membership, not a coarse whole-component union.
     const staticItems = resolveStaticLoopSource(loop.arrayParsed, this.localConstants, {
       isNameShadowed: this.scope.asShadowPredicate(),
     })
@@ -827,11 +824,11 @@ export class XslateAdapter extends BaseAdapter implements IRNodeEmitter<XslateRe
     const arrayName = loop.array.trim()
     if (staticArray === null && /^[A-Za-z_$][\w$]*$/.test(arrayName)) {
       const arrayConst = (this.localConstants ?? []).find(c => c.name === arrayName)
-      if (arrayConst && !arrayConst.isModule && this._resolveLiteralConst(arrayName) === null) {
+      if (arrayConst && this._resolveLiteralConst(arrayName) === null) {
         this.errors.push({
           code: 'BF101',
           severity: 'error',
-          message: `Loop array \`${arrayName}\` is a local computed value (\`${arrayConst.value}\`) that the Xslate adapter cannot bind as a template variable — only numeric/string-literal locals inline at their use site.`,
+          message: `Loop array \`${arrayName}\` is a const (module- or function-scope) computed value (\`${arrayConst.value}\`) that the Xslate adapter cannot bind as a template variable — only numeric/string-literal locals inline at their use site.`,
           loc: loop.loc ?? { file: this.componentName + '.tsx', start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
           suggestion: {
             message:

--- a/packages/adapter-xslate/src/conformance-pins.ts
+++ b/packages/adapter-xslate/src/conformance-pins.ts
@@ -47,6 +47,17 @@ export const conformancePins: ConformancePins = {
       issue: 'https://github.com/piconic-ai/barefootjs/issues/2321',
     },
   ],
+  // #2946: the module-scope const is computed via a function call, not a
+  // static literal — genuinely unresolvable at SSR render time, same
+  // policy as an unresolvable FUNCTION-scope const above. Escape twin:
+  // `module-const-loop-source-computed-client`.
+  'module-const-loop-source-computed': [
+    {
+      code: 'BF101',
+      severity: 'error',
+      issue: 'https://github.com/piconic-ai/barefootjs/issues/2946',
+    },
+  ],
   // #2038: Kolon has no inline `grep` form (unlike mojo, which lowers a
   // nested `.some` to a real inline Perl `grep`) — loud BF101 instead of the
   // old silent degradation to the receiver.

--- a/packages/compat/src/__tests__/compat-engine.test.ts
+++ b/packages/compat/src/__tests__/compat-engine.test.ts
@@ -49,9 +49,11 @@ describe('compileForCompat', () => {
     // successor to #2038), #2321 (static-array-from-props computed loop
     // source), #2700 (a `derived` object-literal signal/memo the
     // constructor-time baker can't reproduce, `signal-object-spread-init`),
-    // and #2909 (a signal/memo call read inside a nested static loop's row,
-    // `static-nested-loop-ref`) surface here even though this test only
-    // exercises the nested-filter-callback shape. Six pins are no longer
+    // #2909 (a signal/memo call read inside a nested static loop's row,
+    // `static-nested-loop-ref`), and #2946 (a module-scope const computed
+    // via a function call used as a loop source,
+    // `module-const-loop-source-computed`) surface here even though this
+    // test only exercises the nested-filter-callback shape. Six pins are no longer
     // among them, each because the shape got a real lowering rather than a
     // narrower refusal: #2319 (dangerous-inner-html-dynamic → a faithful
     // raw-output lowering), #2208 (static-array-children → the loop-source
@@ -74,6 +76,7 @@ describe('compileForCompat', () => {
           'https://github.com/piconic-ai/barefootjs/issues/2321',
           'https://github.com/piconic-ai/barefootjs/issues/2700',
           'https://github.com/piconic-ai/barefootjs/issues/2909',
+          'https://github.com/piconic-ai/barefootjs/issues/2946',
         ],
       },
     ])

--- a/packages/jsx/src/__tests__/static-literal.test.ts
+++ b/packages/jsx/src/__tests__/static-literal.test.ts
@@ -3,9 +3,10 @@ import { parseExpression } from '../expression-parser'
 import { evaluateStaticLiteral, isFullyStaticLiteral, resolveStaticLoopSource } from '../static-literal'
 import type { ConstantInfo } from '../types'
 
-// #2208: a function-scope local const whose initializer is fully known at
-// compile time (no prop/signal/function-call dependency) should bind as a
-// loop source the same way a module-scope const already does.
+// #2208: a local const whose initializer is fully known at compile time (no
+// prop/signal/function-call dependency) should bind as a loop source the
+// same way an inline array literal does — module-scope and function-scope
+// alike (#2946).
 describe('evaluateStaticLiteral (#2208)', () => {
   test('scalars', () => {
     expect(evaluateStaticLiteral(parseExpression("'Alpha'"))).toEqual({ value: 'Alpha' })
@@ -97,9 +98,43 @@ describe('resolveStaticLoopSource (#2208)', () => {
     expect(resolveStaticLoopSource(parseExpression('items'), locals)).toEqual([{ label: 'Alpha' }])
   })
 
-  test('a MODULE-scope const is excluded (handled by the existing seeding path instead)', () => {
+  test('a MODULE-scope const with a static initializer resolves exactly like a function-scope one (#2946)', () => {
     const locals = [constant({ name: 'items', parsed: parseExpression("[{ label: 'Alpha' }]"), isModule: true })]
+    expect(resolveStaticLoopSource(parseExpression('items'), locals)).toEqual([{ label: 'Alpha' }])
+  })
+
+  test('a MODULE-scope const whose initializer is runtime-computed still refuses (#2946)', () => {
+    const locals = [constant({ name: 'items', parsed: parseExpression('buildItems()'), isModule: true })]
     expect(resolveStaticLoopSource(parseExpression('items'), locals)).toBeNull()
+  })
+
+  test('a MODULE-scope const shadowed by an enclosing loop param is excluded via isNameShadowed (#2946)', () => {
+    const locals = [constant({ name: 'items', parsed: parseExpression("[{ label: 'Alpha' }]"), isModule: true })]
+    const result = resolveStaticLoopSource(parseExpression('items'), locals, {
+      isNameShadowed: name => name === 'items',
+    })
+    expect(result).toBeNull()
+  })
+
+  test('a const mutated after its declaration (#2910) refuses regardless of scope', () => {
+    const moduleLocals = [
+      constant({
+        name: 'items',
+        parsed: parseExpression("[{ label: 'Alpha' }]"),
+        isModule: true,
+        mutatedAfterDeclaration: true,
+      }),
+    ]
+    expect(resolveStaticLoopSource(parseExpression('items'), moduleLocals)).toBeNull()
+
+    const functionLocals = [
+      constant({
+        name: 'items',
+        parsed: parseExpression("[{ label: 'Alpha' }]"),
+        mutatedAfterDeclaration: true,
+      }),
+    ]
+    expect(resolveStaticLoopSource(parseExpression('items'), functionLocals)).toBeNull()
   })
 
   test('a runtime-computed local const (#2069) still refuses', () => {

--- a/packages/jsx/src/static-literal.ts
+++ b/packages/jsx/src/static-literal.ts
@@ -3,9 +3,9 @@
  * is a literal, a no-substitution (or fully-static) template literal, an
  * array-literal of pure elements, or an object-literal of pure values
  * evaluates here to its plain JS value. Consumed by each adapter's
- * `renderLoop` to admit a function-scope local const whose initializer is
- * entirely known at compile time as a loop source — inlining its value the
- * same way a module-scope const already is — while still refusing a
+ * `renderLoop` to admit a local const (module- or function-scope alike,
+ * #2946) whose initializer is entirely known at compile time as a loop
+ * source — inlining its value as a native literal — while still refusing a
  * runtime-computed expression (`Object.entries(props.tags).filter(...)`,
  * #2069) with BF101, since `call`/unresolvable-`member` shapes fall through
  * to `null` below.
@@ -117,11 +117,23 @@ export function isFullyStaticLiteral(expr: ParsedExpr): boolean {
 /**
  * Shared loop-source resolution for `renderLoop` across adapters: the loop
  * array is either an inline array-literal, or a bare identifier naming a
- * FUNCTION-scope (`!isModule`) local const whose initializer evaluates
- * statically. Module-scope consts are deliberately excluded — an existing,
- * separate seeding path already handles those. Returns the evaluated items,
- * or `null` if the source isn't resolvable this way (including when it
- * resolves to something other than an array).
+ * local const — module-scope or function-scope alike (#2946) — whose
+ * initializer evaluates statically. The only exclusions are (1) a name the
+ * enclosing loop scope already binds (`isNameShadowed`), (2) a const flagged
+ * `mutatedAfterDeclaration` (#2910 — its initializer is a stale snapshot,
+ * not the const's current value), and (3) a non-literal initializer.
+ *
+ * Module-scope consts used to be excluded outright on the theory that an
+ * existing, separate seeding path already handled them — but that path
+ * (`ssr-defaults.ts`'s `tryStaticEval`/`bindings`, and Go's
+ * `convertInitialValue`) only ever sees a module const through a
+ * `createSignal(...)` argument. A module const `.map()`'d directly, with no
+ * signal in between, was never seeded by anything and silently rendered
+ * empty (ERB/Jinja/Twig/Blade/Xslate/minijinja), failed to compile
+ * (Mojolicious), or failed at execution time (Go) — see #2946.
+ *
+ * Returns the evaluated items, or `null` if the source isn't resolvable this
+ * way (including when it resolves to something other than an array).
  */
 export function resolveStaticLoopSource(
   arrayParsed: ParsedExpr | undefined,
@@ -133,7 +145,7 @@ export function resolveStaticLoopSource(
   if (arrayParsed.kind === 'identifier') {
     if (opts?.isNameShadowed?.(arrayParsed.name)) return null
     const local = localConstants?.find(c => c.name === arrayParsed.name)
-    if (!local || local.isModule || !local.parsed) return null
+    if (!local?.parsed || local.mutatedAfterDeclaration) return null
     target = local.parsed
   }
   const resolved = evaluateStaticLiteral(target)

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-conformance section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. This answers, per fixture and per adapter, whether the construct WORKS — not just whether it compiles. A construct works either as written (✓) or with a documented `/* @client */` comment (✓†, a verified, supported escape — most refusals have one). Fixtures absent from the table below work on every adapter — most as written, some via that documented escape; the headline says how many of each. Listed fixtures need attention somewhere: a bare diagnostic code is still-open debt with no escape yet, a code led by ✗ owes no escape at all (by design), and ≠ means the fixture compiles clean but its rendered output diverges from the reference.",
-    "totalFixtures": 414,
+    "totalFixtures": 419,
     "fixtures": {
       "component-prop-bare-getter": {
         "go-template": {
@@ -2777,6 +2777,112 @@
           }
         }
       },
+      "module-const-loop-source-computed": {
+        "blade": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2946"
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "module-const-loop-source-computed-precomputed"
+          }
+        },
+        "erb": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2946"
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "module-const-loop-source-computed-precomputed"
+          }
+        },
+        "go-template": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2946"
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "module-const-loop-source-computed-precomputed"
+          }
+        },
+        "jinja": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2946"
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "module-const-loop-source-computed-precomputed"
+          }
+        },
+        "minijinja": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2946"
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "module-const-loop-source-computed-precomputed"
+          }
+        },
+        "mojolicious": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2946"
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "module-const-loop-source-computed-precomputed"
+          }
+        },
+        "twig": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2946"
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "module-const-loop-source-computed-precomputed"
+          }
+        },
+        "xslate": {
+          "kind": "refusal",
+          "codes": [
+            "BF101"
+          ],
+          "issues": [
+            "https://github.com/piconic-ai/barefootjs/issues/2946"
+          ],
+          "escape": {
+            "state": "escapable",
+            "twin": "module-const-loop-source-computed-precomputed"
+          }
+        }
+      },
       "namespace-import-primitive": {
         "blade": {
           "kind": "refusal",
@@ -3678,6 +3784,10 @@
         "description": "special characters in array-builder leaf text escape identically at SSR and CSR",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/map-array-builder-escaping.ts"
       },
+      "module-const-loop-source-computed": {
+        "description": "A module-scope const computed via a function call refuses loudly (BF101) on every SSR template…",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/module-const-loop-source-computed.ts"
+      },
       "namespace-import-primitive": {
         "description": "A reactive primitive called through a namespace import refuses with BF013",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/namespace-import-primitive.ts"
@@ -3761,6 +3871,10 @@
       "map-array-builder-body-client": {
         "description": "Array-builder .map() body deferred to the client via /* @client */ — DSL BF021 suppressed",
         "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/map-array-builder-body-client.ts"
+      },
+      "module-const-loop-source-computed-precomputed": {
+        "description": "prop-precompute twin of module-const-loop-source-computed — computation moved to the caller, full…",
+        "url": "https://github.com/piconic-ai/barefootjs/blob/main/packages/adapter-tests/fixtures/module-const-loop-source-computed-precomputed.ts"
       },
       "reduce-right-typeof-body-client": {
         "description": "Off-subset `.reduceRight()` body deferred to the client via /* @client */",

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -14,15 +14,15 @@
   ],
   "kinds": {
     "array-literal": {
-      "total": 114,
+      "total": 116,
       "cells": {
         "hono": {
-          "pass": 114,
-          "total": 114
+          "pass": 116,
+          "total": 116
         },
         "blade": {
-          "pass": 102,
-          "total": 114,
+          "pass": 104,
+          "total": 116,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -79,8 +79,8 @@
           ]
         },
         "erb": {
-          "pass": 103,
-          "total": 114,
+          "pass": 105,
+          "total": 116,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -131,8 +131,8 @@
           ]
         },
         "go-template": {
-          "pass": 101,
-          "total": 114,
+          "pass": 103,
+          "total": 116,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -195,8 +195,8 @@
           ]
         },
         "jinja": {
-          "pass": 102,
-          "total": 114,
+          "pass": 104,
+          "total": 116,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -253,8 +253,8 @@
           ]
         },
         "minijinja": {
-          "pass": 102,
-          "total": 114,
+          "pass": 104,
+          "total": 116,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -311,8 +311,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 101,
-          "total": 114,
+          "pass": 103,
+          "total": 116,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -375,8 +375,8 @@
           ]
         },
         "twig": {
-          "pass": 102,
-          "total": 114,
+          "pass": 104,
+          "total": 116,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -433,8 +433,8 @@
           ]
         },
         "xslate": {
-          "pass": 100,
-          "total": 114,
+          "pass": 102,
+          "total": 116,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1448,11 +1448,11 @@
       }
     },
     "call": {
-      "total": 277,
+      "total": 279,
       "cells": {
         "hono": {
-          "pass": 275,
-          "total": 277,
+          "pass": 277,
+          "total": 279,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1467,8 +1467,8 @@
           ]
         },
         "blade": {
-          "pass": 261,
-          "total": 277,
+          "pass": 262,
+          "total": 279,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1509,6 +1509,12 @@
               "issues": []
             },
             {
+              "fixture": "module-const-loop-source-computed",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2946"
+              ]
+            },
+            {
               "fixture": "namespace-import-primitive",
               "issues": []
             },
@@ -1547,8 +1553,8 @@
           ]
         },
         "erb": {
-          "pass": 262,
-          "total": 277,
+          "pass": 263,
+          "total": 279,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1581,6 +1587,12 @@
             {
               "fixture": "flatmap-typeof-projection",
               "issues": []
+            },
+            {
+              "fixture": "module-const-loop-source-computed",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2946"
+              ]
             },
             {
               "fixture": "namespace-import-primitive",
@@ -1621,8 +1633,8 @@
           ]
         },
         "go-template": {
-          "pass": 258,
-          "total": 277,
+          "pass": 259,
+          "total": 279,
           "gaps": [
             {
               "fixture": "component-prop-bare-getter",
@@ -1665,6 +1677,12 @@
             {
               "fixture": "flatmap-typeof-projection",
               "issues": []
+            },
+            {
+              "fixture": "module-const-loop-source-computed",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2946"
+              ]
             },
             {
               "fixture": "namespace-import-primitive",
@@ -1717,8 +1735,8 @@
           ]
         },
         "jinja": {
-          "pass": 261,
-          "total": 277,
+          "pass": 262,
+          "total": 279,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1757,6 +1775,12 @@
             {
               "fixture": "flatmap-typeof-projection",
               "issues": []
+            },
+            {
+              "fixture": "module-const-loop-source-computed",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2946"
+              ]
             },
             {
               "fixture": "namespace-import-primitive",
@@ -1797,8 +1821,8 @@
           ]
         },
         "minijinja": {
-          "pass": 261,
-          "total": 277,
+          "pass": 262,
+          "total": 279,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1837,6 +1861,12 @@
             {
               "fixture": "flatmap-typeof-projection",
               "issues": []
+            },
+            {
+              "fixture": "module-const-loop-source-computed",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2946"
+              ]
             },
             {
               "fixture": "namespace-import-primitive",
@@ -1877,8 +1907,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 262,
-          "total": 277,
+          "pass": 263,
+          "total": 279,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1911,6 +1941,12 @@
             {
               "fixture": "flatmap-typeof-projection",
               "issues": []
+            },
+            {
+              "fixture": "module-const-loop-source-computed",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2946"
+              ]
             },
             {
               "fixture": "namespace-import-primitive",
@@ -1951,8 +1987,8 @@
           ]
         },
         "twig": {
-          "pass": 261,
-          "total": 277,
+          "pass": 262,
+          "total": 279,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1991,6 +2027,12 @@
             {
               "fixture": "flatmap-typeof-projection",
               "issues": []
+            },
+            {
+              "fixture": "module-const-loop-source-computed",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2946"
+              ]
             },
             {
               "fixture": "namespace-import-primitive",
@@ -2031,8 +2073,8 @@
           ]
         },
         "xslate": {
-          "pass": 261,
-          "total": 277,
+          "pass": 262,
+          "total": 279,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2071,6 +2113,12 @@
             {
               "fixture": "flatmap-typeof-projection",
               "issues": []
+            },
+            {
+              "fixture": "module-const-loop-source-computed",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2946"
+              ]
             },
             {
               "fixture": "namespace-import-primitive",
@@ -2256,11 +2304,11 @@
       }
     },
     "identifier": {
-      "total": 392,
+      "total": 397,
       "cells": {
         "hono": {
-          "pass": 388,
-          "total": 392,
+          "pass": 393,
+          "total": 397,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2283,8 +2331,8 @@
           ]
         },
         "blade": {
-          "pass": 372,
-          "total": 392,
+          "pass": 376,
+          "total": 397,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2341,6 +2389,12 @@
               "issues": []
             },
             {
+              "fixture": "module-const-loop-source-computed",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2946"
+              ]
+            },
+            {
               "fixture": "namespace-import-primitive",
               "issues": []
             },
@@ -2379,8 +2433,8 @@
           ]
         },
         "erb": {
-          "pass": 373,
-          "total": 392,
+          "pass": 377,
+          "total": 397,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2431,6 +2485,12 @@
               "issues": []
             },
             {
+              "fixture": "module-const-loop-source-computed",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2946"
+              ]
+            },
+            {
               "fixture": "namespace-import-primitive",
               "issues": []
             },
@@ -2469,8 +2529,8 @@
           ]
         },
         "go-template": {
-          "pass": 369,
-          "total": 392,
+          "pass": 373,
+          "total": 397,
           "gaps": [
             {
               "fixture": "component-prop-bare-getter",
@@ -2531,6 +2591,12 @@
               "issues": []
             },
             {
+              "fixture": "module-const-loop-source-computed",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2946"
+              ]
+            },
+            {
               "fixture": "namespace-import-primitive",
               "issues": []
             },
@@ -2581,8 +2647,8 @@
           ]
         },
         "jinja": {
-          "pass": 372,
-          "total": 392,
+          "pass": 376,
+          "total": 397,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2637,6 +2703,12 @@
             {
               "fixture": "map-array-builder-escaping",
               "issues": []
+            },
+            {
+              "fixture": "module-const-loop-source-computed",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2946"
+              ]
             },
             {
               "fixture": "namespace-import-primitive",
@@ -2677,8 +2749,8 @@
           ]
         },
         "minijinja": {
-          "pass": 372,
-          "total": 392,
+          "pass": 376,
+          "total": 397,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2735,6 +2807,12 @@
               "issues": []
             },
             {
+              "fixture": "module-const-loop-source-computed",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2946"
+              ]
+            },
+            {
               "fixture": "namespace-import-primitive",
               "issues": []
             },
@@ -2773,8 +2851,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 371,
-          "total": 392,
+          "pass": 375,
+          "total": 397,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2823,6 +2901,12 @@
             {
               "fixture": "map-array-builder-escaping",
               "issues": []
+            },
+            {
+              "fixture": "module-const-loop-source-computed",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2946"
+              ]
             },
             {
               "fixture": "namespace-import-primitive",
@@ -2875,8 +2959,8 @@
           ]
         },
         "twig": {
-          "pass": 372,
-          "total": 392,
+          "pass": 376,
+          "total": 397,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2931,6 +3015,12 @@
             {
               "fixture": "map-array-builder-escaping",
               "issues": []
+            },
+            {
+              "fixture": "module-const-loop-source-computed",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2946"
+              ]
             },
             {
               "fixture": "namespace-import-primitive",
@@ -2971,8 +3061,8 @@
           ]
         },
         "xslate": {
-          "pass": 370,
-          "total": 392,
+          "pass": 374,
+          "total": 397,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3027,6 +3117,12 @@
             {
               "fixture": "map-array-builder-escaping",
               "issues": []
+            },
+            {
+              "fixture": "module-const-loop-source-computed",
+              "issues": [
+                "https://github.com/piconic-ai/barefootjs/issues/2946"
+              ]
             },
             {
               "fixture": "namespace-import-primitive",
@@ -3144,11 +3240,11 @@
       }
     },
     "literal": {
-      "total": 314,
+      "total": 316,
       "cells": {
         "hono": {
-          "pass": 313,
-          "total": 314,
+          "pass": 315,
+          "total": 316,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -3157,8 +3253,8 @@
           ]
         },
         "blade": {
-          "pass": 302,
-          "total": 314,
+          "pass": 304,
+          "total": 316,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3213,8 +3309,8 @@
           ]
         },
         "erb": {
-          "pass": 302,
-          "total": 314,
+          "pass": 304,
+          "total": 316,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3269,8 +3365,8 @@
           ]
         },
         "go-template": {
-          "pass": 299,
-          "total": 314,
+          "pass": 301,
+          "total": 316,
           "gaps": [
             {
               "fixture": "component-prop-bare-getter",
@@ -3341,8 +3437,8 @@
           ]
         },
         "jinja": {
-          "pass": 302,
-          "total": 314,
+          "pass": 304,
+          "total": 316,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3397,8 +3493,8 @@
           ]
         },
         "minijinja": {
-          "pass": 302,
-          "total": 314,
+          "pass": 304,
+          "total": 316,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3453,8 +3549,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 300,
-          "total": 314,
+          "pass": 302,
+          "total": 316,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3521,8 +3617,8 @@
           ]
         },
         "twig": {
-          "pass": 302,
-          "total": 314,
+          "pass": 304,
+          "total": 316,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3577,8 +3673,8 @@
           ]
         },
         "xslate": {
-          "pass": 300,
-          "total": 314,
+          "pass": 302,
+          "total": 316,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3806,11 +3902,11 @@
       }
     },
     "member": {
-      "total": 232,
+      "total": 234,
       "cells": {
         "hono": {
-          "pass": 229,
-          "total": 232,
+          "pass": 231,
+          "total": 234,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3829,8 +3925,8 @@
           ]
         },
         "blade": {
-          "pass": 213,
-          "total": 232,
+          "pass": 215,
+          "total": 234,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3921,8 +4017,8 @@
           ]
         },
         "erb": {
-          "pass": 214,
-          "total": 232,
+          "pass": 216,
+          "total": 234,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4007,8 +4103,8 @@
           ]
         },
         "go-template": {
-          "pass": 210,
-          "total": 232,
+          "pass": 212,
+          "total": 234,
           "gaps": [
             {
               "fixture": "component-prop-bare-getter",
@@ -4115,8 +4211,8 @@
           ]
         },
         "jinja": {
-          "pass": 213,
-          "total": 232,
+          "pass": 215,
+          "total": 234,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4207,8 +4303,8 @@
           ]
         },
         "minijinja": {
-          "pass": 213,
-          "total": 232,
+          "pass": 215,
+          "total": 234,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4299,8 +4395,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 212,
-          "total": 232,
+          "pass": 214,
+          "total": 234,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4397,8 +4493,8 @@
           ]
         },
         "twig": {
-          "pass": 213,
-          "total": 232,
+          "pass": 215,
+          "total": 234,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4489,8 +4585,8 @@
           ]
         },
         "xslate": {
-          "pass": 211,
-          "total": 232,
+          "pass": 213,
+          "total": 234,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4606,15 +4702,15 @@
       }
     },
     "object-literal": {
-      "total": 92,
+      "total": 93,
       "cells": {
         "hono": {
-          "pass": 92,
-          "total": 92
+          "pass": 93,
+          "total": 93
         },
         "blade": {
-          "pass": 89,
-          "total": 92,
+          "pass": 90,
+          "total": 93,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4633,8 +4729,8 @@
           ]
         },
         "erb": {
-          "pass": 89,
-          "total": 92,
+          "pass": 90,
+          "total": 93,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4653,8 +4749,8 @@
           ]
         },
         "go-template": {
-          "pass": 87,
-          "total": 92,
+          "pass": 88,
+          "total": 93,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4685,8 +4781,8 @@
           ]
         },
         "jinja": {
-          "pass": 89,
-          "total": 92,
+          "pass": 90,
+          "total": 93,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4705,8 +4801,8 @@
           ]
         },
         "minijinja": {
-          "pass": 89,
-          "total": 92,
+          "pass": 90,
+          "total": 93,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4725,8 +4821,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 87,
-          "total": 92,
+          "pass": 88,
+          "total": 93,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4757,8 +4853,8 @@
           ]
         },
         "twig": {
-          "pass": 89,
-          "total": 92,
+          "pass": 90,
+          "total": 93,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -4777,8 +4873,8 @@
           ]
         },
         "xslate": {
-          "pass": 87,
-          "total": 92,
+          "pass": 88,
+          "total": 93,
           "gaps": [
             {
               "fixture": "preamble-cells",
@@ -8379,15 +8475,15 @@
       }
     },
     "literal:string": {
-      "total": 215,
+      "total": 217,
       "cells": {
         "hono": {
-          "pass": 215,
-          "total": 215
+          "pass": 217,
+          "total": 217
         },
         "blade": {
-          "pass": 207,
-          "total": 215,
+          "pass": 209,
+          "total": 217,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8426,8 +8522,8 @@
           ]
         },
         "erb": {
-          "pass": 207,
-          "total": 215,
+          "pass": 209,
+          "total": 217,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8466,8 +8562,8 @@
           ]
         },
         "go-template": {
-          "pass": 206,
-          "total": 215,
+          "pass": 208,
+          "total": 217,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8512,8 +8608,8 @@
           ]
         },
         "jinja": {
-          "pass": 207,
-          "total": 215,
+          "pass": 209,
+          "total": 217,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8552,8 +8648,8 @@
           ]
         },
         "minijinja": {
-          "pass": 207,
-          "total": 215,
+          "pass": 209,
+          "total": 217,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8592,8 +8688,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 205,
-          "total": 215,
+          "pass": 207,
+          "total": 217,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8644,8 +8740,8 @@
           ]
         },
         "twig": {
-          "pass": 207,
-          "total": 215,
+          "pass": 209,
+          "total": 217,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8684,8 +8780,8 @@
           ]
         },
         "xslate": {
-          "pass": 205,
-          "total": 215,
+          "pass": 207,
+          "total": 217,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",


### PR DESCRIPTION
## Summary

Fixes #2946.

A `'use client'` component that declares a static array at MODULE scope and `.map()`s it directly (no `createSignal` wrapper in between) used to fail to render its rows on every non-Hono adapter:

- ERB, Jinja, Twig, Blade, Xslate, Rust (minijinja): the container rendered, but the loop body was silently empty.
- Mojolicious: template compile error (`Global symbol "$items" requires explicit package name`).
- Go template: execution-time error (`can't evaluate field Items in type ...Props`).
- Hono (the reference adapter): always rendered correctly.

**Root cause:** `resolveStaticLoopSource` (`packages/jsx/src/static-literal.ts`) is the one shared resolver every adapter's `renderLoop` consults to inline a `.map()` loop's array source as a native literal. It deliberately excluded module-scope consts, on the theory that a separate seeding path (`ssr-defaults.ts` / Go's `convertInitialValue`) already handled them. That path only ever sees a module const through a `createSignal(...)` argument — never a bare `.map()` with no signal in between — so a directly-mapped module array was left completely unresolved, and each adapter's fallback for an unresolvable identifier produced its own distinct failure.

**Fix:** `resolveStaticLoopSource` now resolves a bare identifier bound to a local const's static initializer regardless of whether it's declared at module or function scope. The only remaining exclusions are: a name shadowed by the enclosing loop scope, a non-literal (runtime-computed) initializer, and a const flagged `mutatedAfterDeclaration` (#2910 — its initializer would otherwise bake a stale snapshot instead of the const's current value). Each adapter's own "unresolvable local const" BF101 diagnostic is widened the same way, so a module-scope const computed via a function call now refuses loudly and uniformly instead of silently falling through only when declared inside the component.

The design for this fix was produced by a separate agent run (model: Fable) before implementation; see the commit messages for the attribution split.

## Changes

- `packages/jsx/src/static-literal.ts`: the one-line root-cause fix + docstring updates.
- `packages/jsx/src/__tests__/static-literal.test.ts`: replaces the test that pinned the bug as intentional with tests covering the module-scope-resolves, runtime-computed-still-refuses, shadowed-name, and mutated-after-declaration cases.
- 8 adapters' `renderLoop` (ERB, Jinja, Twig, Blade, Xslate, Rust, Mojolicious, Go template): removed the `!isModule` exclusion from each adapter's own BF101 "unresolvable local const" guard.
- `packages/adapter-go-template/src/__tests__/go-template-adapter.test.ts`: updates the pre-existing `#2835` test — a module-const child-component loop now bakes each item's props directly instead of requiring an `Input` struct field.
- New cross-adapter fixtures under `packages/adapter-tests/fixtures/`:
  - `module-const-loop-source` — the issue's exact repro (plain-element loop body).
  - `module-const-loop-source-child-component` — same shape with a child-component loop body, exercising Go's per-item bake path.
  - `module-const-loop-source-computed` — a module const computed via a function call, correctly refused (BF101) on all 8 non-Hono adapters, with two verified escape twins: `module-const-loop-source-computed-precomputed` (`prop-precompute`) and `module-const-loop-source-computed-client` (`client-directive`).
- `packages/adapter-tests/src/csr-skip-set.ts`: `module-const-loop-source-computed` skipped from CSR conformance (same #2073 class — a module-scope function call isn't available at CSR template scope either); the two fully-static-literal fixtures are NOT skipped.
- `packages/compat/src/__tests__/compat-engine.test.ts`: updated the pinned BF101-issues-union assertion to include #2946.
- Regenerated `packages/adapter-tests/coverage-map.json`, `packages/adapter-tests/generated-data-points.json`, `ui/compat.lock.json`, `ui/support-matrix.lock.json`.
- Changeset covering `@barefootjs/jsx` and all 8 non-Hono adapter packages.

## Test plan

- [x] `bun test packages/jsx` — full suite passes (5 pre-existing failures in `primitive-resolver-all.test.ts` / `primitive-resolver-alias.test.ts` unrelated to this change — a `@barefootjs/client` TS-Program workspace-resolution gap in the sandbox, not reproducible once the workspace is built).
- [x] `bun test packages/adapter-go-template` — full suite green (2076 pass).
- [x] `bun test packages/compat` (escape-coverage, compat-engine, support-matrix freshness, etc.) — full suite green (564 pass) after building all 9 adapter packages locally.
- [x] `bun test packages/adapter-tests/src/__tests__/csr-conformance.test.ts` — green for all 5 new fixtures.
- [x] CI on this PR's own head (base `main`): all 43 checks green, including `lockfile` and `update-expected-html` (this repo's fixture-drift gates).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QtiJChdf9hEB41NF3ekQ96