### PR TITLE
Fix invalid JS for a body-destructured prop's arrow-function default (#2940)

### DIFF
--- a/.changeset/arrow-default-body-destructure.md
+++ b/.changeset/arrow-default-body-destructure.md
@@ -1,0 +1,9 @@
+---
+"@barefootjs/jsx": patch
+---
+
+Fixes #2940: a body-destructured prop's arrow-function default (`const { fmt = (v) => 'v' + v } = props`) now compiles to valid JS instead of a genuine `SyntaxError`.
+
+`collectConstant`'s body-destructure branch (`analyzer.ts`) built the local's `value` as a bare `props.fmt ?? (v) => 'v' + v` — `??`'s right operand may not be a bare arrow function without parens. This string was spliced verbatim into the client-JS init body and the Hono SSR component alike, so both were broken, and two downstream passes (`rewriteDestructuredPropReads`, `pruneUnusedPropExtractions`) silently skipped themselves because the generated code no longer parsed.
+
+The fix routes the analyzer's `value`-building through the same `??`-operand-parenthesizing decision `propReadFallback` already applied to every other live prop read (`props-binding.ts`'s new `coalesceDefaultText`), so an arrow/function-expression default is wrapped in parens everywhere it's spliced after `??`, matching what the parameter-destructured sibling form already did.

--- a/packages/adapter-tests/coverage-map.json
+++ b/packages/adapter-tests/coverage-map.json
@@ -923,6 +923,25 @@
         "text"
       ]
     },
