### PR TITLE
Retry cpanm install in the xslate & mojolicious integrations' Docker images

### DIFF
--- a/integrations/mojolicious/Dockerfile
+++ b/integrations/mojolicious/Dockerfile
@@ -11,7 +11,16 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 # Install CPAN deps into a self-contained prefix so the runtime stage can copy
 # a single directory instead of guessing which /usr/local/... paths exist.
-RUN cpanm --notest --local-lib=/opt/perl-deps Mojolicious
+# Retried: the CPAN mirror occasionally serves a truncated/corrupt tarball,
+# which cpanm treats as a hard failure. Clear its download cache between
+# attempts so a retry re-fetches instead of re-unpacking the same bad file.
+RUN for i in 1 2 3; do \
+      cpanm --notest --local-lib=/opt/perl-deps Mojolicious && exit 0; \
+      echo "cpanm attempt $i failed, retrying..." >&2; \
+      rm -rf /opt/perl-deps ~/.cpanm; \
+      sleep 5; \
+    done; \
+    exit 1
 
 FROM perl:5.38-slim
 RUN useradd -m -r -s /bin/false app

--- a/integrations/mojolicious/Dockerfile.dev
+++ b/integrations/mojolicious/Dockerfile.dev
@@ -11,7 +11,16 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends make gcc libc-dev \
  && rm -rf /var/lib/apt/lists/*
 
-RUN cpanm --notest Mojolicious
+# Retried: the CPAN mirror occasionally serves a truncated/corrupt tarball,
+# which cpanm treats as a hard failure. Clear its download cache between
+# attempts so a retry re-fetches instead of re-unpacking the same bad file.
+RUN for i in 1 2 3; do \
+      cpanm --notest Mojolicious && exit 0; \
+      echo "cpanm attempt $i failed, retrying..." >&2; \
+      rm -rf ~/.cpanm; \
+      sleep 5; \
+    done; \
+    exit 1
 
 WORKDIR /workspace/integrations/mojolicious
 

--- a/integrations/xslate/Dockerfile
+++ b/integrations/xslate/Dockerfile
@@ -12,7 +12,17 @@ RUN apt-get update \
 # Install CPAN deps into a self-contained prefix the runtime stage copies whole.
 # Text::Xslate is XS (needs the compiler above); Starman is the PSGI server
 # (prefork, so the SSE routes — AI chat, dev reload — don't block other workers).
-RUN cpanm --notest --local-lib=/opt/perl-deps Text::Xslate Plack Starman
+# Retried: the CPAN mirror occasionally serves a truncated/corrupt tarball
+# (e.g. a gzip that fails to unpack), which cpanm treats as a hard failure.
+# Clear its download cache between attempts so a retry re-fetches instead of
+# re-unpacking the same bad file.
+RUN for i in 1 2 3; do \
+      cpanm --notest --local-lib=/opt/perl-deps Text::Xslate Plack Starman && exit 0; \
+      echo "cpanm attempt $i failed, retrying..." >&2; \
+      rm -rf /opt/perl-deps ~/.cpanm; \
+      sleep 5; \
+    done; \
+    exit 1
 
 FROM perl:5.40-slim
 RUN useradd -m -r -s /bin/false app

--- a/integrations/xslate/Dockerfile.dev
+++ b/integrations/xslate/Dockerfile.dev
@@ -11,7 +11,16 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends make gcc libc-dev \
  && rm -rf /var/lib/apt/lists/*
 
-RUN cpanm --notest Text::Xslate Plack Starman
+# Retried: the CPAN mirror occasionally serves a truncated/corrupt tarball,
+# which cpanm treats as a hard failure. Clear its download cache between
+# attempts so a retry re-fetches instead of re-unpacking the same bad file.
+RUN for i in 1 2 3; do \
+      cpanm --notest Text::Xslate Plack Starman && exit 0; \
+      echo "cpanm attempt $i failed, retrying..." >&2; \
+      rm -rf ~/.cpanm; \
+      sleep 5; \
+    done; \
+    exit 1
 
 WORKDIR /workspace/integrations/xslate
 


### PR DESCRIPTION
## Summary

`main`'s `Deploy Sites` workflow failed twice in a row on `deploy-integrations-xslate`
(run [34721646388](https://github.com/piconic-ai/barefootjs/actions/runs/34721646388),
attempts 1 and 2, both after PR #2957 merged). The Docker build's
`cpanm --notest --local-lib=/opt/perl-deps Text::Xslate Plack Starman` step failed
because the CPAN mirror served a truncated/corrupt tarball for `Cpanel-JSON-XS-4.52`:

```
gzip: stdin: not in gzip format
! Failed to unpack Cpanel-JSON-XS-4.52.tar.gz: no directory
! Installing the dependencies failed: Module 'Cpanel::JSON::XS' is not installed
```

This cascades: `Cpanel::JSON::XS` → `JSON::MaybeXS` → `HTTP::Entity::Parser` → `Plack`
→ `Starman`, so the whole install aborts. Neither the merged PR nor any recent change
touches this Dockerfile — it's CPAN mirror flakiness, not a code regression, but the
Dockerfile had no retry so every hit of that flakiness takes `main` red.

pullfrog's review on this PR also flagged that `integrations/mojolicious/` has the
identical unguarded `cpanm` pattern, subject to the same failure mode in the same
workflow — folded into this PR rather than filed as a separate follow-up.

- Wrapped the `cpanm` install in `integrations/xslate/Dockerfile` (build stage),
  `integrations/xslate/Dockerfile.dev`, `integrations/mojolicious/Dockerfile` (build
  stage), and `integrations/mojolicious/Dockerfile.dev` in a 3-attempt retry loop.
- Clear cpanm's download cache (`~/.cpanm`) between attempts so a retry re-fetches
  the tarball instead of re-unpacking the same corrupt file from cache.

## Test plan

- [x] Verified the retry-loop shell syntax with `bash -n`.
- [ ] Could not run a full `docker build` locally (no Docker daemon available in this
      session) — please confirm `deploy-integrations-xslate` and
      `deploy-integrations-mojolicious` go green on this PR's CI run (or the next
      `main` deploy) before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ERHEWeUqM6YY4V2uzJ4gwa