### PR TITLE
Serve ui.barefootjs.dev via bun run dev, and clarify proxy-only ports

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,8 +87,10 @@ jobs:
           bun run --filter '@barefootjs/hono' build
 
       # Slide decks under site/core/slides/<slug>/ are peitho decks; their
-      # output (public/slides/<slug>/) is not committed, it is built here.
-      # Pinned release + checksum, same pattern as Vale in ci-docs.yml.
+      # output (public/slides/<slug>/) is not committed, it is built as part
+      # of the "Build site" step below (`bun run build` runs `slides:build
+      # --all` first, see site/core/package.json). Pinned release + checksum,
+      # same pattern as Vale in ci-docs.yml.
       - name: Install peitho
         run: |
           NAME="peitho-v${PEITHO_VERSION}-x86_64-unknown-linux-gnu"
@@ -99,10 +101,7 @@ jobs:
           rm -rf peitho.tar.gz "${NAME}"
           peitho --version
 
-      - name: Build slide decks
-        run: cd site/core && bun run slides:build --all
-
-      - name: Build site
+      - name: Build site (includes slide decks)
         run: cd site/core && bun run build
 
       - name: Deploy to Cloudflare Workers

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,23 @@
 # Development docker-compose for BarefootJS.
 #
 # Single host port (4000) is exposed; everything else is reached through the
-# proxy. BarefootJS compilation (`bun run build`) still runs on the host so
-# the JSX iteration loop stays fast — containers bind-mount the host-built
-# `dist/` so they pick up recompiled output immediately.
+# proxy (scripts/dev-all.ts) — it logs every reachable URL, including
+# http://ui.localhost:4000/ for site-ui (Host-header routed, since it's a
+# separate origin in production). BarefootJS compilation (`bun run build`)
+# still runs on the host so the JSX iteration loop stays fast — containers
+# bind-mount the host-built `dist/` so they pick up recompiled output
+# immediately.
+#
+# site-core's `/slides/*` (e.g. /slides/overview) needs an extra, separate
+# host-side build step beyond the regular `bun run build`: the peitho CLI
+# (https://github.com/piconic-ai/peitho) must be on PATH (or `PEITHO=<path>`),
+# then from site/core run `bun run slides:build --all && bun run build` to
+# populate dist/slides/. See site/core/scripts/build-slides.ts.
 #
 # Each service is independent (no `depends_on`), so any subset can be brought
 # up for focused debugging:
 #
-#   docker compose up                        # everything (proxy + 4 services)
+#   docker compose up                        # everything (proxy + every service)
 #   docker compose up proxy mojolicious      # just one adapter, via proxy
 #   docker compose up mojolicious            # adapter only (no proxy)
 #
@@ -296,6 +305,17 @@ services:
       context: .
       dockerfile: site/core/Dockerfile.dev
     working_dir: /workspace/site/core
+    volumes:
+      - .:/workspace:cached
+
+  # ui.barefootjs.dev in production — a separate origin there, so the proxy
+  # routes it by Host header (http://ui.localhost:4000) instead of a path
+  # prefix, since site/ui's routes and asset links assume they own "/".
+  site-ui:
+    build:
+      context: .
+      dockerfile: site/ui/Dockerfile.dev
+    working_dir: /workspace/site/ui
     volumes:
       - .:/workspace:cached
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,11 +8,12 @@
 # bind-mount the host-built `dist/` so they pick up recompiled output
 # immediately.
 #
-# site-core's `/slides/*` (e.g. /slides/overview) needs an extra, separate
-# host-side build step beyond the regular `bun run build`: the peitho CLI
-# (https://github.com/piconic-ai/peitho) must be on PATH (or `PEITHO=<path>`),
-# then from site/core run `bun run slides:build --all && bun run build` to
-# populate dist/slides/. See site/core/scripts/build-slides.ts.
+# site-core's `/slides/*` (e.g. /slides/overview) is populated by the same
+# host-side `bun run build` (from site/core): it runs `slides:build --all`
+# first, which needs the peitho CLI (https://github.com/mizzy/peitho) on
+# PATH (or `PEITHO=<path>`) — without it, that step warns and skips, leaving
+# dist/slides/ empty rather than failing the build. See
+# site/core/scripts/build-slides.ts.
 #
 # Each service is independent (no `depends_on`), so any subset can be brought
 # up for focused debugging:

