### PR TITLE
docs: add badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@
   No virtual DOM. No SPA required.
 </p>
 
+<p align="center">
+  <a href="https://www.npmjs.com/package/create-barefootjs"><img alt="npm" src="https://img.shields.io/npm/v/create-barefootjs" /></a>
+  <a href="https://jsr.io/@barefootjs/client"><img alt="JSR" src="https://jsr.io/badges/@barefootjs/client" /></a>
+  <a href="https://github.com/piconic-ai/barefootjs/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/piconic-ai/barefootjs/actions/workflows/ci.yml/badge.svg" /></a>
+  <a href="https://bundlephobia.com/package/@barefootjs/client"><img alt="npm bundle size" src="https://img.shields.io/bundlephobia/minzip/@barefootjs/client" /></a>
+  <a href="LICENSE"><img alt="License: MIT" src="https://img.shields.io/github/license/piconic-ai/barefootjs" /></a>
+  <a href="https://x.com/barefootjs_dev"><img alt="Follow on X" src="https://img.shields.io/badge/follow-%40barefootjs__dev-black?logo=x" /></a>
+</p>
+
 > [!WARNING]
 > **Alpha Software** — BarefootJS is in early alpha. APIs may change without notice. Not recommended for production use.
 


### PR DESCRIPTION
## Summary

- Add a badge row under the tagline in `README.md`: npm (`create-barefootjs`), JSR (`@barefootjs/client`), CI (`ci.yml` — Core), npm bundle size (`@barefootjs/client` minzip, via Bundlephobia), MIT license, and a static "Follow on X" badge (`@barefootjs_dev`).
- The root `package.json` is `private`, so the npm/bundle-size badges point at representative published packages (`create-barefootjs` is the first command a new user runs; `@barefootjs/client` is the browser runtime).
- The X badge is a static shields.io badge rather than the dynamic `twitter/follow` count endpoint, since that endpoint is broken for most accounts after X's API changes.

## Test plan

- [x] Rendered the badge markdown locally to confirm syntax/links resolve to real, existing resources (npm package, JSR package, `ci.yml` workflow, `LICENSE` file, X profile).
- Doc-only change; no code paths affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FuroUfozqB22PRBsR6YQxy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FuroUfozqB22PRBsR6YQxy)_