### PR TITLE
Fix a same-tag-name multi-root cond branch losing its extra siblings on swap

### DIFF
--- a/.changeset/multi-root-cond-same-tag.md
+++ b/.changeset/multi-root-cond-same-tag.md
@@ -1,0 +1,9 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Fixes #2960: a ternary conditional whose one arm is a single element and whose other arm is a multi-root JSX fragment now compiles correctly even when the fragment's roots share the SAME tag name (e.g. `cond ? <div>...</div> : (<><div id="before">...</div><div id="after">...</div></>)`).
+
+`addCondAttrToTemplate`'s `isSingleRootElement` helper decided "single root" by checking whether the branch's HTML string ended with a closing tag of the root's own tag name — a check that a second, unrelated sibling of the same tag name satisfies just as well as a genuine single root's own closing tag. Misclassified this way, the multi-root branch got `bf-c="<id>"` stamped onto only its first element instead of being comment-wrapped, which routed the client runtime's branch swap (`insert()`) through `updateElementConditional`'s `fragment.firstChild`-only path and silently dropped every sibling after the first on a live toggle.
+
+`isSingleRootElement` now walks top-level tags tracking nesting depth instead of that lexical shortcut, while keeping the same entry/exit guards as before so a shape the `bf-c` splice can't stamp (a self-closing root, a hyphenated custom-element tag) still falls through to comment-wrap exactly as it did previously.

--- a/packages/client/__tests__/runtime/issue-2960-multi-root-cond-branch-swap.test.ts
+++ b/packages/client/__tests__/runtime/issue-2960-multi-root-cond-branch-swap.test.ts
@@ -1,0 +1,65 @@
+/**
+ * #2960 — end-to-end runtime pin for the compiler-level fix in
+ * `addCondAttrToTemplate`/`isSingleRootElement` (jsx package). Exercises
+ * `insert()` with exactly the template shape the compiler now emits for
+ * `cond ? <div id="welcome">Welcome</div> : (<><div id="before">...</div><div id="after">...</div></>)`
+ * — a single-element `bf-c` branch on one side, a comment-marker-wrapped
+ * multi-root branch on the other — and asserts a live branch swap keeps
+ * every node of the multi-root branch, not just the first.
+ *
+ * Before the compiler fix, the multi-root branch (two `<div>`s, same tag
+ * name) was wrongly classified as a single root and compiled with
+ * `bf-c="<id>"` on only the first `<div>` instead of comment markers.
+ * That routed the swap through `updateElementConditional`, whose
+ * `fragment.firstChild` kept only `#before` and silently dropped
+ * `#after`. This test locks in the corrected marker-wrapped shape, which
+ * `updateFragmentConditional` already moves node-by-node (no change
+ * needed there).
+ */
+import { describe, test, expect, beforeAll } from 'bun:test'
+import { insert } from '../../src/runtime/insert'
+import { createSignal } from '../../src/reactive'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+
+beforeAll(() => {
+  if (typeof window === 'undefined') {
+    GlobalRegistrator.register()
+  }
+})
+
+describe('#2960: asymmetric single-element vs. same-tag-name multi-root cond branch', () => {
+  test('swapping into the multi-root branch keeps every sibling', () => {
+    document.body.innerHTML = `
+      <div bf-s="Test_1">
+        <div bf-c="s1" id="welcome">Welcome</div>
+      </div>
+    `
+    const scope = document.querySelector('[bf-s]')!
+    const [open, setOpen] = createSignal(false)
+
+    insert(
+      scope,
+      's1',
+      () => open() === false,
+      { template: () => '<div bf-c="s1" id="welcome">Welcome</div>', bindEvents: () => {} },
+      {
+        template: () =>
+          '<!--bf-cond-start:s1--><div id="before">before</div><div id="after">after</div><!--bf-cond-end:s1-->',
+        bindEvents: () => {},
+      }
+    )
+
+    expect(scope.querySelector('#welcome')).not.toBeNull()
+
+    setOpen(true)
+
+    expect(scope.querySelector('#before')?.textContent).toBe('before')
+    expect(scope.querySelector('#after')?.textContent).toBe('after')
+
+    // Swap back: the multi-root branch's nodes are removed cleanly.
+    setOpen(false)
+    expect(scope.querySelector('#welcome')?.textContent).toBe('Welcome')
+    expect(scope.querySelector('#before')).toBeNull()
+    expect(scope.querySelector('#after')).toBeNull()
+  })
+})

