### PR TITLE
Fix a fragment-root child's own conditional markers being erased by its parent's branch swap

### DIFF
--- a/.changeset/fragment-root-child-cond-marker-strip.md
+++ b/.changeset/fragment-root-child-cond-marker-strip.md
@@ -1,0 +1,9 @@
+---
+"@barefootjs/client": patch
+---
+
+Fixes #2959: a `'use client'` fragment-root child component mounted as an ordinary nested child inside a parent's own fragment-conditional branch (the plain `t && initChild(name, t, props)` call a compiled `bindEvents` makes, not `upsertChild`/`materializeComponent`) could have its OWN internal conditional permanently stop updating after the very first render, with no error and no warning.
+
+Root cause: `updateFragmentConditional` (`packages/client/src/runtime/insert.ts`) splices a branch's freshly parsed content between the real, persistent `bf-cond-start:<id>`/`bf-cond-end:<id>` DOM markers already bracketing the insertion point, after first stripping the branch's own redundant copy of that same wrapper (`addCondAttrToTemplate` always embeds one in the template). The old filter dropped ANY top-level comment whose value merely started with `bf-cond-`, not only that specific pair — so a fragment-root child mounted inside the branch (no wrapper element of its own) had ITS OWN `bf-cond-start:<childId>`/`bf-cond-end:<childId>` markers erased from the DOM outright, since they sit as top-level siblings of its other output. With no markers left anywhere, the child's own `insert()` call could never find its start comment again on any later toggle.
+
+Now only the parsed fragment's own first/last child is stripped, and only when it matches the current id's marker value exactly.

