### PR TITLE
Add .dockerignore to fix docker compose up pipe errors

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+# Every integration's Dockerfile (dev and production) builds with the repo
+# root as context, so workspace deps and shared packages/ resolve correctly.
+# node_modules is huge (native binaries for bun/rolldown/oxc-parser/rollup/
+# workerd/tsgo) and is never COPYed into any image: dev containers get it via
+# bind mount (docker-compose.yml), production containers install or vendor
+# their deps separately. Sending it as part of the build context each time
+# is unnecessary and, without buildx (BuildKit) installed, the classic
+# builder can fail outright with "io: read/write on closed pipe" while
+# streaming a multi-GB tar of it.
+node_modules
+.git


### PR DESCRIPTION
## Summary

- `bun run dev` runs `docker compose up`, which builds every service with the repo root as build context (`context: .`).
- None of the `Dockerfile.dev` files `COPY` anything — dev containers get source via bind mounts — and the production `Dockerfile`s only `COPY` specific files/dirs, never `node_modules`.
- With no `.dockerignore`, the full `node_modules` tree (multi-GB of native binaries: rolldown, oxc-parser, rollup, workerd, tsgo, ...) was sent as part of the build context on every build. Without the buildx plugin, Docker falls back to the classic builder, which failed streaming that context with `io: read/write on closed pipe`.
- Adding a repo-root `.dockerignore` excluding `node_modules` and `.git` fixes this; verified locally that `docker compose build proxy` and `docker compose build hono` now succeed in ~10-20s instead of failing after ~3 minutes.

## Test plan

- [x] `docker compose build proxy` succeeds
- [x] `docker compose build hono` succeeds
- [ ] `bun run dev` brings up the full stack without the pipe error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RbD21pa2PhYh7ZUtHA4qro