### PR TITLE
Fix resolveCoreHref's missing standalone-port branch

### DIFF
--- a/site/core/build.ts
+++ b/site/core/build.ts
@@ -14,7 +14,7 @@
  * - dist/uno.css + dist/static/globals.css (tokens + globals + landing)
  * - dist/static/logos/, dist/static/snippets/, icons
  * - dist/slides/ (public/slides/** copied verbatim — peitho decks built by
- *   the `slides:build --all` step `bun run build` (this script's own
+ *   the `slides:build --all` step that `bun run build` (this script's own
  *   package.json entry) runs first, see scripts/build-slides.ts; empty when
  *   peitho isn't installed, since that step skips with a warning instead of
  *   failing)

--- a/site/core/renderer.tsx
+++ b/site/core/renderer.tsx
@@ -7,7 +7,7 @@
  */
 
 import { jsxRenderer, useRequestContext } from 'hono/jsx-renderer'
-import { resolveUiHref } from '@barefootjs/site-shared/lib/site-urls'
+import { resolveCoreHref, resolveUiHref } from '@barefootjs/site-shared/lib/site-urls'
 import { navigation, type NavItem } from './lib/navigation'
 import { SidebarNav, type SidebarEntry, type SidebarGroup, type SidebarLink } from '../shared/components/sidebar-page-nav'
 import { PageNav, type PageNavLink } from '../shared/components/page-nav'
@@ -119,13 +119,12 @@ export const renderer = jsxRenderer(
   ({ children, title, description, meta, slug, toc, prev, next }) => {
     const c = useRequestContext()
     const requestUrl = new URL(c.req.url)
-    const hostname = requestUrl.hostname
     const uiHref = resolveUiHref(requestUrl)
 
     const pageTitle = title ? `${title} — BarefootJS` : 'BarefootJS Documentation'
     const currentSlug = slug || ''
 
-    const baseUrl = hostname === 'localhost' ? 'http://localhost:3000' : 'https://barefootjs.dev'
+    const baseUrl = resolveCoreHref(requestUrl).replace(/\/$/, '')
     const ogTitle = title ?? 'BarefootJS'
     const ogDescription = description ?? 'TSX in. Your stack out.'
     const ogImageUrl = `${baseUrl}/og?title=${encodeURIComponent(ogTitle)}`

--- a/site/shared/lib/site-urls.ts
+++ b/site/shared/lib/site-urls.ts
@@ -21,7 +21,7 @@ function isDevHost(hostname: string): boolean {
 /** Link to barefootjs.dev (site-core), given the current request's URL. */
 export function resolveCoreHref(requestUrl: URL, path = '/'): string {
   if (!isDevHost(requestUrl.hostname)) return `https://barefootjs.dev${path}`
-  return `http://localhost:4000${path}`
+  return requestUrl.port === '4000' ? `http://localhost:4000${path}` : `http://localhost:4001${path}`
 }
 
 /** Link to ui.barefootjs.dev (site-ui), given the current request's URL. */


### PR DESCRIPTION
## Summary

Follow-up to #2953, addressing review findings after that PR had already merged.

- **[pullrequestreview-5186077461](https://github.com/piconic-ai/barefootjs/pull/2953#pullrequestreview-5186077461), flagged IMPORTANT:** `resolveCoreHref` always returned `http://localhost:4000/` in dev, unlike its sibling `resolveUiHref`, which branches on the request's port to tell the docker-compose proxy setup (port 4000) apart from a standalone `cd site/ui && bun run dev` (port 3002, no proxy in front). Viewed from `site-ui` running standalone, `resolveCoreHref`'s "back to site-core" links (`logoHref`/`coreHref`/`playgroundHref`/`integrationsHref` in `site/ui/renderer.tsx`) pointed at the proxy's port regardless — a dead link unless a docker-compose proxy happened to also be running. Fixed by mirroring `resolveUiHref`'s branch: port 4000 → the proxy is serving the request, link to it; any other port → site-core itself is presumably running standalone on its own default (4001).
- **Nitpick in the same review:** `site/core/renderer.tsx`'s `baseUrl` (used for the OG-image URL) was a fifth hand-rolled copy of the exact dev/prod ternary `site-urls.ts` was introduced to replace, and pointed at port 3000 — nothing in the repo binds that port (site-core's real dev ports are 4000 via the proxy, 4001 standalone). Replaced with `resolveCoreHref`.
- **Nitpick from [pullrequestreview-5185937764](https://github.com/piconic-ai/barefootjs/pull/2953#pullrequestreview-5185937764)**, repeated as still-open in every subsequent review on #2953: a missing "that" in `build.ts`'s docstring. Fixed while already in this file's review-feedback area.

I checked every review left on #2953 (6 total, all from the pullfrog bot) for anything else outstanding — these three were the only unresolved items; everything else was "no issues" per-commit.

## Test plan

- [x] `resolveCoreHref(new URL('http://localhost:3002/'))` (site-ui standalone) now returns `http://localhost:4001/` instead of the dead-in-that-mode `:4000`
- [x] `resolveCoreHref(new URL('http://localhost:4000/'))` and `.../ui.localhost:4000/` still return `http://localhost:4000/` (proxy case unaffected)
- [x] `GET /docs/introduction` through the proxy now reports `og:image` at `http://localhost:4000/og?...` (previously `:3000`, which 404ed)
- [x] `docker compose restart site-core`; `/integrations/hono/` and `ui.localhost:4000/` still 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RbD21pa2PhYh7ZUtHA4qro