--- a/packages/client/__tests__/runtime/issue-2959-fragment-root-child-cond-in-branch-swap.test.ts
+++ b/packages/client/__tests__/runtime/issue-2959-fragment-root-child-cond-in-branch-swap.test.ts
@@ -1,0 +1,149 @@
+/**
+ * #2959 — a `'use client'` fragment-root child component mounted as an
+ * ordinary nested child inside a PARENT's own fragment-conditional branch
+ * (via the plain `t && initChild(name, t, props)` call a compiled
+ * `bindEvents` makes — see `control-flow/stringify/insert.ts`'s
+ * `emitArmBody`, NOT `upsertChild`/`materializeComponent`) could have its
+ * OWN internal conditional permanently stop updating after the very first
+ * render, silently.
+ *
+ * Root cause (`updateFragmentConditional`, `insert.ts`): the branch's own
+ * template embeds a redundant `<!--bf-cond-start:id-->...<!--bf-cond-end:id-->`
+ * wrapper around its content (`addCondAttrToTemplate`), which must be
+ * stripped before splicing the content between the REAL, persistent DOM
+ * markers already bracketing the insertion point. The old filter dropped
+ * ANY top-level comment whose value started with `bf-cond-`, not just
+ * that specific pair — so when a fragment-root child with no wrapper
+ * element of its own (`StatusBarCopy` below) sits inside the branch, ITS
+ * OWN `bf-cond-start:<childId>`/`bf-cond-end:<childId>` markers (top-level
+ * siblings of its `<footer>`, since it has no wrapper) were erased from
+ * the DOM outright. With no markers left to find, the child's own
+ * `insert()` call could never locate its start comment again — a
+ * permanent, silent no-op on every future toggle.
+ */
+import { describe, test, expect, beforeAll, beforeEach } from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+import { compileJSX } from '../../../jsx/src/compiler'
+import { TestAdapter } from '../../../jsx/src/adapters/test-adapter'
+import { writeFileSync, mkdtempSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+beforeAll(() => {
+  if (typeof window === 'undefined') GlobalRegistrator.register()
+})
+
+const adapter = new TestAdapter()
+const runtimePath = join(__dirname, '../../src/runtime/index.ts')
+
+function clientJsFor(source: string, filename: string): string {
+  const result = compileJSX(source, filename, { adapter })
+  const errors = result.errors.filter(e => e.severity === 'error')
+  if (errors.length > 0) {
+    throw new Error(`Compile errors in ${filename}:\n${errors.map(e => `${e.code}: ${e.message}`).join('\n')}`)
+  }
+  const clientJs = result.files.find(f => f.type === 'clientJs')?.content
+  if (!clientJs) throw new Error(`No client JS for ${filename}`)
+  return clientJs
+    .replace(/from\s+['"]@barefootjs\/client\/runtime['"]/g, `from '${runtimePath}'`)
+    .replace(/^import '\/\* @bf-child:\w+ \*\/'\n/gm, '')
+}
+
+async function loadComponent(source: string, filename: string): Promise<void> {
+  const dir = mkdtempSync(join(tmpdir(), 'bf-2959-'))
+  const file = join(dir, `${filename.replace(/\W/g, '_')}_${Math.random().toString(36).slice(2)}.mjs`)
+  writeFileSync(file, clientJsFor(source, filename))
+  await import(file)
+}
+
+const WELCOME_SRC = `'use client'
+export function Welcome2959() {
+  return <div id="welcome-2959">Welcome</div>
+}
+`
+
+// Fragment-root: its render has no single wrapping element — `<footer>`
+// sits alongside its own conditional's markers as top-level siblings,
+// exactly the shape #2959 needs.
+const STATUS_BAR_SRC = `'use client'
+export interface StatusBarProps2959 {
+  errorMessage: string | null
+  statusMessage: string
+}
+export function StatusBarCopy2959(props: StatusBarProps2959) {
+  return (
+    <>
+      {props.errorMessage ? (
+        <div id="banner-copy-2959">{props.errorMessage}</div>
+      ) : null}
+      <footer id="footer-copy-2959">{props.statusMessage}</footer>
+    </>
+  )
+}
+`
+
+const REPRO_SRC = `'use client'
+import { createSignal } from '@barefootjs/client'
+import { StatusBarCopy2959 } from './StatusBarCopy2959'
+import { Welcome2959 } from './Welcome2959'
+
+export function Repro2959() {
+  const [deckOpen, setDeckOpen] = createSignal(false)
+  const [errorMessage, setErrorMessage] = createSignal<string | null>(null)
+  const [statusMessage] = createSignal('Opened deck.md')
+
+  return (
+    <div>
+      <button id="open-deck-2959" onClick={() => setDeckOpen(true)}>open deck</button>
+      <button id="trigger-2959" onClick={() => setErrorMessage('boom')}>trigger error</button>
+      {deckOpen() === false ? (
+        <Welcome2959 />
+      ) : (
+        <>
+          <div id="before-2959">before</div>
+          <StatusBarCopy2959 errorMessage={errorMessage()} statusMessage={statusMessage()} />
+          <div id="after-2959">after</div>
+        </>
+      )}
+    </div>
+  )
+}
+`
+
+describe('#2959 — fragment-root child mounted plainly inside a parent branch keeps its own conditional live', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  test('the child\'s own conditional still updates after the parent branch swap that mounted it', async () => {
+    await loadComponent(WELCOME_SRC, 'Welcome2959.tsx')
+    await loadComponent(STATUS_BAR_SRC, 'StatusBarCopy2959.tsx')
+    await loadComponent(REPRO_SRC, 'Repro2959.tsx')
+
+    const { createComponent } = await import(runtimePath)
+    const el = createComponent('Repro2959', {}) as HTMLElement
+    document.body.appendChild(el)
+
+    expect(el.querySelector('#welcome-2959')).not.toBeNull()
+
+    // Swap the parent's OWN conditional into the branch that mounts
+    // StatusBarCopy2959 as a plain nested child.
+    ;(el.querySelector('#open-deck-2959') as HTMLElement).click()
+
+    expect(el.querySelector('#welcome-2959')).toBeNull()
+    expect(el.querySelector('#before-2959')).not.toBeNull()
+    expect(el.querySelector('#footer-copy-2959')?.textContent).toBe('Opened deck.md')
+    // Null branch: the child's own conditional has not fired yet.
+    expect(el.querySelector('#banner-copy-2959')).toBeNull()
+
+    // Trigger the CHILD's own internal conditional. Before the fix, this
+    // permanently no-oped because the child's own bf-cond-start/end
+    // markers were erased from the DOM by the parent's branch-swap splice.
+    ;(el.querySelector('#trigger-2959') as HTMLElement).click()
+
+    expect(el.querySelector('#banner-copy-2959')?.textContent).toBe('boom')
+    // Every other sibling in the parent's branch is still intact.
+    expect(el.querySelector('#before-2959')).not.toBeNull()
+    expect(el.querySelector('#after-2959')).not.toBeNull()
+  })
+})

--- a/packages/client/src/runtime/insert.ts
+++ b/packages/client/src/runtime/insert.ts
@@ -504,6 +504,30 @@ function updateFragmentConditional(region: CondRegion, id: string, result: Branc
       ? startComment.parentNode
       : null
     const fragment = spliceSlots(parseHTML(html, insertParent), slots)
+    // `result.html` embeds its OWN `<!--bf-cond-start:id-->`/
+    // `<!--bf-cond-end:id-->` wrapper (`addCondAttrToTemplate`) — a static
+    // hint baked into every fragment-cond template, redundant here since
+    // the REAL, persistent DOM markers (`startComment`/`endComment`) already
+    // bracket the insertion point. Strip only THAT specific pair — the
+    // parsed fragment's own first/last child, matched by exact value —
+    // before moving everything else in.
+    //
+    // A blanket "any top-level comment whose value starts with bf-cond-"
+    // filter (the previous check here) went further than that and silently
+    // dropped OTHER conditionals' markers too: a fragment-root child
+    // component mounted directly inside this branch (no wrapper element of
+    // its own, e.g. `t && initChild(name, t, props)`) puts ITS OWN
+    // `bf-cond-start:<childId>`/`bf-cond-end:<childId>` markers as
+    // top-level siblings right alongside its other output — indistinguishable
+    // from this conditional's own wrapper by a prefix check. Erasing them
+    // left the child's own conditional with no DOM markers to find ever
+    // again, permanently and silently freezing its branch swap (#2959).
+    if (fragment.firstChild?.nodeType === 8 && fragment.firstChild.nodeValue === startMarker) {
+      fragment.removeChild(fragment.firstChild)
+    }
+    if (fragment.lastChild?.nodeType === 8 && fragment.lastChild.nodeValue === endMarker) {
+      fragment.removeChild(fragment.lastChild)
+    }
     // Move parsed nodes by identity rather than cloning. A slot Node
     // nested inside an element wrapper (e.g. `<div>${__bfSlot(...)}</div>`)
     // would otherwise be cloned along with its parent, dropping event
@@ -512,9 +536,7 @@ function updateFragmentConditional(region: CondRegion, id: string, result: Branc
     let child = fragment.firstChild
     while (child) {
       const next: ChildNode | null = child.nextSibling
-      if (!(child.nodeType === 8 && child.nodeValue?.startsWith('bf-cond-'))) {
-        startComment!.parentNode?.insertBefore(child, endComment)
-      }
+      startComment!.parentNode?.insertBefore(child, endComment)
       child = next
     }
   } else if (condEl) {


### PR DESCRIPTION
## Summary

Fixes #2959. **Stacked on #2961** — please review/merge that one first.

A `'use client'` fragment-root child mounted as an ordinary nested child (`t && initChild(name, t, props)`, the plain call a compiled parent's `bindEvents` makes — see `emitArmBody` in `packages/jsx/src/ir-to-client-js/control-flow/stringify/insert.ts`, **not** `upsertChild`/`materializeComponent`) could have its **own** internal conditional permanently stop updating after the very first render, with no error and no warning.

## Root cause

`updateFragmentConditional` (`packages/client/src/runtime/insert.ts`) splices a branch's freshly parsed content between the real, persistent `bf-cond-start:<id>`/`bf-cond-end:<id>` DOM markers already bracketing the insertion point. The branch's own template embeds a redundant copy of that same wrapper (`addCondAttrToTemplate` always adds it), which has to be stripped before moving the rest of the content in.

The old filter dropped **any** top-level comment whose value merely started with `bf-cond-`, not only that specific pair. A fragment-root child has no wrapper element of its own, so its own `bf-cond-start:<childId>`/`bf-cond-end:<childId>` markers sit as top-level siblings of its other output — indistinguishable from the parent's own wrapper by a prefix check alone. They were erased from the DOM outright during the parent's branch swap that mounted the child, so with no markers left anywhere, the child's own `insert()` call could never find its start comment again on any later toggle — a permanent, silent no-op.

I initially chased this down the `commentScopeRegistry`-registration path the issue description suggested, but traced it further with Fable's help and confirmed the registry entry is actually set correctly (`findCommentChildScope` in `query.ts`) — the real defect is this marker-stripping filter being too broad.

## Fix

Only the parsed fragment's own first/last child is stripped now, and only when it matches the current id's marker value **exactly** (not merely "starts with `bf-cond-`").

## Tests

`packages/client/__tests__/runtime/issue-2959-fragment-root-child-cond-in-branch-swap.test.ts` — compiles the exact repro shape (a fragment-root child with its own null-guarded conditional, sitting between a leading and trailing sibling inside a parent's own fragment-conditional branch) through the real compiler and mounts it via the real runtime. Confirmed this test fails against the old filter and passes against the fix.

## Verification

- `bun run packages/adapter-tests/scripts/generate-expected-html.ts`, run by hand against this branch's head per CLAUDE.md's stacked-PR rule (the drift-check job doesn't run on a non-`main`-base PR) — zero fixture drift.
- Full `packages/client/__tests__` suite: same 3 pre-existing, environment-only failures as on `main`; no new failures.
- `packages/client/__tests__/runtime/insert.test.ts`, `insert-integration.test.ts`, `insert-nested-child-slot-collision.test.ts`: all pass, no regressions from the tightened filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HtBG2rHUtMYwcfESMbiVS7

---
_Generated by [Claude Code](https://claude.ai/code/session_01HtBG2rHUtMYwcfESMbiVS7)_