--- a/packages/jsx/src/__tests__/issue-2960-multi-root-cond-same-tag.test.ts
+++ b/packages/jsx/src/__tests__/issue-2960-multi-root-cond-same-tag.test.ts
@@ -117,4 +117,25 @@ describe('#2960: multi-root cond branch whose roots share a tag name', () => {
     expect(result).toContain('bf-c="s0"')
     expect(result).not.toContain('bf-cond-start:')
   })
+
+  // A self-closing/void root followed by a real sibling element
+  // (`<input .../><label>...</label>`, todo-app's "mark all as complete"
+  // branch) is genuinely two roots. The whole-string self-closing check
+  // only catches a self-closing tag with NOTHING else in the string, so
+  // this shape still reaches the depth-tracking walk — an earlier version
+  // of that walk unconditionally `continue`d past every self-closing tag
+  // on the theory that one could never be the outermost token by the time
+  // the walk runs, which is wrong: the initial tag-name gate only checks
+  // the tag name and the character right after it, not whether the tag
+  // later turns out to self-close. That version silently merged the
+  // `<input/>` and `<label>` into a false single root, stamping `bf-c`
+  // onto only the `<input/>` and dropping `<label>` on a live swap.
+  // Caught by `generate-expected-html.ts` drifting the `todo-app` fixture.
+  test('a self-closing root followed by a sibling element is multi-root, not single', () => {
+    const html = '<input id="toggle-all" class="toggle-all" type="checkbox" bf="s2" /><label for="toggle-all">Mark all as complete</label>'
+    const result = addCondAttrToTemplate(html, 's1')
+    expect(result).toContain('bf-cond-start:s1')
+    expect(result).toContain('bf-cond-end:s1')
+    expect(result).not.toContain('bf-c=')
+  })
 })

--- a/packages/jsx/src/__tests__/issue-2960-multi-root-cond-same-tag.test.ts
+++ b/packages/jsx/src/__tests__/issue-2960-multi-root-cond-same-tag.test.ts
@@ -102,4 +102,19 @@ describe('#2960: multi-root cond branch whose roots share a tag name', () => {
       })
     }
   })
+
+  // The depth-tracking walk must not treat BarefootJS's own marker
+  // comments (`<!--bf:sN-->`, its `<!--/-->` pair) as if they were real
+  // tags — an earlier version of this fix's tag-matching regex matched
+  // any `<...>` run indiscriminately, so a perfectly ordinary single-root
+  // branch with an internal reactive text slot got miscounted into an
+  // unbalanced depth and wrongly comment-wrapped instead of getting
+  // `bf-c`. Caught by `doc-examples.test.ts`'s snapshot drifting on the
+  // `count() > 0 ? <p>...</p> : <p>No items</p>` example.
+  test('a single root containing internal bf: slot marker comments still gets bf-c, not comment-wrap', () => {
+    const html = '<p bf="s2"><!--bf:s1-->${__bfSlot(count(), __slots)}<!--/--> items</p>'
+    const result = addCondAttrToTemplate(html, 's0')
+    expect(result).toContain('bf-c="s0"')
+    expect(result).not.toContain('bf-cond-start:')
+  })
 })