+    "body-destructured-prop-default-arrow": {
+      "kinds": [
+        "arrow",
+        "binary",
+        "call",
+        "identifier",
+        "literal",
+        "logical",
+        "member"
+      ],
+      "axes": [
+        "binary:+",
+        "literal:string",
+        "logical:??"
+      ],
+      "contexts": [
+        "text"
+      ]
+    },
     "body-destructured-prop-default-renamed": {
       "kinds": [
         "identifier",
@@ -6770,15 +6789,15 @@
   "kindCounts": {
     "array-literal": 116,
     "array-method": 71,
-    "arrow": 74,
-    "binary": 106,
-    "call": 279,
+    "arrow": 75,
+    "binary": 107,
+    "call": 280,
     "conditional": 33,
-    "identifier": 397,
+    "identifier": 398,
     "index-access": 14,
-    "literal": 316,
-    "logical": 51,
-    "member": 234,
+    "literal": 317,
+    "logical": 52,
+    "member": 235,
     "object-literal": 93,
     "template-literal": 31,
     "unary": 29,
@@ -6813,7 +6832,7 @@
     "binary:!==": 12,
     "binary:%": 1,
     "binary:*": 14,
-    "binary:+": 24,
+    "binary:+": 25,
     "binary:-": 12,
     "binary:/": 1,
     "binary:<": 1,
@@ -6823,9 +6842,9 @@
     "literal:boolean": 71,
     "literal:null": 26,
     "literal:number": 143,
-    "literal:string": 217,
+    "literal:string": 218,
     "logical:&&": 7,
-    "logical:??": 43,
+    "logical:??": 44,
     "logical:||": 16,
     "lowering:date": 4,
     "lowering:formatDate": 2,

--- a/packages/adapter-tests/fixtures/body-destructured-prop-default-arrow.ts
+++ b/packages/adapter-tests/fixtures/body-destructured-prop-default-arrow.ts
@@ -1,0 +1,49 @@
+import { createFixture } from '../src/types'
+
+/**
+ * A body-destructured prop whose default is an arrow function (`const {
+ * fmt = (v) => 'v' + v } = props`) — #2940.
+ *
+ * `collectConstant`'s body-destructure branch (`analyzer.ts`) used to build
+ * the local's `value` as a bare `props.fmt ?? (v) => 'v' + v`, unlike the
+ * PARAMETER-destructured sibling form (`function Foo({ fmt = (v) => ... })`),
+ * which already parenthesized the default via `ParamInfo.defaultContainsArrow`
+ * (`propReadFallback`, `props-binding.ts`). `??`'s right operand may not be a
+ * bare arrow function without parens, so this was a genuine `SyntaxError` in
+ * every output that splices `ConstantInfo.value` verbatim — the client-JS
+ * init body AND the Hono SSR component, since the reference adapter reuses
+ * the same string. `renderCsrComponent` (`csr-render.ts`) `import()`s the
+ * whole compiled client module, so pre-fix this fixture's CSR leg failed
+ * with a `SyntaxError` at import time; post-fix it imports and renders
+ * cleanly. Hono is correct by construction here, so `expectedHtml` is
+ * generated from it unmodified.
+ *
+ * `fmt` is read from an event handler (not a top-level reactive position) so
+ * the fixture also pins that the bug isn't limited to the "gets inlined into
+ * a `createEffect`" shape — a handler-scoped read needs the SAME declaration
+ * fixed.
+ *
+ * Named `ArrowDefaultFmt`, not `Child` — the compiled `init<Name>` function
+ * for a component literally named `Child` collides with the CSR conformance
+ * harness's own `initChild` shim (`csr-render.ts`), the same class of
+ * reserved-identifier collision `body-destructured-prop-default-renamed`
+ * avoids the same way.
+ */
+export const fixture = createFixture({
+  id: 'body-destructured-prop-default-arrow',
+  description: 'A body-destructured prop default that is an arrow function compiles to valid JS (#2940)',
+  source: `
+"use client"
+import { createSignal } from "@barefootjs/client"
+function ArrowDefaultFmt(props: { fmt?: (v: number) => string }) {
+  const { fmt = (v) => 'v' + v } = props
+  const [label, setLabel] = createSignal('none')
+  return <button class="fmt" onClick={() => setLabel(fmt(1))}>{label()}</button>
+}
+export { ArrowDefaultFmt }
+`,
+  props: {},
+  expectedHtml: `
+    <button bf-s="test" bf="s1" class="fmt"><!--bf:s0-->none<!--/--></button>
+  `,
+})

--- a/packages/adapter-tests/fixtures/index.ts
+++ b/packages/adapter-tests/fixtures/index.ts
@@ -25,6 +25,7 @@ import { fixture as propsReactivityComparison } from './props-reactivity-compari
 import { fixture as destructuredPropsLive } from './destructured-props-live'
 import { fixture as bodyDestructuredPropsLive } from './body-destructured-props-live'
 import { fixture as bodyDestructuredPropDefaultRenamed } from './body-destructured-prop-default-renamed'
+import { fixture as bodyDestructuredPropDefaultArrow } from './body-destructured-prop-default-arrow'
 import { fixture as form } from './form'
 import { fixture as portal } from './portal'
 import { fixture as todoApp } from './todo-app'
@@ -667,6 +668,7 @@ export const jsxFixtures: JSXFixture[] = [
   destructuredPropsLive,
   bodyDestructuredPropsLive,
   bodyDestructuredPropDefaultRenamed,
+  bodyDestructuredPropDefaultArrow,
   form,
   portal,
   todoApp,

--- a/packages/jsx/src/__tests__/body-destructured-prop-default-arrow.test.ts
+++ b/packages/jsx/src/__tests__/body-destructured-prop-default-arrow.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Regression for #2940: a BODY-destructured prop's arrow-function default
+ * (`const { fmt = (v) => 'v' + v } = props`) used to build
+ * `ConstantInfo.value` as a bare `props.fmt ?? (v) => 'v' + v` —
+ * `collectConstant`'s body-destructure branch (`analyzer.ts`) never checked
+ * whether the default contained an arrow/function expression before
+ * splicing it after `??`, unlike the PARAMETER-destructured sibling form,
+ * which already parenthesized via `ParamInfo.defaultContainsArrow`
+ * (`propReadFallback`, `props-binding.ts`).
+ *
+ * `a ?? (v) => expr` is not valid JS — an arrow function cannot appear
+ * directly as the right operand of `??` without parens — so this was a
+ * genuine SyntaxError in three places that all read `ConstantInfo.value`
+ * verbatim: the emitted client-JS init body, the Hono SSR component (the
+ * reference adapter also splices `value` unchanged), and every downstream
+ * pass that re-parses it (which silently gave up and skipped instead of
+ * crashing, masking the bug as a missed optimization rather than a syntax
+ * error).
+ *
+ * The fix routes the analyzer's `value`-building through the same
+ * `coalesceDefaultText` decision `propReadFallback` already used, so there
+ * is one implementation of "how does a `??` default get parenthesized",
+ * not two.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import ts from 'typescript'
+import { analyzeComponent } from '../analyzer'
+import { compileJSX } from '../index'
+import { HonoAdapter } from '../../../adapter-hono/src/adapter/index'
+
+const ARROW_DEFAULT_SOURCE = `
+'use client'
+function Child(props: { fmt?: (v: number) => string }) {
+  const { fmt = (v) => 'v' + v } = props
+  return <span>{fmt(1)}</span>
+}
+export { Child }
+`
+
+const RENAMED_ARROW_DEFAULT_SOURCE = `
+'use client'
+function Child(props: { fmt?: (v: number) => string }) {
+  const { fmt: f = (v) => 'v' + v } = props
+  return <span>{f(1)}</span>
+}
+export { Child }
+`
+
+function compile(source: string) {
+  return compileJSX(source, 'Child.tsx', { adapter: new HonoAdapter() })
+}
+
+function parseDiagnosticCount(js: string): number {
+  const sourceFile = ts.createSourceFile('generated.js', js, ts.ScriptTarget.Latest, false, ts.ScriptKind.JS)
+  // @ts-expect-error - internal, but the established way this repo checks
+  // "did the generated code actually parse" (see client-template-escape-
+  // soundness.test.ts / map-body-no-silent-divergence.test.ts).
+  return sourceFile.parseDiagnostics?.length ?? 0
+}
+
+describe('body-destructured prop with an arrow-function default (#2940)', () => {
+  test('analyzer: `value` parenthesizes the arrow default', () => {
+    const ctx = analyzeComponent(ARROW_DEFAULT_SOURCE, 'Child.tsx')
+    const fmt = ctx.localConstants.find(c => c.name === 'fmt')
+    expect(fmt).toBeDefined()
+    expect(fmt?.value).toBe("props.fmt ?? ((v) => 'v' + v)")
+    expect(fmt?.containsArrow).toBe(true)
+  })
+
+  test('emitted client JS parses as valid JS, with no bare `?? (v) =>`', () => {
+    const warnings: unknown[][] = []
+    const originalWarn = console.warn
+    console.warn = (...args: unknown[]) => { warnings.push(args) }
+    let result: ReturnType<typeof compile>
+    try {
+      result = compile(ARROW_DEFAULT_SOURCE)
+    } finally {
+      console.warn = originalWarn
+    }
+
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(clientJs).toBeDefined()
+    const js = clientJs!.content
+
+    expect(js).not.toMatch(/\?\?\s*\(v\)\s*=>/)
+    expect(parseDiagnosticCount(js)).toBe(0)
+
+    // The two downstream passes that used to silently bail because the
+    // generated code didn't parse must now run to completion.
+    expect(warnings.some(w => String(w[0]).includes('rewriteDestructuredPropReads'))).toBe(false)
+    expect(warnings.some(w => String(w[0]).includes('pruneUnusedPropExtractions'))).toBe(false)
+  })
+
+  test('Hono SSR component also parenthesizes the default (the reference adapter splices `value` verbatim too)', () => {
+    const result = compile(ARROW_DEFAULT_SOURCE)
+    const ssrComponent = result.files.find(f => f.type === 'markedTemplate')
+    expect(ssrComponent).toBeDefined()
+    expect(ssrComponent!.content).not.toMatch(/\?\?\s*\(v\)\s*=>/)
+  })
+
+  test('renamed alias (`{ fmt: f = (v) => ... }`) gets the same paren-wrap', () => {
+    const ctx = analyzeComponent(RENAMED_ARROW_DEFAULT_SOURCE, 'Child.tsx')
+    const f = ctx.localConstants.find(c => c.name === 'f')
+    expect(f).toBeDefined()
+    expect(f?.value).toBe("props.fmt ?? ((v) => 'v' + v)")
+    expect(f?.containsArrow).toBe(true)
+
+    const result = compile(RENAMED_ARROW_DEFAULT_SOURCE)
+    const clientJs = result.files.find(f => f.type === 'clientJs')
+    expect(parseDiagnosticCount(clientJs!.content)).toBe(0)
+  })
+})

--- a/packages/jsx/src/analyzer.ts
+++ b/packages/jsx/src/analyzer.ts
@@ -11,7 +11,7 @@ import type { ImportSpecifier, TypeInfo, ParamInfo, ReactiveFactoryInfo, Decline
 import { parseExpression, parseBlockBodyTolerant, foldBlockToExpr, tsNodeToParsedExpr } from './expression-parser.ts'
 import type { CallbackBodyAcceptor } from './adapters/interface.ts'
 import { rewriteBarePropRefs } from './prop-rewrite.ts'
-import { buildPropAliasMap } from './props-binding.ts'
+import { buildPropAliasMap, coalesceDefaultText } from './props-binding.ts'
 import { incrementCounter } from './instrumentation.ts'
 import {
   type AnalyzerContext,
@@ -3181,10 +3181,18 @@ function collectConstant(
       if (!ts.isBindingElement(el) || !ts.isIdentifier(el.name) || el.dotDotDotToken) continue
       const localName = el.name.text
       const sourceKey = el.propertyName && ts.isIdentifier(el.propertyName) ? el.propertyName.text : localName
-      const defaultValueExpr = el.initializer ? ctx.getJS(el.initializer) : undefined
+      // Shared with the #2943 `ParamInfo` overlay below so "what does this
+      // default look like" (source text, `defaultContainsArrow`) has one
+      // computation, not two independently-drifting ones.
+      const defaultFields = el.initializer ? bindingElementDefaultFields(el.initializer, ctx) : undefined
       const baseValue = `${propsName}.${sourceKey}`
-      const value = defaultValueExpr ? `${baseValue} ?? ${defaultValueExpr}` : baseValue
-      const containsArrow = el.initializer ? nodeContainsArrow(el.initializer) : false
+      // Parenthesize an arrow/function-expression default (#2940) — `??`
+      // binds tighter than an arrow head, so a bare `props.fmt ?? (v) =>
+      // ...` is a SyntaxError in the emitted JS. Same rule
+      // `propReadFallback` already applies to every other live prop read.
+      const value = defaultFields?.defaultValue !== undefined
+        ? `${baseValue} ?? ${coalesceDefaultText(defaultFields.defaultValue, defaultFields.defaultContainsArrow)}`
+        : baseValue
       const freeIdentifiers = el.initializer ? extractFreeIdentifiersFromNode(el.initializer) : new Set([propsName])
       // Structured parse of `value`, same as the plain-identifier branch
       // below (#2724 review finding): without this, a RENAMED destructure
@@ -3210,7 +3218,7 @@ function collectConstant(
         type: null,
         loc: getSourceLocation(node, ctx.sourceFile, ctx.filePath),
         freeIdentifiers,
-        containsArrow: containsArrow || undefined,
+        containsArrow: defaultFields?.defaultContainsArrow,
         // Body-level destructure-from-props is collected only when
         // _isModule === false; binding lives in init scope.
         origin: { phase: 'hydrate', scope: 'init', effect: 'pure' },
@@ -3233,8 +3241,7 @@ function collectConstant(
       // this is a static, compile-time fact about the source, not a
       // liveness question, so (unlike `resolveBodyPropAliases`'s
       // `requireLiveRewriteSafe` gate) nothing here excludes them.
-      if (el.initializer) {
-        const defaultFields = bindingElementDefaultFields(el.initializer, ctx)
+      if (el.initializer && defaultFields) {
         const existing = ctx.propsParams.find(p => !p.isRest && p.sourceName === undefined && p.name === sourceKey)
         if (localName === sourceKey) {
           // Unrenamed: overlay onto the type-member entry `sourceKey`

--- a/packages/jsx/src/props-binding.ts
+++ b/packages/jsx/src/props-binding.ts
@@ -245,6 +245,20 @@ export function propReadBase(p: LivePropReadInfo): string {
 }
 
 /**
+ * The text a destructure default contributes as the right operand of a `??`
+ * prop read. An arrow (or function-expression) default needs its own
+ * parens — `??` binds tighter than an arrow head, so `_p.onInput ?? () =>
+ * {}` is a SyntaxError. The one implementation of that decision, shared by
+ * `propReadFallback` below (every live `_p.X` read) and `collectConstant`'s
+ * body-destructure expansion (`analyzer.ts`, which builds
+ * `ConstantInfo.value`) — see #2940, where the analyzer built that value
+ * without this check and emitted invalid JS.
+ */
+export function coalesceDefaultText(defaultValue: string, defaultContainsArrow: boolean | undefined): string {
+  return defaultContainsArrow ? `(${defaultValue})` : defaultValue
+}
+
+/**
  * The `??` right-hand side for a prop read, or null when the bare read is
  * correct. Precedence:
  *   1. an explicit destructure default (`{ x = 1 }`) — an arrow default gets
@@ -263,7 +277,7 @@ export function propReadFallback(
   usage: PropUsage | undefined,
   usedAsCondition: boolean,
 ): string | null {
-  if (p.defaultValue) return p.defaultContainsArrow ? `(${p.defaultValue})` : p.defaultValue
+  if (p.defaultValue) return coalesceDefaultText(p.defaultValue, p.defaultContainsArrow)
   if (usage?.usedAsLoopArray) return '[]'
   if (propHasPropertyAccess(usage) && !usedAsCondition) return '{}'
   return null

--- a/ui/compat.lock.json
+++ b/ui/compat.lock.json
@@ -1814,7 +1814,7 @@
   },
   "fixtureDivergences": {
     "note": "Render-conformance section: the shared conformance corpus (packages/adapter-tests) is rendered through every adapter’s REAL backend and byte-compared against the Hono reference. This answers, per fixture and per adapter, whether the construct WORKS — not just whether it compiles. A construct works either as written (✓) or with a documented `/* @client */` comment (✓†, a verified, supported escape — most refusals have one). Fixtures absent from the table below work on every adapter — most as written, some via that documented escape; the headline says how many of each. Listed fixtures need attention somewhere: a bare diagnostic code is still-open debt with no escape yet, a code led by ✗ owes no escape at all (by design), and ≠ means the fixture compiles clean but its rendered output diverges from the reference.",
-    "totalFixtures": 419,
+    "totalFixtures": 420,
     "fixtures": {
       "component-prop-bare-getter": {
         "go-template": {

--- a/ui/support-matrix.lock.json
+++ b/ui/support-matrix.lock.json
@@ -680,15 +680,15 @@
       }
     },
     "arrow": {
-      "total": 74,
+      "total": 75,
       "cells": {
         "hono": {
-          "pass": 74,
-          "total": 74
+          "pass": 75,
+          "total": 75
         },
         "blade": {
-          "pass": 65,
-          "total": 74,
+          "pass": 66,
+          "total": 75,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -733,8 +733,8 @@
           ]
         },
         "erb": {
-          "pass": 66,
-          "total": 74,
+          "pass": 67,
+          "total": 75,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -773,8 +773,8 @@
           ]
         },
         "go-template": {
-          "pass": 65,
-          "total": 74,
+          "pass": 66,
+          "total": 75,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -819,8 +819,8 @@
           ]
         },
         "jinja": {
-          "pass": 65,
-          "total": 74,
+          "pass": 66,
+          "total": 75,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -865,8 +865,8 @@
           ]
         },
         "minijinja": {
-          "pass": 65,
-          "total": 74,
+          "pass": 66,
+          "total": 75,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -911,8 +911,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 66,
-          "total": 74,
+          "pass": 67,
+          "total": 75,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -951,8 +951,8 @@
           ]
         },
         "twig": {
-          "pass": 65,
-          "total": 74,
+          "pass": 66,
+          "total": 75,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -997,8 +997,8 @@
           ]
         },
         "xslate": {
-          "pass": 65,
-          "total": 74,
+          "pass": 66,
+          "total": 75,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1056,15 +1056,15 @@
       }
     },
     "binary": {
-      "total": 106,
+      "total": 107,
       "cells": {
         "hono": {
-          "pass": 106,
-          "total": 106
+          "pass": 107,
+          "total": 107
         },
         "blade": {
-          "pass": 97,
-          "total": 106,
+          "pass": 98,
+          "total": 107,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1111,8 +1111,8 @@
           ]
         },
         "erb": {
-          "pass": 98,
-          "total": 106,
+          "pass": 99,
+          "total": 107,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1153,8 +1153,8 @@
           ]
         },
         "go-template": {
-          "pass": 97,
-          "total": 106,
+          "pass": 98,
+          "total": 107,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1201,8 +1201,8 @@
           ]
         },
         "jinja": {
-          "pass": 97,
-          "total": 106,
+          "pass": 98,
+          "total": 107,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1249,8 +1249,8 @@
           ]
         },
         "minijinja": {
-          "pass": 97,
-          "total": 106,
+          "pass": 98,
+          "total": 107,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1297,8 +1297,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 98,
-          "total": 106,
+          "pass": 99,
+          "total": 107,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1339,8 +1339,8 @@
           ]
         },
         "twig": {
-          "pass": 97,
-          "total": 106,
+          "pass": 98,
+          "total": 107,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1387,8 +1387,8 @@
           ]
         },
         "xslate": {
-          "pass": 97,
-          "total": 106,
+          "pass": 98,
+          "total": 107,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -1448,11 +1448,11 @@
       }
     },
     "call": {
-      "total": 279,
+      "total": 280,
       "cells": {
         "hono": {
-          "pass": 277,
-          "total": 279,
+          "pass": 278,
+          "total": 280,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1467,8 +1467,8 @@
           ]
         },
         "blade": {
-          "pass": 262,
-          "total": 279,
+          "pass": 263,
+          "total": 280,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1553,8 +1553,8 @@
           ]
         },
         "erb": {
-          "pass": 263,
-          "total": 279,
+          "pass": 264,
+          "total": 280,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1633,8 +1633,8 @@
           ]
         },
         "go-template": {
-          "pass": 259,
-          "total": 279,
+          "pass": 260,
+          "total": 280,
           "gaps": [
             {
               "fixture": "component-prop-bare-getter",
@@ -1735,8 +1735,8 @@
           ]
         },
         "jinja": {
-          "pass": 262,
-          "total": 279,
+          "pass": 263,
+          "total": 280,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1821,8 +1821,8 @@
           ]
         },
         "minijinja": {
-          "pass": 262,
-          "total": 279,
+          "pass": 263,
+          "total": 280,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1907,8 +1907,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 263,
-          "total": 279,
+          "pass": 264,
+          "total": 280,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -1987,8 +1987,8 @@
           ]
         },
         "twig": {
-          "pass": 262,
-          "total": 279,
+          "pass": 263,
+          "total": 280,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2073,8 +2073,8 @@
           ]
         },
         "xslate": {
-          "pass": 262,
-          "total": 279,
+          "pass": 263,
+          "total": 280,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2304,11 +2304,11 @@
       }
     },
     "identifier": {
-      "total": 397,
+      "total": 398,
       "cells": {
         "hono": {
-          "pass": 393,
-          "total": 397,
+          "pass": 394,
+          "total": 398,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2331,8 +2331,8 @@
           ]
         },
         "blade": {
-          "pass": 376,
-          "total": 397,
+          "pass": 377,
+          "total": 398,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2433,8 +2433,8 @@
           ]
         },
         "erb": {
-          "pass": 377,
-          "total": 397,
+          "pass": 378,
+          "total": 398,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2529,8 +2529,8 @@
           ]
         },
         "go-template": {
-          "pass": 373,
-          "total": 397,
+          "pass": 374,
+          "total": 398,
           "gaps": [
             {
               "fixture": "component-prop-bare-getter",
@@ -2647,8 +2647,8 @@
           ]
         },
         "jinja": {
-          "pass": 376,
-          "total": 397,
+          "pass": 377,
+          "total": 398,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2749,8 +2749,8 @@
           ]
         },
         "minijinja": {
-          "pass": 376,
-          "total": 397,
+          "pass": 377,
+          "total": 398,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2851,8 +2851,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 375,
-          "total": 397,
+          "pass": 376,
+          "total": 398,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -2959,8 +2959,8 @@
           ]
         },
         "twig": {
-          "pass": 376,
-          "total": 397,
+          "pass": 377,
+          "total": 398,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3061,8 +3061,8 @@
           ]
         },
         "xslate": {
-          "pass": 374,
-          "total": 397,
+          "pass": 375,
+          "total": 398,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3240,11 +3240,11 @@
       }
     },
     "literal": {
-      "total": 316,
+      "total": 317,
       "cells": {
         "hono": {
-          "pass": 315,
-          "total": 316,
+          "pass": 316,
+          "total": 317,
           "gaps": [
             {
               "fixture": "jsx-element-prop-ternary",
@@ -3253,8 +3253,8 @@
           ]
         },
         "blade": {
-          "pass": 304,
-          "total": 316,
+          "pass": 305,
+          "total": 317,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3309,8 +3309,8 @@
           ]
         },
         "erb": {
-          "pass": 304,
-          "total": 316,
+          "pass": 305,
+          "total": 317,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3365,8 +3365,8 @@
           ]
         },
         "go-template": {
-          "pass": 301,
-          "total": 316,
+          "pass": 302,
+          "total": 317,
           "gaps": [
             {
               "fixture": "component-prop-bare-getter",
@@ -3437,8 +3437,8 @@
           ]
         },
         "jinja": {
-          "pass": 304,
-          "total": 316,
+          "pass": 305,
+          "total": 317,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3493,8 +3493,8 @@
           ]
         },
         "minijinja": {
-          "pass": 304,
-          "total": 316,
+          "pass": 305,
+          "total": 317,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3549,8 +3549,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 302,
-          "total": 316,
+          "pass": 303,
+          "total": 317,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3617,8 +3617,8 @@
           ]
         },
         "twig": {
-          "pass": 304,
-          "total": 316,
+          "pass": 305,
+          "total": 317,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3673,8 +3673,8 @@
           ]
         },
         "xslate": {
-          "pass": 302,
-          "total": 316,
+          "pass": 303,
+          "total": 317,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -3754,15 +3754,15 @@
       }
     },
     "logical": {
-      "total": 51,
+      "total": 52,
       "cells": {
         "hono": {
-          "pass": 51,
-          "total": 51
+          "pass": 52,
+          "total": 52
         },
         "blade": {
-          "pass": 49,
-          "total": 51,
+          "pass": 50,
+          "total": 52,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -3777,8 +3777,8 @@
           ]
         },
         "erb": {
-          "pass": 49,
-          "total": 51,
+          "pass": 50,
+          "total": 52,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -3793,8 +3793,8 @@
           ]
         },
         "go-template": {
-          "pass": 49,
-          "total": 51,
+          "pass": 50,
+          "total": 52,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -3809,8 +3809,8 @@
           ]
         },
         "jinja": {
-          "pass": 49,
-          "total": 51,
+          "pass": 50,
+          "total": 52,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -3825,8 +3825,8 @@
           ]
         },
         "minijinja": {
-          "pass": 49,
-          "total": 51,
+          "pass": 50,
+          "total": 52,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -3841,8 +3841,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 49,
-          "total": 51,
+          "pass": 50,
+          "total": 52,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -3857,8 +3857,8 @@
           ]
         },
         "twig": {
-          "pass": 49,
-          "total": 51,
+          "pass": 50,
+          "total": 52,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -3873,8 +3873,8 @@
           ]
         },
         "xslate": {
-          "pass": 49,
-          "total": 51,
+          "pass": 50,
+          "total": 52,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -3902,11 +3902,11 @@
       }
     },
     "member": {
-      "total": 234,
+      "total": 235,
       "cells": {
         "hono": {
-          "pass": 231,
-          "total": 234,
+          "pass": 232,
+          "total": 235,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -3925,8 +3925,8 @@
           ]
         },
         "blade": {
-          "pass": 215,
-          "total": 234,
+          "pass": 216,
+          "total": 235,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4017,8 +4017,8 @@
           ]
         },
         "erb": {
-          "pass": 216,
-          "total": 234,
+          "pass": 217,
+          "total": 235,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4103,8 +4103,8 @@
           ]
         },
         "go-template": {
-          "pass": 212,
-          "total": 234,
+          "pass": 213,
+          "total": 235,
           "gaps": [
             {
               "fixture": "component-prop-bare-getter",
@@ -4211,8 +4211,8 @@
           ]
         },
         "jinja": {
-          "pass": 215,
-          "total": 234,
+          "pass": 216,
+          "total": 235,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4303,8 +4303,8 @@
           ]
         },
         "minijinja": {
-          "pass": 215,
-          "total": 234,
+          "pass": 216,
+          "total": 235,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4395,8 +4395,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 214,
-          "total": 234,
+          "pass": 215,
+          "total": 235,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4493,8 +4493,8 @@
           ]
         },
         "twig": {
-          "pass": 215,
-          "total": 234,
+          "pass": 216,
+          "total": 235,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -4585,8 +4585,8 @@
           ]
         },
         "xslate": {
-          "pass": 213,
-          "total": 234,
+          "pass": 214,
+          "total": 235,
           "gaps": [
             {
               "fixture": "date-method-uncatalogued",
@@ -7258,15 +7258,15 @@
       }
     },
     "binary:+": {
-      "total": 24,
+      "total": 25,
       "cells": {
         "hono": {
-          "pass": 24,
-          "total": 24
+          "pass": 25,
+          "total": 25
         },
         "blade": {
-          "pass": 23,
-          "total": 24,
+          "pass": 24,
+          "total": 25,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -7277,8 +7277,8 @@
           ]
         },
         "erb": {
-          "pass": 23,
-          "total": 24,
+          "pass": 24,
+          "total": 25,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -7289,8 +7289,8 @@
           ]
         },
         "go-template": {
-          "pass": 23,
-          "total": 24,
+          "pass": 24,
+          "total": 25,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -7301,8 +7301,8 @@
           ]
         },
         "jinja": {
-          "pass": 23,
-          "total": 24,
+          "pass": 24,
+          "total": 25,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -7313,8 +7313,8 @@
           ]
         },
         "minijinja": {
-          "pass": 23,
-          "total": 24,
+          "pass": 24,
+          "total": 25,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -7325,8 +7325,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 23,
-          "total": 24,
+          "pass": 24,
+          "total": 25,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -7337,8 +7337,8 @@
           ]
         },
         "twig": {
-          "pass": 23,
-          "total": 24,
+          "pass": 24,
+          "total": 25,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -7349,8 +7349,8 @@
           ]
         },
         "xslate": {
-          "pass": 23,
-          "total": 24,
+          "pass": 24,
+          "total": 25,
           "gaps": [
             {
               "fixture": "static-array-from-props-with-component",
@@ -8475,15 +8475,15 @@
       }
     },
     "literal:string": {
-      "total": 217,
+      "total": 218,
       "cells": {
         "hono": {
-          "pass": 217,
-          "total": 217
+          "pass": 218,
+          "total": 218
         },
         "blade": {
-          "pass": 209,
-          "total": 217,
+          "pass": 210,
+          "total": 218,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8522,8 +8522,8 @@
           ]
         },
         "erb": {
-          "pass": 209,
-          "total": 217,
+          "pass": 210,
+          "total": 218,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8562,8 +8562,8 @@
           ]
         },
         "go-template": {
-          "pass": 208,
-          "total": 217,
+          "pass": 209,
+          "total": 218,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8608,8 +8608,8 @@
           ]
         },
         "jinja": {
-          "pass": 209,
-          "total": 217,
+          "pass": 210,
+          "total": 218,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8648,8 +8648,8 @@
           ]
         },
         "minijinja": {
-          "pass": 209,
-          "total": 217,
+          "pass": 210,
+          "total": 218,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8688,8 +8688,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 207,
-          "total": 217,
+          "pass": 208,
+          "total": 218,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8740,8 +8740,8 @@
           ]
         },
         "twig": {
-          "pass": 209,
-          "total": 217,
+          "pass": 210,
+          "total": 218,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8780,8 +8780,8 @@
           ]
         },
         "xslate": {
-          "pass": 207,
-          "total": 217,
+          "pass": 208,
+          "total": 218,
           "gaps": [
             {
               "fixture": "every-typeof-predicate",
@@ -8897,15 +8897,15 @@
       }
     },
     "logical:??": {
-      "total": 43,
+      "total": 44,
       "cells": {
         "hono": {
-          "pass": 43,
-          "total": 43
+          "pass": 44,
+          "total": 44
         },
         "blade": {
-          "pass": 41,
-          "total": 43,
+          "pass": 42,
+          "total": 44,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -8920,8 +8920,8 @@
           ]
         },
         "erb": {
-          "pass": 41,
-          "total": 43,
+          "pass": 42,
+          "total": 44,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -8936,8 +8936,8 @@
           ]
         },
         "go-template": {
-          "pass": 41,
-          "total": 43,
+          "pass": 42,
+          "total": 44,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -8952,8 +8952,8 @@
           ]
         },
         "jinja": {
-          "pass": 41,
-          "total": 43,
+          "pass": 42,
+          "total": 44,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -8968,8 +8968,8 @@
           ]
         },
         "minijinja": {
-          "pass": 41,
-          "total": 43,
+          "pass": 42,
+          "total": 44,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -8984,8 +8984,8 @@
           ]
         },
         "mojolicious": {
-          "pass": 41,
-          "total": 43,
+          "pass": 42,
+          "total": 44,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -9000,8 +9000,8 @@
           ]
         },
         "twig": {
-          "pass": 41,
-          "total": 43,
+          "pass": 42,
+          "total": 44,
           "gaps": [
             {
               "fixture": "static-array-from-props",
@@ -9016,8 +9016,8 @@
           ]
         },
         "xslate": {
-          "pass": 41,
-          "total": 43,
+          "pass": 42,
+          "total": 44,
           "gaps": [
             {
               "fixture": "static-array-from-props",


### PR DESCRIPTION
## Summary

- Fixes #2940: a body-destructured prop's arrow-function default (`const { fmt = (v) => 'v' + v } = props`) compiled to invalid JS — `collectConstant`'s body-destructure branch in `analyzer.ts` built the local's `value` as a bare `props.fmt ?? (v) => 'v' + v`. `??`'s right operand may not be a bare arrow function without parens, so this was a genuine `SyntaxError` spliced verbatim into both the emitted client-JS init body and the Hono SSR component (the reference adapter reuses the same string). Two downstream passes (`rewriteDestructuredPropReads`, `pruneUnusedPropExtractions`) were silently skipping themselves because the generated code no longer parsed.
- Extracted `coalesceDefaultText` in `props-binding.ts` — the same `??`-operand-parenthesizing decision `propReadFallback` already applied to every other live prop read — and routed `collectConstant`'s value-building through it, so an arrow/function-expression default is wrapped in parens everywhere it's spliced after `??`, matching what the parameter-destructured sibling form (`function Foo({ fmt = (v) => ... })`) already did.

## Test plan

- [x] New compiler unit test (`packages/jsx/src/__tests__/body-destructured-prop-default-arrow.test.ts`) pinning: the analyzer's `value` is parenthesized, the emitted client JS parses with zero diagnostics and contains no bare `?? (v) =>`, the two downstream passes no longer emit their "did not parse, skipping" warnings, the Hono SSR component is also fixed, and the renamed-alias shape (`{ fmt: f = (v) => ... }`) gets the same fix.
- [x] New CSR conformance fixture (`body-destructured-prop-default-arrow`) that `import()`s the compiled client module end-to-end — this is the fixture that would throw a `SyntaxError` at import time before the fix. `expectedHtml` generated from the Hono reference adapter.
- [x] Regenerated `coverage-map.json` for the new fixture.
- [x] `bun test packages/jsx` and `bun test packages/adapter-tests` pass (verified the small number of pre-existing unrelated failures were an environment build-order issue — `@barefootjs/client` wasn't built yet — not caused by this change).
- [x] `bunx tsc --noEmit` on `packages/jsx` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDmkmDfGfh883qtX1sHAYX

---
_Generated by [Claude Code](https://claude.ai/code/session_01MDmkmDfGfh883qtX1sHAYX)_