### PR TITLE
Dock the overview deck's chrome into a bottom bar on phones and touch screens

### DIFF
--- a/site/core/slides/overview/component/narration.ts
+++ b/site/core/slides/overview/component/narration.ts
@@ -193,23 +193,28 @@ function dockChrome(compact: boolean) {
     bar.remove()
   }
 }
+// Fit the canvas into the viewport minus `bottomInset` (the bar's height on compact screens,
+// 0 otherwise): the same translate+scale the viewer's own fit writes, so on desktop this is a
+// no-op restatement. Always re-done here, in both modes, because compactQuery can flip
+// without a resize (a mouse attached to or detached from a touchscreen) and the viewer's
+// fit only runs on resize — relying on it would leave the last compact fit on the canvas.
+function fitCanvas(canvas: HTMLElement, bottomInset: number) {
+  const avail = innerHeight - bottomInset
+  const s = Math.min(innerWidth / CANVAS_W, avail / CANVAS_H)
+  const w = CANVAS_W * s, h = CANVAS_H * s
+  canvas.style.transform = `translate(${(innerWidth - w) / 2}px, ${(avail - h) / 2}px) scale(${s})`
+}
 function placeChrome() {
   const canvas = document.getElementById('peitho-canvas')
   if (!canvas) return
-  dockChrome(compactQuery.matches)
-  if (compactQuery.matches) {
-    // Re-fit the canvas into the viewport minus the bar so the bar never covers slide content
-    // (a phone in landscape is height-bound). Same transform shape as the viewer's own fit,
-    // applied after it: the viewer's resize handler registered first, this one runs last.
-    const avail = innerHeight - bar.offsetHeight
-    const s = Math.min(innerWidth / CANVAS_W, avail / CANVAS_H)
-    const w = CANVAS_W * s, h = CANVAS_H * s
-    canvas.style.transform = `translate(${(innerWidth - w) / 2}px, ${(avail - h) / 2}px) scale(${s})`
-    const r = canvas.getBoundingClientRect()
+  const compact = compactQuery.matches
+  dockChrome(compact)
+  fitCanvas(canvas, compact ? bar.offsetHeight : 0)
+  const r = canvas.getBoundingClientRect()
+  if (compact) {
     progress.style.left = `${r.left}px`; progress.style.top = `${r.top}px`; progress.style.width = `${r.width}px`
     return
   }
-  const r = canvas.getBoundingClientRect()
   const s = r.width / CANVAS_W
   const put = (el: HTMLElement, x: number, y: number) => {
     el.style.left = `${r.left + x * s}px`

--- a/site/core/slides/overview/component/narration.ts
+++ b/site/core/slides/overview/component/narration.ts
@@ -80,6 +80,24 @@ style.textContent = `
   body.bf-dark #bf-nav button { border-color: rgba(255,255,255,.28); background: rgba(255,255,255,.08); color: #fff; }
   body.bf-dark #bf-nav button:hover { background: #fff; color: #0a0a0a; border-color: #fff; }
   body.bf-dark #bf-counter { color: rgba(255,255,255,.55); }
+  /* Compact chrome (phones, any coarse-pointer screen): the counter, the language toggle and
+     the page buttons leave the canvas and dock into a bar fixed to the bottom of the viewport,
+     at thumb size and unscaled — on a 390px-wide phone the canvas-anchored chrome would be a
+     third of its size, unusable. See placeChrome(). */
+  #bf-bar {
+    position: fixed; left: 0; right: 0; bottom: 0; z-index: 20;
+    display: grid; grid-template-columns: 1fr auto 1fr; align-items: center; gap: 12px;
+    padding: 10px 16px calc(10px + env(safe-area-inset-bottom, 0px));
+    background: rgba(251,250,247,.88); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px);
+    border-top: 1px solid rgba(10,10,10,.08);
+  }
+  body.bf-dark #bf-bar { background: rgba(10,10,10,.76); border-top-color: rgba(255,255,255,.12); }
+  #bf-bar #bf-counter, #bf-bar #bf-nav, #bf-bar #bf-langs { position: static; transform: none; }
+  #bf-bar #bf-counter { grid-column: 2; font-size: 13px; text-align: center; }
+  #bf-bar #bf-langs { grid-column: 1; justify-self: start; }
+  #bf-bar #bf-langs button { font-size: 13px; padding: 0 18px; height: 44px; }
+  #bf-bar #bf-nav { grid-column: 3; justify-self: end; gap: 10px; }
+  #bf-bar #bf-nav button { width: 48px; height: 48px; font-size: 28px; }
   body.bf-dark #bf-progress { background: rgba(255,255,255,.12); }`
 document.head.append(style)
 
@@ -156,9 +174,41 @@ function paintProgress() {
 // corner (base.css's bottom padding; the arcade's caption sits above it).
 const CANVAS_W = 1280, CANVAS_H = 720
 const COUNTER_RIGHT = 22, COUNTER_BOTTOM = 18, NAV_BOTTOM = 40, NAV_RIGHT = 18
+// Phones and other touch screens: dock the chrome into a bottom bar instead (#bf-bar above).
+// Width alone catches a phone in portrait; the pointer clause catches a phone in landscape
+// and a tablet, where the canvas-scaled buttons would still be too small to tap.
+const compactQuery = matchMedia('(max-width: 820px), (hover: none) and (pointer: coarse)')
+const bar = document.createElement('div')
+bar.id = 'bf-bar'
+function dockChrome(compact: boolean) {
+  if (compact) {
+    if (!bar.isConnected) document.body.append(bar)
+    for (const el of [langs, counter, nav]) {
+      if (el === langs && LANGS.length === 0) continue
+      if (el.parentElement !== bar) bar.append(el)
+      el.style.left = el.style.top = el.style.transform = ''
+    }
+  } else if (bar.isConnected) {
+    for (const el of [counter, nav, langs]) if (el.parentElement === bar) document.body.append(el)
+    bar.remove()
+  }
+}
 function placeChrome() {
   const canvas = document.getElementById('peitho-canvas')
   if (!canvas) return
+  dockChrome(compactQuery.matches)
+  if (compactQuery.matches) {
+    // Re-fit the canvas into the viewport minus the bar so the bar never covers slide content
+    // (a phone in landscape is height-bound). Same transform shape as the viewer's own fit,
+    // applied after it: the viewer's resize handler registered first, this one runs last.
+    const avail = innerHeight - bar.offsetHeight
+    const s = Math.min(innerWidth / CANVAS_W, avail / CANVAS_H)
+    const w = CANVAS_W * s, h = CANVAS_H * s
+    canvas.style.transform = `translate(${(innerWidth - w) / 2}px, ${(avail - h) / 2}px) scale(${s})`
+    const r = canvas.getBoundingClientRect()
+    progress.style.left = `${r.left}px`; progress.style.top = `${r.top}px`; progress.style.width = `${r.width}px`
+    return
+  }
   const r = canvas.getBoundingClientRect()
   const s = r.width / CANVAS_W
   const put = (el: HTMLElement, x: number, y: number) => {
@@ -175,6 +225,7 @@ function placeChrome() {
   if (langs.isConnected) put(langs, CANVAS_W - NAV_RIGHT - nav.offsetWidth - 10 - langs.offsetWidth, CANVAS_H - NAV_BOTTOM - 34 + (34 - langs.offsetHeight) / 2)
 }
 window.addEventListener('resize', placeChrome)
+compactQuery.addEventListener('change', placeChrome)
 
 // A slide on a dark ground marks its <section> with data-ground="dark"; the chrome follows.
 function paintChrome() {


### PR DESCRIPTION
## Summary

Follow-up to #2949. On a phone the deck chrome (language toggle, previous/next buttons, slide counter) is anchored inside the 16:9 canvas and scales with it: on a 390px-wide screen it renders at about a third of its size and cannot be tapped.

On compact screens the chrome now leaves the canvas and docks into a bar fixed to the bottom of the viewport, at thumb size and unscaled. Desktop is unchanged.

## What changed

`site/core/slides/overview/component/narration.ts` only:

- **Compact query**: `(max-width: 820px), (hover: none) and (pointer: coarse)`. Width alone catches a phone in portrait; the pointer clause catches a phone in landscape and a tablet, where the canvas-scaled buttons would still be too small to tap.
- **`#bf-bar`**: a three-column bar fixed to the bottom of the viewport — language pill left (44px tall), counter centred, page buttons right (48px circles) — padded for the home-indicator safe area, translucent paper with blur, and dark on `data-ground="dark"` slides. `placeChrome()` moves the three existing elements into it (and back out) as the query flips, so the handlers and state are untouched.
- **Canvas re-fit**: on compact screens the canvas is re-fitted into the viewport minus the bar, using the same transform shape as the viewer's own fit, applied after it. The bar never covers slide content (a phone in landscape is height-bound; in portrait the fit is width-bound and nothing changes).

## Test plan

- [x] `bun run slides:build overview` with the pinned peitho v1.26.0 binary.
- [x] Headless Chromium at 390×844 (portrait), 844×390 (landscape), 1024×768 (touch tablet): the bar appears, the page buttons measure 48×48 and a tap navigates, the language pill switches language, the counter updates, and the canvas bottom edge meets the bar top in landscape. On the arcade slide the bar takes the dark variant.
- [x] 1920×1080: no bar; the chrome placement is identical to before.
- [x] No page errors on any of the above.
- Not run: the monorepo's full test suite and the site E2E suite; nothing outside `site/core/slides/overview/component/narration.ts` changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ScCN7LKcFvPNjSWuFZv42L

---
_Generated by [Claude Code](https://claude.ai/code/session_01ScCN7LKcFvPNjSWuFZv42L)_