--- a/scripts/dev-all.ts
+++ b/scripts/dev-all.ts
@@ -1,30 +1,42 @@
 #!/usr/bin/env bun
 /**
- * Dev-all proxy: expose every adapter and the main site under one origin.
+ * Dev-all proxy: expose every adapter and both sites under one origin.
  *
- *   :4000/integrations/hono/*        → hono service
- *   :4000/integrations/h3/*          → h3 service
- *   :4000/integrations/elysia/*      → elysia service
- *   :4000/integrations/echo/*        → echo service
- *   :4000/integrations/gin/*         → gin service
- *   :4000/integrations/chi/*         → chi service
- *   :4000/integrations/nethttp/*     → nethttp service
- *   :4000/integrations/mojolicious/* → mojolicious service
- *   :4000/integrations/xslate/*      → xslate service
- *   :4000/integrations/flask/*       → flask service
- *   :4000/integrations/fastapi/*     → fastapi service
- *   :4000/integrations/sinatra/*     → sinatra service
- *   :4000/integrations/rails/*       → rails service
- *   :4000/integrations/axum/*        → axum service
- *   :4000/integrations/php/*         → php service
- *   :4000/integrations/django/*      → django service
- *   :4000/integrations/blade/*       → blade service
- *   :4000/integrations/laravel/*     → laravel service
- *   :4000/*                          → site-core service
+ * `docker-compose.yml` only publishes THIS proxy's port to the host — every
+ * other service is container-network-only, so a port an app logs internally
+ * (Flask on 3008, Gin on 8081, ...) is never reachable directly. This proxy
+ * is the one place that maps "port I saw in the logs" to "URL I can open":
+ *
+ *   http://localhost:4000/integrations/hono/        → hono service
+ *   http://localhost:4000/integrations/h3/          → h3 service
+ *   http://localhost:4000/integrations/elysia/      → elysia service
+ *   http://localhost:4000/integrations/echo/        → echo service
+ *   http://localhost:4000/integrations/gin/         → gin service
+ *   http://localhost:4000/integrations/chi/         → chi service
+ *   http://localhost:4000/integrations/nethttp/     → nethttp service
+ *   http://localhost:4000/integrations/mojolicious/ → mojolicious service
+ *   http://localhost:4000/integrations/xslate/      → xslate service
+ *   http://localhost:4000/integrations/flask/       → flask service
+ *   http://localhost:4000/integrations/fastapi/     → fastapi service
+ *   http://localhost:4000/integrations/sinatra/     → sinatra service
+ *   http://localhost:4000/integrations/rails/       → rails service
+ *   http://localhost:4000/integrations/axum/        → axum service
+ *   http://localhost:4000/integrations/php/         → php service
+ *   http://localhost:4000/integrations/django/      → django service
+ *   http://localhost:4000/integrations/blade/       → blade service
+ *   http://localhost:4000/integrations/laravel/     → laravel service
+ *   http://localhost:4000/*                         → site-core (barefootjs.dev)
+ *   http://ui.localhost:4000/*                      → site-ui (ui.barefootjs.dev)
+ *
+ * site-ui is routed by Host header rather than a path prefix: in production
+ * it is a separate origin (ui.barefootjs.dev), and its routes/asset links
+ * assume they own "/", so a path prefix would need rewriting. `*.localhost`
+ * resolves to 127.0.0.1 without any /etc/hosts edit in every current
+ * browser (and in curl via `--resolve`).
  *
  * Designed to run inside the dev docker-compose network where service names
  * (hono, h3, elysia, echo, gin, chi, nethttp, mojolicious, xslate, sinatra,
- * rails, axum, site-core) resolve via Docker DNS. Each upstream
+ * rails, axum, site-core, site-ui) resolve via Docker DNS. Each upstream
  * target is overridable via env vars so the same script also works on the
  * host (e.g. when iterating on the proxy itself), and so individual targets
  * can be redirected to host.docker.internal when an integration is being run
@@ -63,7 +75,8 @@ const routes: readonly Route[] = [
   { prefix: '/integrations/laravel',     target: process.env.LARAVEL_TARGET     ?? 'http://laravel:3016',     label: 'Laravel (PHP)' },
 ] as const
 
-const DEFAULT_TARGET = process.env.SITE_CORE_TARGET ?? 'http://site-core:4001'
+const SITE_CORE_TARGET = process.env.SITE_CORE_TARGET ?? 'http://site-core:4001'
+const SITE_UI_TARGET = process.env.SITE_UI_TARGET ?? 'http://site-ui:3002'
 
 function matchRoute(pathname: string): Route | null {
   for (const route of routes) {
@@ -78,9 +91,10 @@ Bun.serve({
   port: PORT,
   async fetch(req): Promise<Response> {
     const url = new URL(req.url)
-    const route = matchRoute(url.pathname)
-    const target = route?.target ?? DEFAULT_TARGET
-    const label = route ? route.prefix : 'site-core'
+    const isUiHost = url.hostname.startsWith('ui.')
+    const route = isUiHost ? null : matchRoute(url.pathname)
+    const target = route?.target ?? (isUiHost ? SITE_UI_TARGET : SITE_CORE_TARGET)
+    const label = route ? route.prefix : isUiHost ? 'site-ui' : 'site-core'
 
     const proxyUrl = target + url.pathname + url.search
     try {
@@ -113,8 +127,23 @@ Bun.serve({
   },
 })
 
-console.log(`dev-all proxy listening on http://localhost:${PORT}`)
-for (const r of routes) {
-  console.log(`  ${r.prefix.padEnd(26)} → ${r.target}`)
+// `docker compose up` interleaves every service's own startup log (each
+// printing whatever internal port ITS framework picked — 3008, 8081, ...),
+// none of which are reachable directly. This is the one line a developer
+// should actually look for: every URL below is the full, open-this address.
+console.log('')
+console.log(`════════════════════════════════════════════════════════════════`)
+console.log(`  dev-all proxy — the ONLY host-reachable port is ${PORT}`)
+console.log(`  (every URL logged elsewhere by an individual service is`)
+console.log(`   container-internal and cannot be opened directly)`)
+console.log(`════════════════════════════════════════════════════════════════`)
+const entries: Array<{ url: string; label: string }> = [
+  { url: `http://localhost:${PORT}/`, label: 'site-core (barefootjs.dev)' },
+  { url: `http://ui.localhost:${PORT}/`, label: 'site-ui (ui.barefootjs.dev)' },
+  ...routes.map((r) => ({ url: `http://localhost:${PORT}${r.prefix}/`, label: r.label })),
+]
+const urlWidth = Math.max(...entries.map((e) => e.url.length)) + 2
+for (const e of entries) {
+  console.log(`  ${e.url.padEnd(urlWidth)}→ ${e.label}`)
 }
-console.log(`  ${'(fallback)'.padEnd(26)} → ${DEFAULT_TARGET} (site-core)`)
+console.log(`════════════════════════════════════════════════════════════════`)

--- a/site/core/build.ts
+++ b/site/core/build.ts
@@ -14,8 +14,10 @@
  * - dist/uno.css + dist/static/globals.css (tokens + globals + landing)
  * - dist/static/logos/, dist/static/snippets/, icons
  * - dist/slides/ (public/slides/** copied verbatim — peitho decks built by
- *   `bun run slides:build`, see scripts/build-slides.ts; absent locally
- *   until you build one)
+ *   the `slides:build --all` step `bun run build` (this script's own
+ *   package.json entry) runs first, see scripts/build-slides.ts; empty when
+ *   peitho isn't installed, since that step skips with a warning instead of
+ *   failing)
  * - dist/playground/ (worker + page script + Monaco type bundle)
  * - dist/_headers, dist/llms.txt, dist/robots.txt
  */
