### PR TITLE
Pin Cpanel::JSON::XS to actually fix xslate's Deploy Sites failure

### DIFF
--- a/integrations/xslate/Dockerfile
+++ b/integrations/xslate/Dockerfile
@@ -12,12 +12,16 @@ RUN apt-get update \
 # Install CPAN deps into a self-contained prefix the runtime stage copies whole.
 # Text::Xslate is XS (needs the compiler above); Starman is the PSGI server
 # (prefork, so the SSE routes — AI chat, dev reload — don't block other workers).
-# Retried: the CPAN mirror occasionally serves a truncated/corrupt tarball
-# (e.g. a gzip that fails to unpack), which cpanm treats as a hard failure.
-# Clear its download cache between attempts so a retry re-fetches instead of
-# re-unpacking the same bad file.
+# Plack pulls in JSON::MaybeXS -> Cpanel::JSON::XS. CPAN's package index
+# currently advertises Cpanel::JSON::XS 4.52 as latest, but that release was
+# retracted from the mirror network (its tarball 404s) and the index hasn't
+# caught up, so resolving "latest" 404s every time — not mirror flakiness,
+# it fails identically on every attempt. Pin the last known-good release
+# explicitly so cpanm never tries to resolve/fetch the phantom 4.52.
+# The retry loop stays as defense-in-depth against genuine transient
+# network hiccups, clearing cpanm's download cache between attempts.
 RUN for i in 1 2 3; do \
-      cpanm --notest --local-lib=/opt/perl-deps Text::Xslate Plack Starman && exit 0; \
+      cpanm --notest --local-lib=/opt/perl-deps Text::Xslate Cpanel::JSON::XS@4.51 Plack Starman && exit 0; \
       echo "cpanm attempt $i failed, retrying..." >&2; \
       rm -rf /opt/perl-deps ~/.cpanm; \
       sleep 5; \

--- a/integrations/xslate/Dockerfile.dev
+++ b/integrations/xslate/Dockerfile.dev
@@ -11,11 +11,16 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends make gcc libc-dev \
  && rm -rf /var/lib/apt/lists/*
 
-# Retried: the CPAN mirror occasionally serves a truncated/corrupt tarball,
-# which cpanm treats as a hard failure. Clear its download cache between
-# attempts so a retry re-fetches instead of re-unpacking the same bad file.
+# Plack pulls in JSON::MaybeXS -> Cpanel::JSON::XS. CPAN's package index
+# currently advertises Cpanel::JSON::XS 4.52 as latest, but that release was
+# retracted from the mirror network (its tarball 404s) and the index hasn't
+# caught up, so resolving "latest" 404s every time — not mirror flakiness,
+# it fails identically on every attempt. Pin the last known-good release
+# explicitly so cpanm never tries to resolve/fetch the phantom 4.52.
+# The retry loop stays as defense-in-depth against genuine transient
+# network hiccups, clearing cpanm's download cache between attempts.
 RUN for i in 1 2 3; do \
-      cpanm --notest Text::Xslate Plack Starman && exit 0; \
+      cpanm --notest Text::Xslate Cpanel::JSON::XS@4.51 Plack Starman && exit 0; \
       echo "cpanm attempt $i failed, retrying..." >&2; \
       rm -rf ~/.cpanm; \
       sleep 5; \


### PR DESCRIPTION
## Summary

Follow-up to #2958. That PR added a retry loop to `deploy-integrations-xslate`'s
`cpanm` install, diagnosed (incorrectly) as CPAN mirror flakiness. After merging,
`main`'s `Deploy Sites` kept failing on the same job
(run [34726663632](https://github.com/piconic-ai/barefootjs/actions/runs/34726663632)),
still at `Cpanel-JSON-XS-4.52.tar.gz`, and the retry loop exhausted all 3 attempts
identically each time — a real signal that this isn't transient.

**Actual root cause** (confirmed against live CPAN infrastructure, not just logs):

```
$ curl -sI https://www.cpan.org/authors/id/R/RU/RURBAN/Cpanel-JSON-XS-4.52.tar.gz
HTTP/1.1 404 Not Found

$ curl https://fastapi.metacpan.org/v1/release/RURBAN/Cpanel-JSON-XS-4.52
{"release": null, "total": 0}   # release doesn't exist

$ curl https://cpanmetadb.plackperl.org/v1.0/package/Cpanel::JSON::XS
distfile: R/RU/RURBAN/Cpanel-JSON-XS-4.52.tar.gz   # but the index still points here
version: 4.52
```

`Cpanel::JSON::XS` 4.52 was released 2026-09-11, then retracted — MetaCPAN's own
"latest release" now shows 4.51 — but the CPAN package index (`02packages.details.txt`,
which `cpanm`/`cpanmetadb` resolve "latest" against) hasn't caught up yet. So
`cpanm`'s dependency resolution for `Plack` → `JSON::MaybeXS` → `Cpanel::JSON::XS`
keeps trying to fetch a file that no longer exists, gets a 404 HTML page back, and
mistakes it for a corrupt gzip. Every attempt fails identically — no amount of
retrying fixes an index pointing at a deleted release.

## Fix

Pin `Cpanel::JSON::XS@4.51` (the last real release) explicitly ahead of `Plack` in
both `integrations/xslate/Dockerfile` (build stage) and `Dockerfile.dev`, so `cpanm`
never resolves/fetches the phantom 4.52. The retry loop from #2958 stays as
defense-in-depth — it's real protection against genuine transient mirror hiccups,
which I hit and confirmed separately during local verification (see below).

## Test plan

- [x] Reproduced the exact failure against live CPAN infra (`curl` 404 above).
- [x] Installed `cpanm` locally (`apt-get install cpanminus`) and ran the **exact**
      fixed command end-to-end:
      `cpanm --notest --local-lib=/tmp/verify Text::Xslate Cpanel::JSON::XS@4.51 Plack Starman`
      → completed successfully, "34 distributions installed".
- [ ] Still no Docker daemon in this session to build the actual image — please
      confirm `deploy-integrations-xslate` goes green on the next `main` deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ERHEWeUqM6YY4V2uzJ4gwa

---
_Generated by [Claude Code](https://claude.ai/code/session_01ERHEWeUqM6YY4V2uzJ4gwa)_