--- a/packages/jsx/src/__tests__/issue-2960-multi-root-cond-same-tag.test.ts
+++ b/packages/jsx/src/__tests__/issue-2960-multi-root-cond-same-tag.test.ts
@@ -1,0 +1,105 @@
+/**
+ * #2960 — `addCondAttrToTemplate`'s `isSingleRootElement` heuristic
+ * mis-classified a multi-root ternary branch as a single element root
+ * whenever its LAST element happened to share its FIRST element's tag
+ * name (`<div>...</div><div>...</div>`): the check was "does the string
+ * end with a closing tag of the root's own tag name", which a second,
+ * unrelated sibling of the same tag name satisfies just as well as a
+ * genuine single root's own closing tag.
+ *
+ * Compiled wrong, this stamps `bf-c="<id>"` onto only the first element
+ * instead of comment-wrapping the whole branch — which routes the
+ * runtime's branch swap through `insert()`'s `updateElementConditional`
+ * (`fragment.firstChild`-only) instead of `updateFragmentConditional`
+ * (which moves every top-level node), silently dropping every sibling
+ * but the first on a live branch swap.
+ */
+import { describe, test, expect } from 'bun:test'
+import { compileJSX } from '../compiler'
+import { TestAdapter } from '../adapters/test-adapter'
+import { addCondAttrToTemplate } from '../ir-to-client-js/html-template'
+
+const adapter = new TestAdapter()
+
+describe('#2960: multi-root cond branch whose roots share a tag name', () => {
+  test('comment-wraps a same-tag-name multi-root branch instead of stamping bf-c on only the first element', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Repro() {
+        const [open, setOpen] = createSignal(false)
+        return (
+          <div>
+            <button onClick={() => setOpen(true)}>open</button>
+            {open() === false ? (
+              <div id="welcome">Welcome</div>
+            ) : (
+              <>
+                <div id="before">before</div>
+                <div id="after">after</div>
+              </>
+            )}
+          </div>
+        )
+      }
+    `
+
+    const result = compileJSX(source, 'Repro.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+
+    // The multi-root branch must be comment-wrapped ...
+    expect(clientJs!.content).toContain('bf-cond-start:')
+    expect(clientJs!.content).toContain('bf-cond-end:')
+    // ... and BOTH of its sibling elements must appear inside the
+    // template literal, not just the first one.
+    expect(clientJs!.content).toMatch(/id=\\?"before\\?"/)
+    expect(clientJs!.content).toMatch(/id=\\?"after\\?"/)
+  })
+
+  test('a genuine single-root branch (no same-tag sibling) still gets bf-c, not comment markers', () => {
+    const source = `
+      'use client'
+      import { createSignal } from '@barefootjs/client'
+
+      export function Simple() {
+        const [on, setOn] = createSignal(false)
+        return <div>{on() ? <span id="a">A</span> : <span id="b">B</span>}</div>
+      }
+    `
+
+    const result = compileJSX(source, 'Simple.tsx', { adapter })
+    expect(result.errors).toHaveLength(0)
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    expect(clientJs!.content).toContain('bf-c=')
+    expect(clientJs!.content).not.toContain('bf-cond-start:')
+  })
+
+  // The depth-tracking fix above must not widen which shapes are treated
+  // as "single root" beyond what the sibling `bf-c` splice regex
+  // (`html.replace(/^(<\w+)(\s|>)/, ...)`) can actually stamp — a
+  // self-closing root's own `/` or a hyphenated custom-element tag name
+  // both fail that splice. Every one of these must still come back
+  // comment-wrapped (never bare, unmodified HTML with neither `bf-c` nor
+  // markers, which would make `insert()` unable to find the branch at all).
+  describe('does not widen single-root detection into shapes the bf-c splice cannot stamp', () => {
+    const unstampable = [
+      ['<input/>', 'self-closing void element root'],
+      ['<my-widget>a</my-widget>', 'hyphenated custom-element root'],
+      ['<my-widget>a</my-widget><my-widget>b</my-widget>', 'multi-root, same hyphenated tag'],
+    ] as const
+
+    for (const [html, label] of unstampable) {
+      test(label, () => {
+        const result = addCondAttrToTemplate(html, 'c1')
+        expect(result).toContain('bf-cond-start:c1')
+        expect(result).toContain('bf-cond-end:c1')
+      })
+    }
+  })
+})

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -1621,17 +1621,64 @@ export function addCondAttrToTemplate(html: string, condId: string): string {
   return `<!--bf-cond-start:${condId}-->${html}<!--bf-cond-end:${condId}-->`
 }
 
-/** Check if HTML string has a single root element (not multiple siblings). */
+/**
+ * Check if HTML string has a single root element (not multiple siblings).
+ *
+ * Walks top-level tags tracking nesting depth rather than checking only
+ * "does the string end with a closing tag of the root's tag name" — that
+ * lexical shortcut matches `<div id="before">before</div><div id="after">after</div>`
+ * (two sibling `<div>`s) as a false single root, because the STRING happens
+ * to end in `</div>`, the same tag name the root opened with, even though
+ * that closing tag belongs to the second, unrelated div (#2960). A
+ * multi-root branch wrongly classified here gets `bf-c="<id>"` stamped
+ * onto only its first element instead of being comment-wrapped, and
+ * `insert()`'s runtime then drops every sibling but the first on a branch
+ * swap (`updateElementConditional`'s `fragment.firstChild`).
+ */
 function isSingleRootElement(html: string): boolean {
-  // Match the opening tag name, then find its closing tag
-  const match = html.match(/^<(\w+)[\s>]/)
+  const trimmed = html.trim()
+  // Same gate as before this fix: only a tag name matching `\w+`,
+  // followed immediately by whitespace or `>`, is recognized here — that
+  // is exactly the shape `addCondAttrToTemplate`'s splice regex
+  // (`html.replace(/^(<\w+)(\s|>)/, ...)`) can stamp `bf-c` onto. A root
+  // this gate doesn't recognize (a self-closing tag's own `/`, a
+  // hyphenated custom-element tag) falls through to `false`
+  // (comment-wrap) unchanged from before — widening this gate without
+  // also teaching the splice regex the same shapes would silently drop
+  // BOTH the `bf-c` stamp and the comment-wrap fallback for those roots.
+  const match = trimmed.match(/^<(\w+)[\s>]/)
   if (!match) return false
-  const tag = match[1]
-  // Self-closing tags like <br/>, <input/>
-  if (/^<\w+[^>]*\/>$/.test(html.trim())) return true
-  // Check that the last closing tag matches and nothing follows it
-  const closingPattern = new RegExp(`</${tag}>\\s*$`)
-  return closingPattern.test(html.trim())
+  // Self-closing tags like <br/>, <input/> with nothing else.
+  if (/^<\w+[^>]*\/>$/.test(trimmed)) return true
+
+  // Walk top-level tags tracking nesting depth, rather than checking only
+  // "does the string end with a closing tag of the root's tag name" —
+  // that lexical shortcut matches
+  // `<div id="before">before</div><div id="after">after</div>` (two
+  // sibling `<div>`s) as a false single root, because the STRING happens
+  // to end in `</div>`, the same tag name the root opened with, even
+  // though that closing tag belongs to the second, unrelated div (#2960).
+  // A multi-root branch wrongly classified here gets `bf-c="<id>"`
+  // stamped onto only its first element instead of being comment-wrapped,
+  // and `insert()`'s runtime then drops every sibling but the first on a
+  // branch swap (`updateElementConditional`'s `fragment.firstChild`).
+  const tagPattern = /<\/?[^\s/>]+[^>]*>/g
+  let depth = 0
+  let tagMatch: RegExpExecArray | null
+  while ((tagMatch = tagPattern.exec(trimmed))) {
+    const raw = tagMatch[0]
+    // Nested void/self-closing tag: depth unchanged. Unreachable at
+    // depth 0 — the two guards above already resolved every shape where
+    // a self-closing tag could be the outermost token.
+    if (raw.endsWith('/>')) continue
+    depth += raw.startsWith('</') ? -1 : 1
+    if (depth === 0) {
+      // Back to depth 0: the root element's own closing tag. Single root
+      // only if nothing else follows it.
+      return tagPattern.lastIndex === trimmed.length
+    }
+  }
+  return false
 }
 
 /**

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -1675,10 +1675,21 @@ function isSingleRootElement(html: string): boolean {
   while ((tagMatch = tagPattern.exec(trimmed))) {
     const raw = tagMatch[0]
     if (raw.startsWith('<!--')) continue // HTML comment, not a tag: depth unchanged
-    // Nested void/self-closing tag: depth unchanged. Unreachable at
-    // depth 0 — the two guards above already resolved every shape where
-    // a self-closing tag could be the outermost token.
-    if (raw.endsWith('/>')) continue
+    if (raw.endsWith('/>')) {
+      // Self-closing/void tag (e.g. `<input .../>`). The whole-string
+      // check above only catches a self-closing tag with NOTHING else in
+      // the string — a self-closing root FOLLOWED by more content (e.g.
+      // `<input .../><label>...</label>`, a genuine two-root branch) still
+      // reaches here with the guard above already satisfied (it only
+      // looks at the tag name and the very next character, not whether
+      // the tag turns out to self-close). At depth 0 this tag completes a
+      // whole top-level unit by itself, so treat it exactly like any
+      // other tag's closing point: single root only if nothing follows.
+      // Nested inside another element (depth > 0) it's just an ordinary
+      // child and doesn't affect depth.
+      if (depth === 0) return tagPattern.lastIndex === trimmed.length
+      continue
+    }
     depth += raw.startsWith('</') ? -1 : 1
     if (depth === 0) {
       // Back to depth 0: the root element's own closing tag. Single root

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -1662,11 +1662,19 @@ function isSingleRootElement(html: string): boolean {
   // stamped onto only its first element instead of being comment-wrapped,
   // and `insert()`'s runtime then drops every sibling but the first on a
   // branch swap (`updateElementConditional`'s `fragment.firstChild`).
-  const tagPattern = /<\/?[^\s/>]+[^>]*>/g
+  // The comment alternative must come first so it wins at a `<!--`
+  // position — without it, a BarefootJS marker comment like
+  // `<!--bf:s1-->`/`<!--/-->` (a reactive text slot nested inside a
+  // genuine single root) matches the generic tag alternative too (its
+  // body has no `\s`, `/` or `>` before the closing `-->`) and gets
+  // miscounted as an opening tag, throwing off the depth count for
+  // perfectly ordinary single-root branches.
+  const tagPattern = /<!--[\s\S]*?-->|<\/?[^\s/>]+[^>]*>/g
   let depth = 0
   let tagMatch: RegExpExecArray | null
   while ((tagMatch = tagPattern.exec(trimmed))) {
     const raw = tagMatch[0]
+    if (raw.startsWith('<!--')) continue // HTML comment, not a tag: depth unchanged
     // Nested void/self-closing tag: depth unchanged. Unreachable at
     // depth 0 — the two guards above already resolved every shape where
     // a self-closing tag could be the outermost token.

--- a/packages/jsx/src/ir-to-client-js/html-template.ts
+++ b/packages/jsx/src/ir-to-client-js/html-template.ts
@@ -1651,18 +1651,8 @@ function isSingleRootElement(html: string): boolean {
   // Self-closing tags like <br/>, <input/> with nothing else.
   if (/^<\w+[^>]*\/>$/.test(trimmed)) return true
 
-  // Walk top-level tags tracking nesting depth, rather than checking only
-  // "does the string end with a closing tag of the root's tag name" —
-  // that lexical shortcut matches
-  // `<div id="before">before</div><div id="after">after</div>` (two
-  // sibling `<div>`s) as a false single root, because the STRING happens
-  // to end in `</div>`, the same tag name the root opened with, even
-  // though that closing tag belongs to the second, unrelated div (#2960).
-  // A multi-root branch wrongly classified here gets `bf-c="<id>"`
-  // stamped onto only its first element instead of being comment-wrapped,
-  // and `insert()`'s runtime then drops every sibling but the first on a
-  // branch swap (`updateElementConditional`'s `fragment.firstChild`).
-  // The comment alternative must come first so it wins at a `<!--`
+  // Walk top-level tags tracking nesting depth — see the docstring above
+  // for why (#2960). The comment alternative must come first so it wins at a `<!--`
   // position — without it, a BarefootJS marker comment like
   // `<!--bf:s1-->`/`<!--/-->` (a reactive text slot nested inside a
   // genuine single root) matches the generic tag alternative too (its


### PR DESCRIPTION
## Summary

Fixes #2960.

`addCondAttrToTemplate`'s `isSingleRootElement` heuristic decided "single root" by checking whether the branch's HTML string **ended with a closing tag of the root's own tag name**. A second, unrelated sibling of the *same* tag name (`<div id="before">before</div><div id="after">after</div>`) satisfies that check just as well as a genuine single root's own closing tag, so the branch got `bf-c="<id>"` stamped onto only its first element instead of being comment-wrapped.

That misclassification then fed `insert()`'s own `isFragmentCond` probe (`packages/client/src/runtime/insert.ts`), which trusts the compiled markup: with no `bf-cond-start:`/`bf-cond-end:` markers present, a live branch swap into that arm routed through `updateElementConditional`, whose `fragment.firstChild` kept only the first parsed node and silently dropped every sibling after it.

## Fix

`isSingleRootElement` now walks top-level tags tracking nesting depth instead of the "ends with the right closing tag" shortcut, while keeping the **exact same entry/exit guards** as before (the `\w+`-tag-name gate, the whole-string self-closing check) — so a shape the sibling `bf-c` splice regex can't stamp (a self-closing root, a hyphenated custom-element tag) still falls through to comment-wrap exactly as it did previously. I diffed the new implementation against the old one across a matrix of single-root / multi-root / self-closing / hyphenated-tag shapes and confirmed byte-identical output for every case except the one it was wrong about.

## Tests

- `packages/jsx/src/__tests__/issue-2960-multi-root-cond-same-tag.test.ts` — compiler-level pin: asserts the compiled client JS comment-wraps the same-tag-name multi-root branch, plus a safety-net section pinning the "must not widen into a shape the splice can't stamp" invariant above.
- `packages/client/__tests__/runtime/issue-2960-multi-root-cond-branch-swap.test.ts` — runtime-level pin: exercises `insert()` with exactly the corrected compiled shape and asserts both `#before` and `#after` survive a live branch swap in both directions.

## Verification

- `bun run packages/adapter-tests/scripts/generate-expected-html.ts` reports **zero fixture drift** (identical `352 updated, 13 failed, 54 skipped` on this branch and on pristine `main` — the 13 failures are a pre-existing, environment-only `Cannot find module '@barefootjs/client'` issue in this checkout, unrelated to this change).
- Full `packages/jsx/src/__tests__` suite: same pre-existing failures reproduce identically on `main` (unrelated resolver/checker tests); no new failures.
- Full `packages/client/__tests__` suite: same 3 pre-existing failures reproduce identically on `main`; no new failures.
- `packages/adapter-tests/src/__tests__/csr-conformance.test.ts`: 389/389 pass.

## Stack

This is the bottom of a 2-PR stack; #2959's fix (also in `insert.ts`'s neighborhood) is stacked on top of this branch in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HtBG2rHUtMYwcfESMbiVS7

---
_Generated by [Claude Code](https://claude.ai/code/session_01HtBG2rHUtMYwcfESMbiVS7)_