@@ -215,9 +217,10 @@ if (logoFiles.length > 0) {
   console.log(`Copied: dist/logos/, dist/static/logos/ (${logoFiles.length} files)`)
 }
 
-// ── 8a. Copy public/slides/** → dist/slides/** (peitho decks built by
-// `bun run slides:build`; deploy.yml runs it before this script, so the
-// directory may be absent in a plain local build) ─────────────────
+// ── 8a. Copy public/slides/** → dist/slides/** (peitho decks built by the
+// `slides:build --all` step that runs before this script as part of `bun
+// run build`; the directory may still be empty if peitho isn't installed,
+// since that step skips with a warning rather than failing) ───────────
 async function copyDirRecursive(srcDir: string, destDir: string): Promise<number> {
   let count = 0
   const entries = await readdir(srcDir, { withFileTypes: true }).catch(() => [])

--- a/site/core/landing/renderer.tsx
+++ b/site/core/landing/renderer.tsx
@@ -11,6 +11,7 @@ import { CommandPalette } from '@/components/command-palette'
 import { commandGroups } from '../lib/command-items'
 import { BfScripts } from '../../../packages/adapter-hono/src/scripts'
 import { themeInitScript } from '@barefootjs/site-shared/lib/theme-init'
+import { resolveUiHref } from '@barefootjs/site-shared/lib/site-urls'
 import { LpHeader, LpFooter } from './components/lp-chrome'
 
 /**
@@ -39,8 +40,7 @@ function WithPredictableIds({ children }: { children: any }) {
 export const landingRenderer = jsxRenderer(
   ({ children, title, description }) => {
     const c = useRequestContext()
-    const hostname = new URL(c.req.url).hostname
-    const uiHref = hostname === 'localhost' ? 'http://localhost:3002/' : 'https://ui.barefootjs.dev'
+    const uiHref = resolveUiHref(new URL(c.req.url))
 
     const pageTitle = title || 'BarefootJS — TSX in. Your stack out.'
     const pageDescription = description || 'Components without the Node server.'

--- a/site/core/landing/routes.tsx
+++ b/site/core/landing/routes.tsx
@@ -7,6 +7,7 @@
  */
 
 import { Hono } from 'hono'
+import { resolveUiHref } from '@barefootjs/site-shared/lib/site-urls'
 import { landingRenderer } from './renderer'
 import { initHighlighter } from './components/shared/highlighter'
 import { Hero, DemoSection } from './components/hero'
@@ -25,8 +26,7 @@ export async function createLandingApp() {
 
   // Landing page
   app.get('/', (c) => {
-    const hostname = new URL(c.req.url).hostname
-    const uiHref = hostname === 'localhost' ? 'http://localhost:3002/' : 'https://ui.barefootjs.dev'
+    const uiHref = resolveUiHref(new URL(c.req.url))
     return c.render(
       <>
         <Hero uiHref={uiHref} />

--- a/site/core/package.json
+++ b/site/core/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "concurrently -k -n vite,server -c blue,yellow \"bunx vite dev\" \"bun run --watch server.tsx\"",
-    "build": "bun run build.ts",
+    "build": "bun run slides:build --all && bun run build.ts",
     "test:e2e": "playwright test",
     "deploy": "bun run build && wrangler deploy",
     "slides:build": "bun run scripts/build-slides.ts"

--- a/site/core/renderer.tsx
+++ b/site/core/renderer.tsx
@@ -7,6 +7,7 @@
  */
 
 import { jsxRenderer, useRequestContext } from 'hono/jsx-renderer'
+import { resolveUiHref } from '@barefootjs/site-shared/lib/site-urls'
 import { navigation, type NavItem } from './lib/navigation'
 import { SidebarNav, type SidebarEntry, type SidebarGroup, type SidebarLink } from '../shared/components/sidebar-page-nav'
 import { PageNav, type PageNavLink } from '../shared/components/page-nav'
@@ -117,8 +118,9 @@ import { MobilePageNav } from '../shared/components/mobile-page-nav'
 export const renderer = jsxRenderer(
   ({ children, title, description, meta, slug, toc, prev, next }) => {
     const c = useRequestContext()
-    const hostname = new URL(c.req.url).hostname
-    const uiHref = hostname === 'localhost' ? 'http://localhost:3002/' : 'https://ui.barefootjs.dev'
+    const requestUrl = new URL(c.req.url)
+    const hostname = requestUrl.hostname
+    const uiHref = resolveUiHref(requestUrl)
 
     const pageTitle = title ? `${title} — BarefootJS` : 'BarefootJS Documentation'
     const currentSlug = slug || ''

--- a/site/core/scripts/build-slides.ts
+++ b/site/core/scripts/build-slides.ts
@@ -14,9 +14,13 @@
  *                                  non-component entries are bundled into assets/deck.js and
  *                                  injected into index.html
  *
- * The output (public/slides/<slug>/) is gitignored: deploy.yml installs a pinned peitho
- * release and runs `bun run slides:build --all` before the site build, and ci-slides.yml
- * does the same on pull requests. Set PEITHO to the binary path when it is not on PATH.
+ * The output (public/slides/<slug>/) is gitignored and rebuilt by `bun run build` (see
+ * build.ts), which invokes `--all` as its first step. deploy.yml and ci-slides.yml install a
+ * pinned peitho release before that, so it is always present there. On a plain local `bun run
+ * build` peitho commonly isn't installed, so `--all` degrades to a skip-with-warning instead
+ * of failing the whole build — an explicit slug (`slides:build overview`) still hard-fails,
+ * since that's a deliberate request to build one deck, not an incidental part of `build`. Set
+ * PEITHO to the binary path when it is not on PATH.
  */
 import { existsSync, readdirSync, statSync, readFileSync, writeFileSync, mkdirSync, cpSync, rmSync } from 'node:fs'
 import { resolve, join, dirname } from 'node:path'
@@ -104,7 +108,16 @@ function escapeHtml(s: string): string {
 }
 
 const args = process.argv.slice(2)
-const slugs = args.includes('--all') ? listDecks() : args.filter((a) => !a.startsWith('-'))
+const isAllMode = args.includes('--all')
+
+if (isAllMode && !Bun.which(PEITHO)) {
+  console.warn(`⚠ peitho not found (looked for "${PEITHO}" — set PEITHO=<path> if it's installed elsewhere).`)
+  console.warn(`  Skipping slide deck build; dist/slides/ will be empty. Install peitho to build them locally:`)
+  console.warn(`  https://github.com/mizzy/peitho/releases`)
+  process.exit(0)
+}
+
+const slugs = isAllMode ? listDecks() : args.filter((a) => !a.startsWith('-'))
 if (slugs.length === 0) {
   console.error('usage: bun run slides:build <slug> [<slug>...] | --all\navailable: ' + (listDecks().join(', ') || '(none)'))
   process.exit(1)

--- a/site/core/server.tsx
+++ b/site/core/server.tsx
@@ -5,7 +5,7 @@
 
 import { Hono } from 'hono'
 import { serveStatic } from 'hono/bun'
-import { existsSync } from 'node:fs'
+import { appendTrailingSlash } from 'hono/trailing-slash'
 import { resolve, dirname } from 'node:path'
 import { createApp } from './app'
 import { loadContentFromDisk } from './lib/content-loader'
@@ -38,16 +38,15 @@ server.use('/static/*', serveStatic({
 // (peitho.css, assets/deck.js), which only resolve correctly when the
 // browser's URL ends in a slash. Production's Cloudflare Workers Assets
 // auto-redirects a trailing-slash-less directory request before serving its
-// index.html; hono/bun's serveStatic below does not, so without this a bare
-// /slides/<slug> 200s with the wrong base URL and every relative asset
-// 404s. Redirect first to match production's behavior.
-server.use('/slides/*', async (c, next) => {
-  const { pathname } = new URL(c.req.url)
-  if (!pathname.endsWith('/') && existsSync(resolve('./dist', pathname.slice(1), 'index.html'))) {
-    return c.redirect(pathname + '/', 308)
-  }
-  await next()
-})
+// index.html; hono/bun's serveStatic below does not (it 200s /slides/<slug>
+// with the deck's own index.html, never 404ing), so appendTrailingSlash's
+// default (redirect-on-404-only) never fires — `alwaysRedirect` plus a
+// `skip` for asset paths (which must NOT gain a trailing slash) is needed
+// to match production's behavior here.
+server.use('/slides/*', appendTrailingSlash({
+  alwaysRedirect: true,
+  skip: (path) => /\.\w+$/.test(path),
+}))
 
 // Serve built slide decks (e.g. public/slides/overview/ from `bun run slides:build`,
 // copied to dist/slides/ by build.ts) — mirrors how Cloudflare Workers Assets

--- a/site/core/server.tsx
+++ b/site/core/server.tsx
@@ -5,6 +5,7 @@
 
 import { Hono } from 'hono'
 import { serveStatic } from 'hono/bun'
+import { existsSync } from 'node:fs'
 import { resolve, dirname } from 'node:path'
 import { createApp } from './app'
 import { loadContentFromDisk } from './lib/content-loader'
@@ -32,6 +33,21 @@ server.use('/static/*', serveStatic({
   root: './dist',
   rewriteRequestPath: (path) => path.replace('/static', ''),
 }))
+
+// Each deck's index.html links its own assets with relative paths
+// (peitho.css, assets/deck.js), which only resolve correctly when the
+// browser's URL ends in a slash. Production's Cloudflare Workers Assets
+// auto-redirects a trailing-slash-less directory request before serving its
+// index.html; hono/bun's serveStatic below does not, so without this a bare
+// /slides/<slug> 200s with the wrong base URL and every relative asset
+// 404s. Redirect first to match production's behavior.
+server.use('/slides/*', async (c, next) => {
+  const { pathname } = new URL(c.req.url)
+  if (!pathname.endsWith('/') && existsSync(resolve('./dist', pathname.slice(1), 'index.html'))) {
+    return c.redirect(pathname + '/', 308)
+  }
+  await next()
+})
 
 // Serve built slide decks (e.g. public/slides/overview/ from `bun run slides:build`,
 // copied to dist/slides/ by build.ts) — mirrors how Cloudflare Workers Assets

--- a/site/shared/lib/site-urls.ts
+++ b/site/shared/lib/site-urls.ts
@@ -1,0 +1,31 @@
+/**
+ * barefootjs.dev and ui.barefootjs.dev are separate origins in production.
+ * In dev (`bun run dev` at the repo root → docker-compose's dev-all proxy,
+ * scripts/dev-all.ts), both are reached through one origin (:4000):
+ * site-core at the root, site-ui by Host header at ui.localhost:4000 —
+ * site-ui's own routes/asset links assume they own "/", so a path prefix
+ * would need rewriting that a Host match avoids. A bare `bun run dev` run
+ * directly inside site/core or site/ui (vite dev, no docker-compose)
+ * instead binds each site to its own port with no proxy in front: 4001 for
+ * site-core (site/core/server.tsx), 3002 for site-ui (site/ui/server.tsx).
+ *
+ * `c.req.url`'s host reflects the incoming Host header (Bun's Request.url
+ * is built from it, not from the process's own bind address), so it tells
+ * you which of the two dev setups above is actually serving the request.
+ */
+
+function isDevHost(hostname: string): boolean {
+  return hostname === 'localhost' || hostname.endsWith('.localhost')
+}
+
+/** Link to barefootjs.dev (site-core), given the current request's URL. */
+export function resolveCoreHref(requestUrl: URL, path = '/'): string {
+  if (!isDevHost(requestUrl.hostname)) return `https://barefootjs.dev${path}`
+  return `http://localhost:4000${path}`
+}
+
+/** Link to ui.barefootjs.dev (site-ui), given the current request's URL. */
+export function resolveUiHref(requestUrl: URL, path = '/'): string {
+  if (!isDevHost(requestUrl.hostname)) return `https://ui.barefootjs.dev${path}`
+  return requestUrl.port === '4000' ? `http://ui.localhost:4000${path}` : `http://localhost:3002${path}`
+}

--- a/site/shared/package.json
+++ b/site/shared/package.json
@@ -14,6 +14,7 @@
     "./lib/docs-tabs-init": "./lib/docs-tabs-init.ts",
     "./lib/og-image": "./lib/og-image.ts",
     "./lib/cache-control": "./lib/cache-control.ts",
+    "./lib/site-urls": "./lib/site-urls.ts",
     "./fonts/inter-bold": "./fonts/inter-bold.ts",
     "./tokens": "./tokens/index.ts"
   },

--- a/site/ui/Dockerfile.dev
+++ b/site/ui/Dockerfile.dev
@@ -1,0 +1,16 @@
+# syntax=docker/dockerfile:1
+#
+# Development image for site/ui (ui.barefootjs.dev — the component gallery /
+# API reference site). Source and host-built dist/ are bind-mounted via
+# docker-compose; bun watches server.tsx and reloads on every save.
+#
+# Build context is the repo root so workspace deps resolve through
+# /workspace/node_modules.
+
+FROM oven/bun:1.3-alpine
+
+WORKDIR /workspace/site/ui
+
+EXPOSE 3002
+
+CMD ["bun", "run", "--watch", "server.tsx"]

--- a/site/ui/renderer.tsx
+++ b/site/ui/renderer.tsx
@@ -6,6 +6,7 @@
  */
 
 import { jsxRenderer, useRequestContext } from 'hono/jsx-renderer'
+import { resolveCoreHref, resolveUiHref } from '@barefootjs/site-shared/lib/site-urls'
 
 declare module 'hono' {
   interface ContextRenderer {
@@ -68,15 +69,15 @@ export const renderer = jsxRenderer(
   ({ children, title, description }) => {
     const c = useRequestContext()
     const currentPath = c.req.path
-    const hostname = new URL(c.req.url).hostname
-    const logoHref = hostname === 'localhost' ? 'http://localhost:4000/' : 'https://barefootjs.dev'
-    const coreHref = hostname === 'localhost' ? 'http://localhost:4000/docs/introduction' : 'https://barefootjs.dev/docs/introduction'
-    const playgroundHref = hostname === 'localhost' ? 'http://localhost:4000/playground' : 'https://barefootjs.dev/playground'
-    const integrationsHref = hostname === 'localhost' ? 'http://localhost:4000/integrations' : 'https://barefootjs.dev/integrations'
+    const requestUrl = new URL(c.req.url)
+    const logoHref = resolveCoreHref(requestUrl)
+    const coreHref = resolveCoreHref(requestUrl, '/docs/introduction')
+    const playgroundHref = resolveCoreHref(requestUrl, '/playground')
+    const integrationsHref = resolveCoreHref(requestUrl, '/integrations')
 
     const pageTitle = title ? `${title} | BarefootJS UI` : 'BarefootJS UI'
 
-    const baseUrl = hostname === 'localhost' ? 'http://localhost:3002' : 'https://ui.barefootjs.dev'
+    const baseUrl = resolveUiHref(requestUrl).replace(/\/$/, '')
     const ogTitle = title ?? 'BarefootJS UI'
     const ogDescription = description ?? 'TSX in. Your stack out.'
     const ogImageUrl = `${baseUrl}/og?title=${encodeURIComponent(ogTitle)}`


### PR DESCRIPTION
## Summary

Dev-experience gaps raised after #2951/#2952 fixed `bun run dev`:

1. **`ui.barefootjs.dev` (`site/ui`, the component gallery) wasn't reachable from `bun run dev`** — only `site-core` (`barefootjs.dev`) had a compose service. Added `site/ui/Dockerfile.dev` (mirrors `site/core/Dockerfile.dev`) and a `site-ui` service in `docker-compose.yml`.
   - Routed through the dev-all proxy **by Host header** (`http://ui.localhost:4000/`) rather than a path prefix: in production it's a separate origin, and `site/ui`'s routes/asset links assume they own `/`, so a path prefix would need HTML/asset-path rewriting that a Host match avoids entirely. `*.localhost` resolves to `127.0.0.1` in every current browser (and via `curl --resolve`) with no `/etc/hosts` edit.
   - This surfaced two pre-existing cross-site nav-link bugs: site-core's header linked to `http://localhost:3002/` (site-ui's bare port, which now has no host port mapping — unreachable), and site-ui's own header links back to site-core only matched `hostname === 'localhost'`, so viewed at `ui.localhost:4000` they fell through to *production* `barefootjs.dev` URLs. Replaced all four hand-rolled copies of the `hostname === 'localhost' ? dev : prod` ternary with one shared `site/shared/lib/site-urls.ts` (`resolveCoreHref`/`resolveUiHref`) that treats any `*.localhost` host as dev and picks site-ui's dev URL by port (4000 → proxy → `ui.localhost:4000`; anything else → site-ui run standalone → `localhost:3002`).
2. **`/slides/overview` needed a manual build step, and 404ed its own assets once built** — two separate bugs:
   - `site-core`'s `/slides/*` route serves from `dist/slides/`, which previously required a *separate* host-side step (`bun run slides:build --all`, requiring the `peitho` CLI) beyond the regular `bun run build`. Folded that into `build` itself: `site/core/package.json`'s `build` now runs `slides:build --all` first, and that step skips with a warning (exit 0) instead of failing when `peitho` isn't on PATH (common on a local dev machine) — an explicit slug (`slides:build overview`) still hard-fails. `deploy.yml`'s now-redundant standalone "Build slide decks" step is removed (folded into "Build site"); `ci-slides.yml` is unchanged since it deliberately calls `slides:build --all` directly to fail fast on slide-only PRs.
   - Once built, `GET /slides/overview` (no trailing slash) 200ed but the deck's relative asset links (`peitho.css`, `assets/deck.js`, `manifest.json`) then 404ed, because they resolved against `/slides/` instead of `/slides/overview/`. Production's Cloudflare Workers Assets auto-redirects a trailing-slash-less directory request before serving its `index.html`; `hono/bun`'s `serveStatic` doesn't. Fixed with Hono's built-in `hono/trailing-slash` (`appendTrailingSlash`) middleware, with `alwaysRedirect: true` + a `skip` for extensioned asset paths (needed because `serveStatic` 200s the slug directly instead of 404ing, so the default redirect-on-404 mode never fires, and without `skip` asset paths would themselves get a trailing slash appended). (Not Hono's `strict` app option — that only affects *route matching*, never redirects.)
3. **Ports were hard to make sense of from the logs** — `docker-compose.yml` only publishes the proxy's own port (4000) to the host; every other service's own internally-logged port (Flask on 3008, Gin on 8081, ...) is container-only and unreachable directly, but that's easy to miss once `docker compose up` interleaves 20 services' logs. Reworked `scripts/dev-all.ts`'s startup log into one clearly-marked block listing every full, open-this URL (including the new `ui.localhost` one), computed with dynamic padding so long paths (`/integrations/mojolicious/`) don't misalign.

## Test plan

- [x] `docker compose build site-ui proxy` succeeds
- [x] `docker compose up -d site-ui proxy` (force-recreate) starts cleanly alongside the other 18 already-running services, none of which were disrupted
- [x] `curl --resolve ui.localhost:4000:127.0.0.1 http://ui.localhost:4000/` → 200; `.../components/button` → 200
- [x] `http://localhost:4000/` (site-core) and `.../integrations/hono/` → 200
- [x] `GET http://ui.localhost:4000/` links back to `http://localhost:4000/` (not `barefootjs.dev`); `GET http://localhost:4000/` links to `http://ui.localhost:4000/` (not the unreachable `localhost:3002`) — both round-trip 200
- [x] `bun run build` (site/core) with peitho on PATH produces `dist/slides/overview/`; with `PEITHO` pointed at a nonexistent path, the same command warns, skips slides, and still completes the rest of the build (exit 0)
- [x] `GET /slides/overview` → 301 → `/slides/overview/` → 200, with `peitho.css`/`assets/deck.js`/`manifest.json` all resolving as 200 without themselves gaining a trailing slash; `GET /slides` (no slug) still 404s
- [x] Proxy startup log reviewed for alignment/readability

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RbD21pa2PhYh7ZUtHA4qro