### PR TITLE
Phone-shaped canvas with larger type on narrow screens; keep the bottom bar light on dark slides

### DIFF
--- a/site/core/slides/overview/component/narration.ts
+++ b/site/core/slides/overview/component/narration.ts
@@ -91,7 +91,6 @@ style.textContent = `
     background: rgba(251,250,247,.88); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px);
     border-top: 1px solid rgba(10,10,10,.08);
   }
-  body.bf-dark #bf-bar { background: rgba(10,10,10,.76); border-top-color: rgba(255,255,255,.12); }
   #bf-bar #bf-counter, #bf-bar #bf-nav, #bf-bar #bf-langs { position: static; transform: none; }
   #bf-bar #bf-counter { grid-column: 2; font-size: 13px; text-align: center; }
   #bf-bar #bf-langs { grid-column: 1; justify-self: start; }
@@ -178,9 +177,16 @@ const COUNTER_RIGHT = 22, COUNTER_BOTTOM = 18, NAV_BOTTOM = 40, NAV_RIGHT = 18
 // Width alone catches a phone in portrait; the pointer clause catches a phone in landscape
 // and a tablet, where the canvas-scaled buttons would still be too small to tap.
 const compactQuery = matchMedia('(max-width: 820px), (hover: none) and (pointer: coarse)')
+// Narrow screens only (a phone in portrait) also get the phone-shaped canvas and the
+// single-column, larger-type layouts (body.bf-compact in the CSS). A tablet or a phone in
+// landscape keeps the desktop layout: at their scale the 16:9 slide is still legible, and
+// the tall canvas would not fit their height anyway.
+const narrowQuery = matchMedia('(max-width: 820px)')
 const bar = document.createElement('div')
 bar.id = 'bf-bar'
 function dockChrome(compact: boolean) {
+  const narrow = narrowQuery.matches
+  if (document.body.classList.contains('bf-compact') !== narrow) document.body.classList.toggle('bf-compact', narrow)
   if (compact) {
     if (!bar.isConnected) document.body.append(bar)
     for (const el of [langs, counter, nav]) {
@@ -198,10 +204,24 @@ function dockChrome(compact: boolean) {
 // no-op restatement. Always re-done here, in both modes, because compactQuery can flip
 // without a resize (a mouse attached to or detached from a touchscreen) and the viewer's
 // fit only runs on resize — relying on it would leave the last compact fit on the canvas.
-function fitCanvas(canvas: HTMLElement, bottomInset: number) {
+//
+// On narrow screens the canvas also stops being 16:9: it keeps its 1280-unit width and grows
+// to the viewport's own proportion (a phone in portrait gets a canvas around 1280x2500), so
+// the single-column, larger-type layouts under body.bf-compact have room to flow. The height
+// rides on --peitho-canvas-height, which .peitho-slide already reads. A slide that declares
+// data-canvas="fixed" (the arcade: its play field is authored in 1280x720 coordinates) keeps
+// the 16:9 canvas.
+function fitCanvas(canvas: HTMLElement, narrow: boolean, bottomInset: number) {
   const avail = innerHeight - bottomInset
-  const s = Math.min(innerWidth / CANVAS_W, avail / CANVAS_H)
-  const w = CANVAS_W * s, h = CANVAS_H * s
+  const fixed = !!canvas.querySelector('section[data-canvas="fixed"]')
+  const ch = narrow && !fixed ? Math.max(CANVAS_H, Math.round(CANVAS_W * avail / innerWidth)) : CANVAS_H
+  const hpx = `${ch}px`
+  if (canvas.style.height !== hpx) {
+    canvas.style.height = hpx
+    document.documentElement.style.setProperty('--peitho-canvas-height', hpx)
+  }
+  const s = Math.min(innerWidth / CANVAS_W, avail / ch)
+  const w = CANVAS_W * s, h = ch * s
   canvas.style.transform = `translate(${(innerWidth - w) / 2}px, ${(avail - h) / 2}px) scale(${s})`
 }
 function placeChrome() {
@@ -209,7 +229,7 @@ function placeChrome() {
   if (!canvas) return
   const compact = compactQuery.matches
   dockChrome(compact)
-  fitCanvas(canvas, compact ? bar.offsetHeight : 0)
+  fitCanvas(canvas, narrowQuery.matches, compact ? bar.offsetHeight : 0)
   const r = canvas.getBoundingClientRect()
   if (compact) {
     progress.style.left = `${r.left}px`; progress.style.top = `${r.top}px`; progress.style.width = `${r.width}px`
@@ -231,10 +251,13 @@ function placeChrome() {
 }
 window.addEventListener('resize', placeChrome)
 compactQuery.addEventListener('change', placeChrome)
+narrowQuery.addEventListener('change', placeChrome)
 
 // A slide on a dark ground marks its <section> with data-ground="dark"; the chrome follows.
 function paintChrome() {
-  const dark = !!document.querySelector('#peitho-canvas section[data-ground="dark"]')
+  // Docked in the bottom bar the chrome sits outside the canvas, on the page's own ground,
+  // so a dark slide does not flip it there.
+  const dark = !compactQuery.matches && !!document.querySelector('#peitho-canvas section[data-ground="dark"]')
   if (document.body.classList.contains('bf-dark') !== dark) document.body.classList.toggle('bf-dark', dark)
   const t = total(); const i = slideIndex()
   const [prev, next] = nav.querySelectorAll('button')

--- a/site/core/slides/overview/css/arcade.css
+++ b/site/core/slides/overview/css/arcade.css
@@ -515,3 +515,9 @@
 @media (prefers-reduced-motion: reduce) {
   .a-demo.is-on { animation: none; }
 }
+
+/* Compact canvas (body.bf-compact, see base.css): this slide keeps the 16:9 canvas
+   (data-canvas="fixed"), so only the caption type grows; the field is a demo at
+   phone scale either way. */
+body.bf-compact .layout-arcade .arcade-title { font-size: 52px; line-height: 1.2; }
+body.bf-compact .layout-arcade .arcade-body { font-size: 26px; line-height: 1.5; }

--- a/site/core/slides/overview/css/base.css
+++ b/site/core/slides/overview/css/base.css
@@ -273,3 +273,94 @@ html[lang="ja"] .lede { font-size: 21px; }
 html[lang="ja"] .split-body, html[lang="ja"] .terminal-body { font-size: 22px; }
 html[lang="ja"] .ships li { font-size: 19px; letter-spacing: 0; }
 html[lang="ja"] .layout-cover .cover-body { letter-spacing: 0; }
+
+/* ============================================================================
+   Compact canvas (phones, touch screens) — body.bf-compact, set by narration.ts.
+   The canvas keeps its 1280-unit width and grows to the screen's proportion
+   (about 1280x2500 in portrait), rendered at roughly 0.3 scale; so every size
+   below is in canvas units and lands at ~0.3x on screen: body copy at 48 units
+   is ~15px, headlines at 100 units ~30px. Layouts collapse to one column.
+   Content is deliberately not trimmed here; that is an editorial pass.
+   ========================================================================== */
+body.bf-compact .peitho-slide { padding: 96px 72px 120px; }
+body.bf-compact .peitho-slide h1 { font-size: 100px; line-height: 1.1; letter-spacing: -0.02em; }
+body.bf-compact .head { gap: 28px; }
+body.bf-compact .lede { font-size: 48px; line-height: 1.5; max-width: none; }
+body.bf-compact .peitho-slide code { font-size: 0.92em; }
+body.bf-compact .slot-code, body.bf-compact .code > pre { font-size: 34px; line-height: 1.55; padding: 40px 44px; overflow-x: auto; }
+
+/* cover / end */
+body.bf-compact .layout-cover h1 { font-size: 168px; letter-spacing: -0.03em; line-height: 0.95; }
+body.bf-compact .tagline { font-size: 72px; }
+body.bf-compact .layout-cover .cover-body { font-size: 44px; line-height: 1.5; text-align: center; }
+body.bf-compact .layout-end h1 { font-size: 130px; }
+body.bf-compact .layout-end .cover-body { font-size: 44px; }
+
+/* belief */
+body.bf-compact .belief-inner { max-width: none; gap: 40px; }
+body.bf-compact .belief-body { font-size: 48px; line-height: 1.55; max-width: none; }
+body.bf-compact .belief-sources { position: static; margin-top: 56px; font-size: 28px; line-height: 1.6; }
+
+/* split / terminal / live: one column. Grid items get min-width: 0 so a wide
+   `white-space: pre` code panel scrolls inside its column instead of widening it
+   past the canvas. The mounts stop being flex containers (a `flex: none` grid
+   inside a row flex container would shrink to its content width). */
+body.bf-compact .split-columns, body.bf-compact .terminal-columns, body.bf-compact .live-columns {
+  grid-template-columns: 1fr; align-items: start; gap: 48px; min-height: 0; flex: none;
+}
+body.bf-compact .split-columns > *, body.bf-compact .terminal-columns > *, body.bf-compact .wire-columns > *,
+body.bf-compact .compiler > *, body.bf-compact .trace > *, body.bf-compact .term, body.bf-compact .compiler-out, body.bf-compact .trace-dom {
+  min-width: 0; max-width: 100%;
+}
+body.bf-compact .compiler-mount, body.bf-compact .trace-mount, body.bf-compact .terminal-mount { display: block; flex: none; min-height: 0; }
+body.bf-compact .compiler, body.bf-compact .trace { width: 100%; grid-auto-rows: auto; align-items: start; }
+body.bf-compact .layout-split h1, body.bf-compact .layout-terminal h1, body.bf-compact .layout-belief h1 { font-size: 100px; line-height: 1.1; }
+body.bf-compact .split-body { font-size: 48px; line-height: 1.5; gap: 36px; }
+body.bf-compact .split-body ul { gap: 28px; }
+body.bf-compact .split-body li { padding-left: 84px; }
+body.bf-compact .split-body li::before { width: 56px; height: 56px; font-size: 28px; top: 0.15em; }
+body.bf-compact .split-code > pre { font-size: 34px; line-height: 1.55; }
+body.bf-compact .terminal-body { font-size: 48px; line-height: 1.5; }
+body.bf-compact .terminal-body ul { gap: 28px; }
+body.bf-compact .terminal-body li::before { width: 12px; height: 12px; top: 0.6em; }
+body.bf-compact .term-body { font-size: 32px; line-height: 1.6; padding: 12px 40px 40px; overflow-x: auto; }
+body.bf-compact .term-bar { padding: 24px 30px; gap: 14px; }
+body.bf-compact .term-bar span { width: 20px; height: 20px; }
+
+/* wire */
+body.bf-compact .wire-columns { grid-template-columns: 1fr; gap: 44px; flex: none; }
+body.bf-compact .wire-label { font-size: 28px; }
+body.bf-compact .wire-code > pre { font-size: 34px; line-height: 1.55; padding: 40px 44px; overflow-x: auto; }
+
+/* compiler */
+body.bf-compact .compiler { grid-template-columns: 1fr; gap: 32px; flex: none; }
+body.bf-compact .compiler-tabs { flex-direction: row; flex-wrap: wrap; align-items: flex-start; gap: 12px; }
+body.bf-compact .compiler-tab { font-size: 36px; padding: 16px 30px; border-radius: 20px; }
+body.bf-compact .compiler-out { flex: none; padding: 36px 44px 40px; }
+body.bf-compact .compiler-meta { font-size: 28px; margin-bottom: 28px; }
+body.bf-compact .compiler-code { flex: none; overflow-x: auto; font-size: 32px; line-height: 1.5; }
+
+/* trace */
+body.bf-compact .trace { grid-template-columns: 1fr; gap: 48px; align-items: start; flex: none; }
+body.bf-compact .trace-value { font-size: 280px; }
+body.bf-compact .counter-btn { font-size: 44px; padding: 28px 72px; }
+body.bf-compact .trace-dom-head { font-size: 28px; }
+body.bf-compact .trace-tree { font-size: 32px; line-height: 1.6; overflow-x: auto; }
+
+/* ships */
+body.bf-compact .ships { flex: none; }
+body.bf-compact .ships ul { grid-template-columns: repeat(2, 1fr); grid-auto-rows: auto; gap: 28px; height: auto; }
+body.bf-compact .ships li { padding: 40px 40px 36px; font-size: 40px; }
+body.bf-compact .ships li strong { font-size: 120px; margin-bottom: 24px; }
+
+/* command */
+body.bf-compact .command-code .slot-code { font-size: 44px; padding: 32px 56px; }
+body.bf-compact .command-note { font-size: 44px; }
+
+/* Japanese on the compact canvas: 84 units keeps a 13-character headline
+   (「自分で実行できるチェック。」) on one line at the 1136-unit text width, so the
+   closing 。 never wraps alone. */
+html[lang="ja"] body.bf-compact .peitho-slide h1,
+html[lang="ja"] body.bf-compact .layout-belief h1,
+html[lang="ja"] body.bf-compact .layout-split h1,
+html[lang="ja"] body.bf-compact .layout-terminal h1 { font-size: 84px; line-height: 1.22; }

--- a/site/core/slides/overview/css/showcase.css
+++ b/site/core/slides/overview/css/showcase.css
@@ -139,3 +139,13 @@
  * wraps, and pushes the composition off the bottom of the canvas. */
 html[lang="ja"] .layout-showcase h1 { font-size: 38px; line-height: 1.2; }
 html[lang="ja"] .layout-showcase .lede { font-size: 15px; line-height: 1.5; }
+
+/* Compact canvas (body.bf-compact, see base.css): the composition is authored at
+   a 669px width and scaled 1.65x, so the kit's rem-based type doubles with it and one
+   card fills the row; the header follows the deck's compact sizes. */
+body.bf-compact .layout-showcase.peitho-slide { padding-top: 96px; gap: 28px; }
+body.bf-compact .layout-showcase h1 { font-size: 90px; line-height: 1.1; }
+body.bf-compact .layout-showcase .head { font-size: 44px; line-height: 1.5; }
+body.bf-compact .showcase { width: 669px; transform: translateX(-50%) scale(1.65); transform-origin: top center; }
+body.bf-compact .showcase-grid { grid-template-columns: 1fr; gap: 16px; }
+body.bf-compact .showcase-messages { grid-column: auto; }

--- a/site/core/slides/overview/layouts/arcade.html
+++ b/site/core/slides/overview/layouts/arcade.html
@@ -8,8 +8,12 @@
   only while a game is being PLAYED (see component/components/Arcade.tsx);
   Escape returns it to the title screen without swallowing the key, and
   PageUp / PageDown always belong to the viewer.
+
+  data-canvas="fixed": the play field is authored in 1280x720 coordinates, so on phones
+  (where narration.ts otherwise grows the canvas to the screen's proportion) this slide
+  keeps the 16:9 canvas.
 -->
-<section class="peitho-slide layout-arcade" data-ground="dark">
+<section class="peitho-slide layout-arcade" data-ground="dark" data-canvas="fixed">
   <div class="bf-mount arcade-mount" data-bf="Arcade"></div>
   <div class="arcade-caption">
     <h1 class="arcade-title"><slot name="title" accepts="inline" arity="1"></slot></h1>


### PR DESCRIPTION
## Summary

Follow-up to #2954 (the mobile bottom bar). Two things reported from a phone:

1. On the arcade slide the bottom bar flipped to its dark variant while every other slide had the light one.
2. Type was unreadable: the 16:9 canvas lands at ~0.3 scale on a 390px-wide phone, so 24-unit body copy rendered at about 7px.

The bar now stays light everywhere, and narrow screens get a phone-shaped canvas with single-column layouts and type sized for the phone. Desktop, tablet and landscape phone are unchanged from #2954. Nothing is trimmed; that is an editorial pass to come.

## What changed

- **Bar colour** (`component/narration.ts`): docked in the bar the chrome sits outside the canvas on the page's own ground, so `paintChrome()` ignores `data-ground="dark"` while compact. The dark-bar CSS is removed.
- **Phone-shaped canvas** (`component/narration.ts`): on `max-width: 820px` the canvas keeps its 1280-unit width and grows to the screen's proportion (about 1280×2500 in portrait). `fitCanvas()` writes the height to `--peitho-canvas-height` (which `.peitho-slide` already reads) and fits the taller canvas above the bar. A slide declaring `data-canvas="fixed"` keeps 16:9 — the arcade does (`layouts/arcade.html`), its play field being authored in 1280×720 coordinates. A tablet or a phone in landscape keeps the desktop layout: legible at their scale, and the tall canvas would not fit their height; the bar still docks there.
- **Compact layouts** (`body.bf-compact`, set by `narration.ts`; rules at the end of `css/base.css`, `css/showcase.css`, `css/arcade.css`): every side-by-side grid becomes one column (split, terminal, wire, compiler, trace; ships two-up), body copy at 48 units (~15px on screen), headlines at 100 (84 for Japanese so a 13-character title stays on one line), code at 32–34 units scrolling horizontally inside its panel (grid items get `min-width: 0` so a `white-space: pre` panel cannot widen the canvas), the compiler tabs as a wrapping row, the showcase composition authored at 669px and scaled 1.65× so one kit card fills the row, the belief footnotes in flow instead of pinned to the canvas corner, and the arcade caption only slightly larger.

## Test plan

- [x] `bun run slides:build overview` with the pinned peitho v1.26.0 binary.
- [x] Headless Chromium at 390×844, every slide in both languages: a scripted pass finds no element extending past the canvas, no page errors, `body.bf-dark` false on the arcade slide with the bar in its light colours; screenshots reviewed for every slide.
- [x] 844×390, 1024×768 (touch) and 1920×1080: the four-viewport matrix from #2954 is unchanged (bar present on the first two, desktop chrome on the last; canvas stays 16:9).
- [x] Compiler slide on the phone: all seven outputs fit the panel height, long lines scroll horizontally.
- Not run: the monorepo's full test suite and the site E2E suite; nothing outside `site/core/slides/overview/` changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ScCN7LKcFvPNjSWuFZv42L

---
_Generated by [Claude Code](https://claude.ai/code/session_01ScCN7LKcFvPNjSWuFZv42L)_