### PR TITLE
Fix COPY paths in dev Dockerfiles for repo-root build context

### DIFF
--- a/integrations/django/Dockerfile.dev
+++ b/integrations/django/Dockerfile.dev
@@ -11,7 +11,7 @@ FROM python:3.12-slim
 
 WORKDIR /workspace/integrations/django
 
-COPY requirements.txt ./
+COPY integrations/django/requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
 EXPOSE 3014

--- a/integrations/fastapi/Dockerfile.dev
+++ b/integrations/fastapi/Dockerfile.dev
@@ -10,7 +10,7 @@ FROM python:3.12-slim
 
 WORKDIR /workspace/integrations/fastapi
 
-COPY requirements.txt ./
+COPY integrations/fastapi/requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
 EXPOSE 3009

--- a/integrations/flask/Dockerfile.dev
+++ b/integrations/flask/Dockerfile.dev
@@ -10,7 +10,7 @@ FROM python:3.12-slim
 
 WORKDIR /workspace/integrations/flask
 
-COPY requirements.txt ./
+COPY integrations/flask/requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
 EXPOSE 3008

--- a/integrations/rails/Dockerfile.dev
+++ b/integrations/rails/Dockerfile.dev
@@ -16,7 +16,7 @@ WORKDIR /workspace/integrations/rails
 # of this directory with the host source at container start, but gem installs
 # live under Ruby's system gem path (outside /workspace), so they survive the
 # overlay.
-COPY Gemfile Gemfile.lock ./
+COPY integrations/rails/Gemfile integrations/rails/Gemfile.lock ./
 RUN bundle install
 
 EXPOSE 3011

--- a/integrations/sinatra/Dockerfile.dev
+++ b/integrations/sinatra/Dockerfile.dev
@@ -16,7 +16,7 @@ WORKDIR /workspace/integrations/sinatra
 # rest of this directory with the host source at container start, but gem
 # installs live under Ruby's system gem path (outside /workspace), so they
 # survive the overlay.
-COPY Gemfile Gemfile.lock ./
+COPY integrations/sinatra/Gemfile integrations/sinatra/Gemfile.lock ./
 RUN bundle install
 
 EXPOSE 3010


### PR DESCRIPTION
## Summary

- `docker-compose.yml` builds every dev image with the repo root as build context (`context: .`), but `flask`/`fastapi`/`django`'s `COPY requirements.txt ./` and `sinatra`/`rails`'s `COPY Gemfile Gemfile.lock ./` assumed a context rooted at the integration directory itself.
- With a repo-root context, Docker looked for these files at the repo root and failed: `COPY failed: file not found in build context or excluded by .dockerignore: stat requirements.txt: file does not exist`.
- This bug pre-dates #2951, but was masked: the classic builder (no buildx plugin installed) failed earlier while streaming the multi-GB `node_modules` build context, so these `COPY` steps were never reached. Fixing that in #2951 surfaced this pre-existing path bug.
- Not a production/deploy issue — the production `Dockerfile`s (and their `wrangler.toml` `image_build_context`) already use consistent, correct paths for their respective contexts.

## Fix

Point each `COPY` at the path relative to the repo-root context, matching how the corresponding production `Dockerfile`s already do it for repo-root-context builds (chi/gin/axum):

- `integrations/flask/Dockerfile.dev`: `COPY integrations/flask/requirements.txt ./`
- `integrations/fastapi/Dockerfile.dev`: `COPY integrations/fastapi/requirements.txt ./`
- `integrations/django/Dockerfile.dev`: `COPY integrations/django/requirements.txt ./`
- `integrations/sinatra/Dockerfile.dev`: `COPY integrations/sinatra/Gemfile integrations/sinatra/Gemfile.lock ./`
- `integrations/rails/Dockerfile.dev`: `COPY integrations/rails/Gemfile integrations/rails/Gemfile.lock ./`

## Test plan

- [x] `docker compose build flask fastapi django sinatra rails` succeeds
- [x] `docker compose up` brings up all 20 services (`docker compose ps` shows all `running`)
- [x] Spot-checked `hono`, `flask`, `rails` respond `200` through the proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RbD21pa2PhYh7ZUtHA4qro